### PR TITLE
Update paddle_distributed_primer.md

### DIFF
--- a/pfcc/paddle-code-reading/auto_parallel/paddle_distributed_primer.md
+++ b/pfcc/paddle-code-reading/auto_parallel/paddle_distributed_primer.md
@@ -911,9 +911,9 @@ def train_model():
             #acc_top1 = paddle.metric.accuracy(input=out, label=label, k=1)
             #acc_top5 = paddle.metric.accuracy(input=out, label=label, k=5)
 
-            avg_loss.backward()
-            optimizer.step()
-            model.clear_gradients()
+            #avg_loss.backward()
+            #optimizer.step()
+            #model.clear_gradients()
 
             if batch_id % 5 == 0:
                 print("[Epoch %d, batch %d] loss: %.5f" % (eop, batch_id, avg_loss))

--- a/pfcc/paddle-code-reading/auto_parallel/paddle_distributed_primer.md
+++ b/pfcc/paddle-code-reading/auto_parallel/paddle_distributed_primer.md
@@ -908,12 +908,6 @@ def train_model():
             #loss = paddle.nn.functional.cross_entropy(input=out, label=label)
             loss = model.train_batch([img, label], optimizer)
             avg_loss = paddle.mean(x=loss)
-            #acc_top1 = paddle.metric.accuracy(input=out, label=label, k=1)
-            #acc_top5 = paddle.metric.accuracy(input=out, label=label, k=5)
-
-            #avg_loss.backward()
-            #optimizer.step()
-            #model.clear_gradients()
 
             if batch_id % 5 == 0:
                 print("[Epoch %d, batch %d] loss: %.5f" % (eop, batch_id, avg_loss))


### PR DESCRIPTION
修改 [paddle_distributed_primer.md](https://github.com/PaddlePaddle/community/commit/c6413ff74e8c829b1a4526be113751c41435d4c7) 动手流水线并行的相关示例代码

原因：
在 train_batch 中已包含了 forward, backward, optimize, clear_grad 的过程，不需要在外部再手动进行 backward, optimize, clear_grad，理由如下：
- train_batch 返回的 avg_loss 实际上是在内部已经被 detach 掉的 tensor，其 grad_fn == None，对 avg_loss 进行 backward 没有意义

- 在 train_batch 函数内已经包含了 optimize.step 的调用，不需要再在 train_batch 外部使用 optimizer.step 对模型参数进行第二次更新

- 在 train_batch 函数内已经包含了 clear_grad 的调用，不需要再在 train_batch 外部使用 clear_grad


错误的示例代码容易对初学者理解流水并行造成误解，所以申请更改