### PR TITLE
【Hackathon 4th No.7】修改 paddle.unflatten 的 RFC

### DIFF
--- a/rfcs/APIs/20230314_api_design_for_unflatten.md
+++ b/rfcs/APIs/20230314_api_design_for_unflatten.md
@@ -158,7 +158,7 @@ paddle.unflatten API 的设计主要参考 PyTorch 中的实现，PyTorch 中`un
 
 返回：在 axis 维度扩展成 shape 形状的 tensor
 
-`Tensor.unflatten(shape, axis, name=None)`
+`Tensor.unflatten(axis, shape, name=None)`
 
 参数说明如下：
 


### PR DESCRIPTION
原 RFC 链接：
- https://github.com/PaddlePaddle/community/pull/460

对应竞品的API，从复现模型的易用角度出发，调整 unflatten API 中参数设计顺序。

对应项目链接：
- https://github.com/PaddlePaddle/Paddle/pull/53055