### PR TITLE
Update PaddlePaddle Hackathon 4 fix github links of No.161 and No.162 tasks

### DIFF
--- a/hackthon_4th/【PaddlePaddle Hackathon 4】 模型套件开源贡献任务合集.md
+++ b/hackthon_4th/【PaddlePaddle Hackathon 4】 模型套件开源贡献任务合集.md
@@ -1071,7 +1071,7 @@
 - **任务难度：基础**⭐️
 - **详细描述：**
   - ps2.0数据集，precision 99.56%
-  - 参考repo https://github.com/Jiaolong/gcn-parking-slot
+  - 参考repo https://github.com/Turoad/CLRNet
 - **提交内容：**
   - 代码、模型、训练日志，合入PaddleDetection套件
 - **技术要求：**
@@ -1084,7 +1084,7 @@
 - **任务难度：基础**️⭐️
 - **详细描述：**
   - CULane数据集，backbone RestNet18版本，mF1指标达到55.23
-  - 参考repo https://github.com/Turoad/CLRNet
+  - 参考repo https://github.com/Jiaolong/gcn-parking-slot
 - **提交内容：**
   - 代码、模型、训练日志，合入PaddleDetection套件
 - **技术要求：**


### PR DESCRIPTION
fix github links of No.161 and No.162 tasks