### PR TITLE
RFC doc of paddle.audio.functional.resample 

### DIFF
--- a/rfcs/APIs/20260205_api_design_for_resample.md
+++ b/rfcs/APIs/20260205_api_design_for_resample.md
@@ -107,6 +107,7 @@ paddle/audio/functional.py
 - 边界情况：输入为单通道/多通道/批量数据
 - 错误检查：无效采样率、非浮点输入、无效方法参数等
 - 在paddle仓库中，`Paddle/test/legacy_test/test_audio_functions.py`是对音频相关API进行测试的地方，所以应该在此处增加测试用例。
+- 具体测试细节计划批判性借鉴[TorchAudio functional unittest of resample](https://github.com/pytorch/audio/blob/96200d42e795098ee5e3f0106bcf9c370cf126a1/test/torchaudio_unittest/functional/functional_impl.py)中的算法。
 
 ---
 
@@ -125,5 +126,6 @@ paddle/audio/functional.py
 - PyTorch Audio `resample` 实现
 - 数字信号处理相关文献（如《Discrete-Time Signal Processing》）
 - Paddle API 设计规范
+
 
 


### PR DESCRIPTION
目前paddlepaddle框架内有关audio相关的API还是太少了。虽然框架底层提供的算子都挺全的，但是Python层相比业界内其他框架还是缺了一些API。如果能够在python层增加这些算子，可以有效的扩展、加速paddlepaddle框架在特定领域内（如音频处理）的处理能力，因此提出本PR。如果这个RFC被接受，我将陆陆续续扩展框架内与audio相关的API。

![5`~00K{%4~H}L6SWC~%4T@G](https://github.com/user-attachments/assets/c41e009f-b59f-4d0e-ae40-e50c39a20572)
