### PR TITLE
【Hackathon 5th No.32】为 Paddle 新增 tensor_split / hsplit / dsplit API -- v2.0

### DIFF
--- a/rfcs/APIs/20231003_api_design_for_tensor_split.md
+++ b/rfcs/APIs/20231003_api_design_for_tensor_split.md
@@ -3,10 +3,14 @@
 | API 名称 | tensor_split / hsplit / dsplit |
 | - | - |
 | 提交作者 | megemini(柳顺) |
-| 提交时间 | 2023-10-03 |
-| 版本号 | V1.2 |
+| 提交时间 | 2023-12-07 |
+| 版本号 | V2.0 |
 | 依赖飞桨版本 | develop |
 | 文件名 | 20231003_api_design_for_tensor_split.md |
+
+**修改历史**
+v2.0
+- 将 `vsplit`, `hsplit`, `dsplit` 通过 `tensor_split` 实现  
 
 # 一、概述
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what you’ve done -->

修改 `hsplit`, `vsplit`, `dsplit` 通过 `tensor_split` 实现。

主要修改部分为 `# 五、设计思路与实现方案` 。

参考 rfc：https://github.com/PaddlePaddle/community/blob/master/rfcs/APIs/20231003_api_design_for_tensor_split.md

@zoooo0820 @jeff41404

请评审 ～ 谢谢！
