### PR TITLE
Add PaddlePaddle community startup readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,45 @@
-# community
-PaddlePaddle Developer Community
+# PaddlePaddle Community
+
+Welcome to the PaddlePaddle community! This is the starting point for joining and contributing to the PaddlePaddle community - improving documentation, improving code, giving presentations, etc.
+
+For more information about the project structure and organization, refer to the [project governance](https://github.com/PaddlePaddle/community/blob/master/GOVERNANCE.md) information.
+
+## Communication
+
+The communication page lists things like chats, questions, mailing lists, meetings, etc. For more specific topics, try SIGs.
+
+## Governance
+
+PaddlePaddle has the following officially supported group types:
+
+* The Committee is a specific group to engage in sensitive topics. The group is encouraged to be as open as possible, but, due to the nature of the subject under discussion, private communication is allowed. Examples of committees include steering committees and things like security or code of conduct.
+
+* Special interest group (SIG) is a persistent open group focused on part of the project. SIG must have open and transparent procedures. Anyone can participate and contribute as long as you follow the PaddlePaddle code of conduct. The purpose of SIG is to own and develop a set of sub-SIGs.
+
+ * Each sig can have a set of sub-SIGs. These groups can work independently. Some of the sub-SIGs will be part of the main deliverable of PaddlePaddle. 
+
+For more details about these groups, see the [complete governance document](https://github.com/PaddlePaddle/community/blob/master/GOVERNANCE.md).
+
+A sig can have its own contribution policy, which is described in the "readme" or "contributing" file in the sig folder of this repository, as well as their own mailing lists, idle channels, etc.
+
+If you want to edit details about a SIG, such as its weekly meeting time or prospects, please follow [the instructions]() to specify how to automatically generate our documents.
+
+## Members
+
+We encourage all contributors to become members. Our goal is to build an active, healthy community of contributors, reviewers, and code owners. Learn more about membership requirements and responsibilities on our [community membership]() page.
+
+## Contribution
+
+The first step to make a contribution is to select a sig from [PaddlePaddle sig list](). Start attending sig meetings, join sig channels and subscribe to mailing lists. Sigs often offer a series of "need help" issues that can help new contributors to participate.
+
+[PaddlePaddle contribution guideline]() provides detailed instructions on how to make your ideas and bug fixes visible and accepted, including:
+
+- How to [ask questions]()
+
+- How to [work on something]()
+
+- How to [open pull request]()
+
+
+
+


### PR DESCRIPTION
Add PaddlePaddle community startup readme, including communication, governance, members, contribution guidelines.