### PR TITLE
update call-for-contribution

### DIFF
--- a/pfcc/call-for-contributions/README.md
+++ b/pfcc/call-for-contributions/README.md
@@ -4,11 +4,11 @@
 每个技术方向都会有工程师支持，和该方向中的同学一起确定目标、规划和分工，希望 PFCC 的成员能逐渐成为方向骨干甚至是带头人，带领更多人一起开发。
 
 - [单测报错信息优化](code_style_improvement_for_unittest.md)【已完成】
-- [编译 warning 的消除](code_style_compiler_warning.md)
+- [编译 warning 的消除](code_style_compiler_warning.md)【进行中】
 - [flake8 代码风格检查工具的引入](code_style_flake8.md)【进行中】
 - [clang-tidy 代码风格检查工具的引入](code_style_clang_tidy.md)
-- [Python 2.7 相关代码退场](legacy_python2.md)
-- [Type Hint类型注释](type_hint.md)
+- [Python 2.7 相关代码退场](legacy_python2.md)【进行中】
+- [Type Hint类型注释](type_hint.md)【进行中】
 
 
 ## Project Ideas
@@ -29,6 +29,5 @@ status：[momozi1996](https://github.com/momozi1996) 正在整理材料，并会
 Note：如果成为正式项目，需要首先明确项目Scope，这里先记录想法。
 
 - 社区中的相关issue：[#46622](https://github.com/PaddlePaddle/Paddle/issues/46622)、[#46554](https://github.com/PaddlePaddle/Paddle/pull/46554#pullrequestreview-1122960171)、[#44857](https://github.com/PaddlePaddle/Paddle/pull/44857)、[45756](https://github.com/PaddlePaddle/Paddle/issues/45756)、[#43610](https://github.com/PaddlePaddle/Paddle/issues/43610)
-
 - 可参考的材料：[pytorch/rfcs/RFC-0026-logging-system.md](https://github.com/pytorch/rfcs/blob/4b75803bf90c16b0120787fa0557bfe79ace1ef3/RFC-0026-logging-system.md)
 - [Paddle报错信息文案书写规范](https://github.com/PaddlePaddle/Paddle/wiki/Paddle-Error-Message-Writing-Specification)

--- a/pfcc/call-for-contributions/code_style_clang_tidy.md
+++ b/pfcc/call-for-contributions/code_style_clang_tidy.md
@@ -1,4 +1,7 @@
 # clang-tidy代码风格检查工具的引入
+
+> This project will be mentored by [@luotao1](http://github.com/luotao1)
+
 ## 背景
 Paddle目前使用的代码风格检查工具及hooks版本较低，导致开发者在提交代码时会碰到一些问题，加强代码规范检查，有利于提高Paddle代码质量，增强代码的可读性。
 

--- a/pfcc/call-for-contributions/code_style_compiler_warning.md
+++ b/pfcc/call-for-contributions/code_style_compiler_warning.md
@@ -1,4 +1,6 @@
 # 编译warning的消除
+
+> This project will be mentored by [@zhiqiu](https://github.com/zhiqiu)
 ## 目的
 
 作为一个大型的基础设施类开源项目，减少飞桨框架在编译时的warning，可以提升工程质量和整个代码仓库的可维护性，以及减少潜在的bug。

--- a/pfcc/call-for-contributions/code_style_flake8.md
+++ b/pfcc/call-for-contributions/code_style_flake8.md
@@ -1,5 +1,7 @@
 # flake8 代码风格检查工具的引入
 
+> This project will be mentored by [@luotao1](http://github.com/luotao1)
+
 ## 背景
 
 Paddle 目前使用的代码风格检查工具及 hooks 版本较低，导致开发者在提交代码时会碰到一些问题，加强代码规范检查，有利于提高 Paddle 代码质量，增强代码的可读性。

--- a/pfcc/call-for-contributions/code_style_improvement_for_unittest.md
+++ b/pfcc/call-for-contributions/code_style_improvement_for_unittest.md
@@ -1,5 +1,7 @@
 # 框架易用性提升——单测报错信息优化
 
+> This project will be mentored by [@luotao1](http://github.com/luotao1)
+
 ## 背景
 
 来源于NVIDIA开发者提的 [issue#44641](https://github.com/PaddlePaddle/Paddle/issues/44641)，NVIDIA开发者每月需要上线一次飞桨到NGC官网，他们会在不同的GPU卡上跑全量单测。使用 `np.testing.assert_allclose` 代替 `assertTrue(np.allclose(...))`，可以获得更全面的单测报错信息，便于验证不同卡上的Op精度。

--- a/pfcc/call-for-contributions/legacy_python2.md
+++ b/pfcc/call-for-contributions/legacy_python2.md
@@ -1,45 +1,119 @@
 # Python 2.7 相关代码退场
-## 背景
-Python 2.7在2020年1月1日终止支持，Paddle从2.1版本（2021年）开始不再维护Python 2.7，并准备在2.5版本（2023年）完成Python 2.7相关代码的退场。
-主要涉及到针对 Python 2 subpackage（子包）、module（模块） 与 requirement（运行环境依赖）等几个方面的处理：
-* 删除Python 2 子包
-* 删除没有其它功能的 Python 2 模块
-* 删除非必要的环境依赖
-* 清理 Python2 相关逻辑分支
-* 清理文档中涉及到 Python 2 的内容
+## 一、概要
+### 1、相关背景
+[Python 2.7在2020年1月1日终止支持](https://www.python.org/doc/sunset-python-2/)，Paddle从2.1版本（2021年）开始不再维护Python 2.7。
+Python 2 和 Python 3 在整型、字符串、比较运算符、算数运算符、`round()`、输入/输出函数、文件操作函数、`exec/execfile()`、`xrange()/ range()`、字典、`zip()`、`map()`、`filter()`、迭代器、缩进方式、异常处理、`object`、模块导入方式、列表推导式等都有差异，详细见 [差异与兼容一览表](https://zhuanlan.zhihu.com/p/385023142)。
 
-## 具体内容
-如有遗漏，欢迎大家补充！
-### 删除 Python 2 子包
-#### `Six`
-[six](https://pypi.org/project/six/) 的设计目的是为了解决Python2和3的不兼容问题，名字的来源就是 2×3=6, SIX = Python2 Times Python3。由于Paddle不再维护Python 2.7，整个six库都可以删除。
-* 有250多处import six：其中有些import是冗余的，可以直接删除；其余需要进行更改
-* 有68处from six：涉及使用了six的string_types, zip, range, xrange, cStringIO, cPickle等
-* [python/requirements.txt](https://github.com/PaddlePaddle/Paddle/blob/develop/python/requirements.txt)：移除six库
-#### `__future__`【已完成 by [SigureMo](https://github.com/SigureMo) 】
-Paddle 目前代码里使用的全部是 3.0 及更高版本的内置特性（`generator_stop` 和 `annotations` 未使用），均无需从 `__future__` 模块 import。
-因此可以移除全部 `from __future__ import xxx` 结构。
-* future 详细说明见：<https://docs.python.org/3/library/__future__.html>
-* [Paddle#46411](https://github.com/PaddlePaddle/Paddle/pull/46411) [Paddle#46463](https://github.com/PaddlePaddle/Paddle/pull/46463) 
-移除存量，[Paddle#46466](https://github.com/PaddlePaddle/Paddle/pull/46466) 控制增量
+对 Paddle 中 Python 2.7相关代码进行退场可以提高源码整洁性，提升开发者阅读的便利性。同时，开发者可以直接使用python 3 新特性，无需考虑和 python 2 的兼容性，更专注于编写代码逻辑。
 
-### 删除没有其它功能的 Python 2 模块
-[python/paddle/compat.py](https://github.com/PaddlePaddle/Paddle/blob/develop/python/paddle/compat.py) 文件内为了Python3和2的兼容设计的API，
-整个文件可以删除。框架中使用`compat.xxx`部分可以直接用Python 3的API代替。
+### 2、功能目标
 
-### 删除非必要的环境依赖
-Paddle 镜像 [tools/dockerfile/Dockerfile.ubuntu](https://github.com/PaddlePaddle/Paddle/blob/develop/tools/dockerfile/Dockerfile.ubuntu#L83) 
-安装了Python 2.7.15，可以进行删除来减少镜像体积大小。
-同时可以删除其中的 `pip --no-cache-dir install xxx` 内容。
+对 Paddle 中 Python 2.7相关代码进行退场，提升开发者阅读和开发源码的便利性。
 
-### 清理 Python2 相关逻辑分支
+### 3、方案要点
 
-部分代码中使用 `sys.version_info` 来区分不同 Python 版本，并对不同版本做不同处理，对于 Python2 逻辑分支可以删除。
+Python2.7 相关代码退场，主要涉及到针对 Python 2 subpackage（子包）、module（模块） 与 requirement（运行环境依赖）等几个方面的处理：
 
-示例如下：
+- 删除Python 2 子包
+- 删除没有其它功能的 Python 2 模块
+- 删除非必要的环境依赖
+- 清理 Python2 相关逻辑分支
+- 清理文档中涉及到 Python 2 的内容
 
+## 二、意义
+Paddle从2.1版本（2021年）开始不再维护Python 2.7，因此，可以对相关代码进行退场，开发者可以直接使用python 3 新特性，无需考虑和 python 2 的兼容性，提升开发源码的便利性，更专注于编写代码逻辑。
+
+举例：
+
+1. 整型的处理，不需要写两个分支。[PR#46696](https://github.com/PaddlePaddle/Paddle/pull/46696/files)
+
+<img width="937" alt="image" src="https://user-images.githubusercontent.com/6836917/196356294-ead46c28-f81a-460f-8b04-ca3075b96875.png">
+
+
+2. 对于`range()`的处理，不需要引入`six`子包来兼容。[tensorflow/commit/cfc45e1](https://github.com/tensorflow/tensorflow/commit/cfc45e1027d43cf54b0358d7d9e2fc01f58938dd)
+
+<img width="954" alt="image" src="https://user-images.githubusercontent.com/6836917/196356599-28a9eb1b-1b72-4bb1-bf93-da175508ce74.png">
+
+3. 在开头加上`from __future__ import print_function` 这句之后，即使在 python2.X ，使用 print 就得像 python3.X 那样加括号使用。python2.X 中 print不需要括号，而在 python3.X 中则需要。去掉`__future__`后更简单。[PR#46686](https://github.com/PaddlePaddle/Paddle/pull/46686/files)
 ```python
-# https://github.com/PaddlePaddle/Paddle/blob/7467221be8cecf137fa3d896f4ab08d3132a2178/python/paddle/fluid/param_attr.py#L87
+#python2.7
+print "hello world"
+#python3
+print("hello world")
+```
+
+## 三、业内调研
+
+### Python 2 涉及到的特性
+
+#### Python 2 子包
+1. [six](https://pypi.org/project/six/)：six 的设计目的是为了解决Python2和3的不兼容问题，名字的来源就是 2×3=6, SIX = Python2 Times Python3。不再维护 Python 2.7 后，整个 six 库都可以删除。
+2. `__future__`：使用 3.0 及更高版本的内置特性后，均无需从 `__future__` 模块 import。 因此可以移除全部 `from __future__ import xxx` 结构，见 [future 官方说明](https://docs.python.org/3/library/__future__.html)。
+
+#### Python 2 模块
+
+**1. 删除类中不必要的显式 `object` 继承**
+
+Python 2.x 中默认都是经典类，只有显式继承了 `object` 才是新式类函数；Python 3.x 中默认都是新式类，经典类被移除，没必要显式继承 `object` 。见 [why-do-python-classes-inherit-object](https://stackoverflow.com/questions/4015417/why-do-python-classes-inherit-object) ：
+
+结论：之前为了兼容性的考虑，保留了显式 `object` 继承，如果 python2.7 退场，可以删除这些显式继承。
+
+**2. 删除 `super()` 函数中不必要的参数**
+
+见 [When do you need to pass arguments to python super()?](https://stackoverflow.com/questions/59538746/when-do-you-need-to-pass-arguments-to-python-super) 和 https://peps.python.org/pep-3135/ 中的解释：
+
+### Tensorflow
+TF 从今年1月份开始逐步清理 python2.7 代码，见[Cleanup legacy Python2 PR 列表](https://github.com/tensorflow/tensorflow/search?p=2&q=python2%20legacy&type=commits)，包含以下内容：
+
+|清理内容 | tf commit 示例 | 
+|---|---|
+|Remove usage of the `six` package（删除six子包） | [tensorflow/commit/cfc45e1](https://github.com/tensorflow/tensorflow/commit/cfc45e1027d43cf54b0358d7d9e2fc01f58938dd) |
+|Remove unecessary `__future__` imports（删除`__future`子包） |[tensorflow/commit/cfc45e1](https://github.com/tensorflow/tensorflow/commit/cfc45e1027d43cf54b0358d7d9e2fc01f58938dd)|
+|Remove unnecessary explicit `object` inheritance for classes（删除显式`object`继承）| [tensorflow/commit/cfc45e1](https://github.com/tensorflow/tensorflow/commit/cfc45e1027d43cf54b0358d7d9e2fc01f58938dd)|
+|Remove unnecessary arguments to `super()` calls（删除`super()`函数中不必要的参数）|[tensorflow/commit/fb5a58c](https://github.com/tensorflow/tensorflow/commit/fb5a58c02a4638570b3a803e65655f06b91f24f9)|
+
+### Pytorch
+Pytorch 从2020年8月开始逐步清理 Python2.7 代码，见 [Legacy Python2 and early Python3 leftovers](https://github.com/pytorch/pytorch/issues/42919)，包括：
+
+- Remove unused six code for Python 2/3 compatibility
+- Clean up future imports for Python 2 
+
+Pytorch 的清理力度没有 Tensorflow 全面。
+
+## 四、设计思路与实现方案
+### 1、主体设计思路与折衷
+Paddle Python2.7 相关代码退场涉及如下内容：
+
+- 删除Python 2 子包：`six`和`__future__`
+- 删除没有其它功能的 Python 2 模块：类中不必要的显式`object`继承和`super()`函数中不必要的参数，和`python/paddle/compat.py`文件
+- 删除非必要的环境依赖
+- 清理 Python2 相关逻辑分支
+- 清理文档中涉及到 Python 2 的内容
+
+由于 Paddle 不再维护 Python 2.7，因此，代码退场的 PR 只要 CI 能通过，就可以合入，无其他风险。
+
+### 2、 关键技术点/子模块设计与实现方案
+#### 删除 Python 2 子包
+-  `Six`
+   - 有250多处import six：其中有些import是冗余的，可以直接删除；其余需要进行更改
+   - 有68处from six：涉及使用了six的string_types, zip, range, xrange, cStringIO, cPickle等
+   - [python/requirements.txt](https://github.com/PaddlePaddle/Paddle/blob/develop/python/requirements.txt)：移除six库
+-  `__future__`【已完成 by [SigureMo](https://github.com/SigureMo) 和 [Yulv-git](https://github.com/Yulv-git) 】   
+   - [Paddle#46411](https://github.com/PaddlePaddle/Paddle/pull/46411) [Paddle#46463](https://github.com/PaddlePaddle/Paddle/pull/46463) 移除存量，[Paddle#46466](https://github.com/PaddlePaddle/Paddle/pull/46466) 控制增量
+
+#### 删除没有其它功能的 Python 2 模块
+- 删除类中不必要的显式`object`继承：约530处
+- 删除`super()`函数中不必要的参数：约1600处
+- 删除 [python/paddle/compat.py](https://github.com/PaddlePaddle/Paddle/blob/develop/python/paddle/compat.py) 文件：该文件是为了兼容设计的API，框架中使用`compat.xxx`部分可以直接用Python 3的API代替。 
+
+#### 删除非必要的环境依赖
+Paddle 镜像 [tools/dockerfile/Dockerfile.ubuntu](https://github.com/PaddlePaddle/Paddle/blob/develop/tools/dockerfile/Dockerfile.ubuntu#L83) 安装了Python 2.7.15，可以进行删除来减少镜像体积大小。同时可以删除其中的 `pip --no-cache-dir install xxx` 内容。此项工作完成后，需统计一下包体积变化。
+
+#### 清理 Python2 相关逻辑分支
+
+部分代码中使用 `sys.version_info` （共62处）来区分不同 Python 版本，并对不同版本做不同处理， Python2 逻辑分支可以删除。
+```python
+# https://github.com/PaddlePaddle/Paddle/blob/develop/python/paddle/fluid/param_attr.py#L87
 if sys.version_info.major == 2:
     check_type(name, "name", (str, type(None), unicode), "ParamAttr")
 else:
@@ -51,9 +125,20 @@ check_type(name, "name", (str, type(None)), "ParamAttr")
 # 其他可全局搜索 `sys.version_info` 根据具体情况来处理
 ```
 
-### 清理文档中涉及到 Python 2 的内容
-在 [docs](https://github.com/PaddlePaddle/docs) 仓库下用`grep -irn python2 . | wc -l`， 可以看到有53条结果。
-一个具体的例子是：https://www.paddlepaddle.org.cn/documentation/docs/zh/guides/hardware_support/xpu_docs/paddle_install_cn.html
+#### 清理文档中涉及到 Python 2 的内容
+在 [docs](https://github.com/PaddlePaddle/docs) 仓库下用`grep -irn python2 . | wc -l`， 可以看到有53条结果。如 [飞桨框架昆仑XPU版安装说明](https://www.paddlepaddle.org.cn/documentation/docs/zh/guides/hardware_support/xpu_docs/paddle_install_cn.html)：
 
-## 可行性分析和规划排期
-由于 Paddle 不再维护 Python 2.7，因此，代码退场的PR只要CI能通过，就可以合入，无其他风险。
+# 五、影响和风险总结
+## 对用户的影响
+对开发者的影响：
+
+- 提高源码整洁性，提升开发者阅读的便利性；
+- 开发者可以直接使用python 3 新特性，无需考虑和 python 2 的兼容性，提升开发源码的便利性，更专注于编写代码逻辑。
+
+对用户使用模型影响（无）：
+
+- Paddle 从 2.1 版本（2021年4月）开始不再发 Python 2.7 的包，目前套件 repo 都已支持 Python3 ，因此用户使用模型无影响。
+
+## 风险
+
+由于 Paddle 不再维护 Python 2.7，因此，代码退场的 PR 只要 CI 能通过，就可以合入，无其他风险。

--- a/pfcc/call-for-contributions/legacy_python2.md
+++ b/pfcc/call-for-contributions/legacy_python2.md
@@ -1,4 +1,6 @@
 # Python 2.7 相关代码退场
+> This project will be mentored by [@luotao1](http://github.com/luotao1)
+
 ## 一、概要
 ### 1、相关背景
 [Python 2.7在2020年1月1日终止支持](https://www.python.org/doc/sunset-python-2/)，Paddle从2.1版本（2021年）开始不再维护Python 2.7。
@@ -41,6 +43,7 @@ print "hello world"
 #python3
 print("hello world")
 ```
+<img width="945" alt="image" src="https://user-images.githubusercontent.com/6836917/196360783-515444ee-17e7-4e7b-b77a-64196e3742e4.png">
 
 ## 三、业内调研
 
@@ -56,11 +59,16 @@ print("hello world")
 
 Python 2.x 中默认都是经典类，只有显式继承了 `object` 才是新式类函数；Python 3.x 中默认都是新式类，经典类被移除，没必要显式继承 `object` 。见 [why-do-python-classes-inherit-object](https://stackoverflow.com/questions/4015417/why-do-python-classes-inherit-object) ：
 
+<img width="660" alt="image" src="https://user-images.githubusercontent.com/6836917/196360960-56ce8c1c-c081-4f64-a542-b99ae378b764.png">
+<img width="665" alt="image" src="https://user-images.githubusercontent.com/6836917/196361119-6bc76af3-1358-42be-9ad3-70a1a6c81d6f.png">
+
 结论：之前为了兼容性的考虑，保留了显式 `object` 继承，如果 python2.7 退场，可以删除这些显式继承。
 
 **2. 删除 `super()` 函数中不必要的参数**
 
 见 [When do you need to pass arguments to python super()?](https://stackoverflow.com/questions/59538746/when-do-you-need-to-pass-arguments-to-python-super) 和 https://peps.python.org/pep-3135/ 中的解释：
+
+<img width="770" alt="image" src="https://user-images.githubusercontent.com/6836917/196361507-b224bb5a-5f8e-41a0-b788-efdf4f3969eb.png">
 
 ### Tensorflow
 TF 从今年1月份开始逐步清理 python2.7 代码，见[Cleanup legacy Python2 PR 列表](https://github.com/tensorflow/tensorflow/search?p=2&q=python2%20legacy&type=commits)，包含以下内容：
@@ -127,6 +135,8 @@ check_type(name, "name", (str, type(None)), "ParamAttr")
 
 #### 清理文档中涉及到 Python 2 的内容
 在 [docs](https://github.com/PaddlePaddle/docs) 仓库下用`grep -irn python2 . | wc -l`， 可以看到有53条结果。如 [飞桨框架昆仑XPU版安装说明](https://www.paddlepaddle.org.cn/documentation/docs/zh/guides/hardware_support/xpu_docs/paddle_install_cn.html)：
+
+<img width="543" alt="image" src="https://user-images.githubusercontent.com/6836917/196361719-1fd6b624-2608-4153-8a20-491ae40d52db.png">
 
 # 五、影响和风险总结
 ## 对用户的影响

--- a/rfcs/CodeStyle/20221018_introducing_black.md
+++ b/rfcs/CodeStyle/20221018_introducing_black.md
@@ -1,0 +1,204 @@
+# python 代码检查工具 yapf 升级 black 方案
+| 任务名称     | python 代码检查工具 yapf 升级 black 方案 |
+| ------------ | -------------------------------- |
+| 提交作者     | @luotao1 @SigureMo        |
+| 提交时间     | 2022-10-18                       |
+| 版本号       | v1.0                             |
+| 依赖飞桨版本 | develop                          |
+| 文件名       | 20221018_introducing_black.md   |
+
+## 一、概要
+### 1、相关背景
+Paddle 在 Q2 完成了《代码检查机制完善和工具升级一期项目》，整体代码质量和可读性有了较大提升，升级版本后的自动化代码风格检查，也不再成为贡献者提交代码时的痛点。但仍然需要持续地完善，一期的后续规划是引入 clang-tidy 、flake8 等检查工具，检查 C++ 和 Python 代码的静态逻辑错误。
+
+flake8 作为一个 python linter 不提供自动修复的能力。当前 flake8 包含大量的格式问题需要修复，而格式化工具 yapf 并不能修复一些 PEP 8 中描述的格式规范问题，因此可能需要考虑使用其他格式化工具进行格式化。
+
+black 可以兼顾 PEP 8 和格式上的统一，相比于 yapf 格式化力度更高，可以自动修复较多的格式问题，大大减少开发者手动解决 flake8 问题的频率。将yapf 升级为 black 是有利于 flake8 检查工具的集成。
+
+### 2、功能目标
+
+ 将python代码检查工具yapf升级为black，有助于 flake8 检查工具的集成。
+
+### 3、方案要点
+- yapf 升级为 black 后，对集成 flake8 带来的好处。
+- 如何进行存量代码的修复和增量代码的拦截。
+
+## 二、意义
+- 当前 flake8 包含大量的格式问题需要修复：flake8 默认启用的三个工具（pycodestyle、pyflakes、mccabe）共包含了一共 132 个错误子项，**Paddle 中存在问题的错误子项共 62 个，涉及4w多行python代码。使用 black 替换 yapf 可以一次性解决26个子项，减少7k行代码**，大大减少开发者手动解决 flake8 问题的频率，有助于 flake8 检查工具的集成。
+- black 在生态上比 yapf 更好，Github stars 数、使用量、开源工具的支持都远超 yapf ，有助于后续加入更多的检查工具。
+
+## 三、业内调研
+### Paddle引入flake8初始状态
+flake8 默认启用的三个工具（pycodestyle、pyflakes、mccabe）共包含了一共 132 个子项。Paddle 中存在问题的子项共 62 个，涉及代码约4w多行。
+
+-  错误码参考：
+   - E、W：[PyCodeStyle Error code](https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes)
+   - F：[flake8 Error code](https://flake8.pycqa.org/en/latest/user/error-codes.html)
+- 62个错误码子项清单见：[flake8 tracking issue](https://github.com/PaddlePaddle/Paddle/issues/46039#issue-1372620386)
+- 推进方式：采用在 [.flake8](https://github.com/PaddlePaddle/Paddle/blob/develop/.flake8) 配置文件中 ignore 现存的错误码来推进，修复一类错误就去掉一个错误码
+
+### yapf & black 在Github的使用情况
+
+flake8 作为一个 linter 不提供自动修复的能力，而目前采用的格式化工具 yapf 并不能修复一些 PEP 8 中描述的格式规范问题，因此可能需要考虑使用其他格式化工具进行格式化。
+
+目前主流的格式化工具包含 yapf、black 和 autopep8，三者对比如下：
+
+|-|autopep8|yapf|black|
+|-|-|-|-|
+|GitHub Stars|4.1k|12.8k|29.1k|
+|GitHub Used by|132k|36k|178k|
+|速度|非常慢|慢（Paddle 全量格式化需 13min）|快（同全量格式化 1min）|
+|格式化力度|主要修复 PEP 8 的问题，但太过于关注 PEP 8 导致可能改变代码语义，不算「合格」的格式化工具|不注重 PEP 8，主要注重代码格式的统一|兼顾 PEP 8 和代码格式的统一|
+|可配置性|可选择忽略的 Error Code，修复的激进等级等|各式各样的配置，可以设置各式各样的风格，有点类似 clang-format|基本没有配置项|
+
+此外，有很多工具对 black 支持/兼容性更好，比如：
+
+-  [isort](https://pycqa.github.io/isort/docs/configuration/black_compatibility.html) （对头文件的引入顺序做排序）专门有个 profile 就是针对 black 的，可以保证与 black 没有冲突，而 yapf 则很难与 isort 一起工作（见 [pull/46475#issuecomment](https://github.com/PaddlePaddle/Paddle/pull/46475#issuecomment-1257246946) ）
+-  [blacken-docs](https://github.com/asottile/blacken-docs) （docstring、rst 文档示例代码格式化工具）也是集成了 black。
+
+结论：
+
+- autopep8 可能改变代码语义，不安全；
+- **black 的 stars 数、使用量、速度、开源工具的支持都远超 yapf**，也有助于后续加入更多的集成工具
+
+### 业内情况
+
+- pytorch 的 python 代码检查工具为：`flake8==3.8.2, black==22.3.0, mypy==0.950`，没有使用 yapf
+- keras 的 python [代码检查工具](https://github.com/keras-team/keras/blob/master/requirements.txt)为：`flake8==4.0.1, black==22.3.0, isort==5.10.1` 
+- tensorflow 没有使用 flake8、yapf 和 black，只是推荐手动 yapf 格式化。见issue： [how to auto format python code](https://github.com/tensorflow/tensorflow/issues/50304)，[Some check that we have enabled in .pylintrc are silently not executed anymore](https://github.com/tensorflow/tensorflow/issues/55442) 
+### yapf & black 在Paddle的错误码数量对比
+
+统计说明：
+
+- 共统计59个子项：1）初始62个子项中，排除已经解决的E999和trailing whitespace（W191和W293）
+- 由于fluid将在2.5版本移除，排除 `python/paddle/fluid`目录，但包含 `python/paddle/fluid/tests`目录
+- 表格中的数字是：格式化后剩余的不规范的代码行数
+
+```
+# yapf/black/autopep8 所在列是：对应工具格式化后剩余的不规范的代码行数
+code    yapf    black   diff    percent autopep8        diff    percent
+
+Type: E (yapf 26436 -> black 20023 & autopep8 19200) 
+E101    11      10      -1      -9%     10      -1      -9%
+E121    8       0       -8      -100%   0       -8      -100%
+E122    81      0       -81     -100%   0       -81     -100%
+E123    12      0       -12     -100%   0       -12     -100%
+E125    168     0       -168    -100%   0       -168    -100%
+E126    723     0       -723    -100%   0       -723    -100%
+E127    140     0       -140    -100%   1       -139    -99%
+E128    207     0       -207    -100%   0       -207    -100%
+E129    9       0       -9      -100%   0       -9      -100%
+E131    45      0       -45     -100%   10      -35     -78%
+E201    29      0       -29     -100%   0       -29     -100%
+E202    11      0       -11     -100%   0       -11     -100%
+E225    61      0       -61     -100%   0       -61     -100%
+E226    93      0       -93     -100%   0       -93     -100%
+E228    3       0       -3      -100%   0       -3      -100%
+E231    60      3       -57     -95%    0       -60     -100%
+E241    2       0       -2      -100%   0       -2      -100%
+E251    109     0       -109    -100%   0       -109    -100%
+E261    11      0       -11     -100%   0       -11     -100%
+E262    238     17      -221    -93%    0       -238    -100%
+E265    925     48      -877    -95%    218     -707    -76%
+E266    116     116     0       0%      57      -59     -51%
+E271    4       0       -4      -100%   0       -4      -100%
+E272    1       0       -1      -100%   0       -1      -100%
+E301    7       0       -7      -100%   5       -2      -29%
+E302    3       0       -3      -100%   0       -3      -100%
+E303    7       0       -7      -100%   2       -5      -71%
+E305    2       0       -2      -100%   0       -2      -100%
+E306    1       1       0       0%      0       -1      -100%
+E401    19      19      0       0%      0       -19     -100%
+E402    2666    2666    0       0%      341     -2325   -87%
+E501    19252   16239   -3013   -16%    17714   -1538   -8%
+E502    400     0       -400    -100%   0       -400    -100%
+E701    108     0       -108    -100%   0       -108    -100%
+E711    166     166     0       0%      166     0       0%
+E712    340     340     0       0%      340     0       0%
+E713    22      22      0       0%      22      0       0%
+E714    4       4       0       0%      4       0       0%
+E721    8       8       0       0%      8       0       0%
+E722    149     149     0       0%      149     0       0%
+E731    62      62      0       0%      0       -62     -100%
+E741    153     153     0       0%      153     0       0%
+
+Type: F (yapf 9895 -> black 9913 & autopep8 9858)
+F401    6750    6768    18      0%      6739    -11     -0%
+F402    1       1       0       0%      1       0       0%
+F403    57      57      0       0%      57      0       0%
+F405    556     556     0       0%      556     0       0%
+F522    1       1       0       0%      1       0       0%
+F524    1       1       0       0%      1       0       0%
+F541    33      33      0       0%      33      0       0%
+F601    7       7       0       0%      7       0       0%
+F631    2       2       0       0%      2       0       0%
+F632    18      18      0       0%      18      0       0%
+F811    177     177     0       0%      151     -26     -15%
+F821    88      88      0       0%      88      0       0%
+F841    2204    2204    0       0%      2204    0       0%
+
+Type: W (yapf 1135 -> black 185 & autopep8 1482)
+W191    11      10      -1      -9%     10      -1      -9%
+W504    949     0       -949    -100%   1297    348     37%
+W601    3       3       0       0%      3       0       0%
+W605    172     172     0       0%      172     0       0%
+```
+
+总结：格式化后剩余的不规范的代码行数 & 错误码数量 对比
+
+|-|yapf|black|备注|
+|-|-|-|-|
+|E|26436行，42子项|20023行，17子项| black 优势很明显，减少6k多行代码，25个子项|
+|F|9895行，13子项|9913行，13子项|F 可能会影响语义，不应该被格式化，两者效果类似|
+|W|1135行，4子项|185行，3子项| black 优势很明显，减少1k行代码，1个子项|
+
+black 相比于 yapf 格式化力度更高，可以自动修复较多的格式问题，大大减少开发者手动解决 flake8 问题的频率，有利于 flake8 检查工具的集成。
+
+## 四、设计思路与实现方案
+### 1、主体设计思路与折衷
+**增量监控**：
+
+- 替换配置文件，将`.style.yapf`改成`pyproject.toml`。其中`skip-string-normalization`参数：black 原来是强制字符串用双引号的，后来做出了妥协，这个参数就是允许保持原来的单引号。
+
+<img width="766" alt="image" src="https://user-images.githubusercontent.com/6836917/196332356-90a8ee55-0387-409f-b5ee-77ea8c149a0e.png">
+
+- 在 `.pre-commit-config.yaml` 中，将 yapf 格式工具替换为 black。该方式会在 pre-commit 时自动触发，同时适用于 CI 和本地机器，且无需用户额外操作。（动转静的两个验证行号的单测，需要过滤）
+
+![image](https://user-images.githubusercontent.com/6836917/196331579-5f25ea96-63c0-45a5-9e85-352f049eb7c3.png)
+
+**存量修复**：
+
+- 本地安装 black 进行自动化修复
+
+```bash
+pip install black
+black .
+
+git checkout develop -- 'python/paddle/fluid/tests/unittests/dygraph_to_static/test_error.py'
+git checkout develop -- 'python/paddle/fluid/tests/unittests/dygraph_to_static/test_origin_info.py'
+```
+- 在`.flake8`中，将 black 工具修复过的26个子项错误码去除。
+
+### 2、 关键技术点/子模块设计与实现方案
+
+**可行性验证**：[pull/46014](https://github.com/PaddlePaddle/Paddle/pull/46014) 过滤了动转静的两个验证行号的单测（`dygraph_to_static/test_error.py`和`dygraph_to_static/test_origin_info.py`）后，接近 24 万行 change 不经任何人工调整可直接通过单测。
+
+**推进方式**：按照《代码检查机制完善和工具升级一期项目》的推进方式。
+
+- 由于该 PR 较大，引起其他PR冲突的概率很高，为了减少对其他PR的影响，会提前通知大家该PR合入的时间点。
+- develop 分支修复存量问题，并将配置从 yapf 改成 black，即合入本 PR。release/2.4 分支只改配置，不修存量问题。
+
+## 五、影响和风险总结
+### 对用户的影响
+yapf 升级 black 是对开发者的影响
+
+- black 可以自动修复较多的格式问题，大大减少开发者手动解决 flake8 问题的频率。可以让开发者专注于编写代码逻辑，而不是浪费时间在调整代码格式上。
+- 在正式升级后初次提交代码时，pre-commit需要初始化 black 检查环节，等待的时间会稍微长一点（大概1min），后续提交代码不受影响。
+- 提交代码时 black 检查时间取决于修改文件的数量和类型。最长不超过1min（全量代码格式化的时间），在完成存量修复后，该时间会大大缩短。
+
+### 风险
+只影响格式，CI 通过即可。
+
+## 附件及参考资料
+ 1. [flake8 tracking issue](https://github.com/PaddlePaddle/Paddle/issues/46039)
+ 1. [use black instead of yapf 测试代码](https://github.com/PaddlePaddle/Paddle/pull/46014)


### PR DESCRIPTION
1. 更新内部评审通过的【Python 2.7 相关代码退场】call-for-contribution
2. 新增内部评审通过的【python 代码检查工具 yapf 升级 black 方案】RFC文档
3. 更新 call-for-contribution 的 进度以及 mentor 信息