### PR TITLE
Add sig project recommendations for each newly created paddlepaddle sig project.

### DIFF
--- a/TOC/SIG_PROJECT_RECOMMENDATIONS.md
+++ b/TOC/SIG_PROJECT_RECOMMENDATIONS.md
@@ -1,0 +1,22 @@
+# Recommended Practices for PaddlePaddle SIG Project
+
+Here are some recommended practices to increase PaddlePaddle SIG project's visibility.
+
+* Document your project governance and make it available in the project repository.
+
+* Setting up issue templates and pull request templates helps you customize and standardize the information that you'd like contributors to include when they open questions and pull requests in the repository.
+
+* Ensure that each repurchase contains a license file.
+
+* Provide documentation on release methodology, cadence, criteria, etc.
+
+* Add a README file to your repository, welcome new community members to the project, and explain why the project is useful and how to get started.
+
+* Add a CONTRIBUTING file to your repository to show other developers and your user community how to contribute to the project. At a higher level, the document will explain what types of contributions are required and how the process works.
+
+* Add the OWNERS file to define the person or team responsible for the code in the repository.
+
+* Add a CODE_OF_CONDUCT file, which sets the basic rules of behavior related to participants and helps to create a friendly environment. Although not every project has a CODE_OF_CONDUCT file, but its presence indicates that this is a popular project and defines criteria for interaction with the project community.
+
+
+


### PR DESCRIPTION
Add sig project recommendations for each newly created paddlepaddle sig project.