### PR TITLE
Update enflame task: free compute credits for developers

### DIFF
--- a/pfcc/paddle-hardware/燧原科技-基于FastDeploy跑通ERNIE-4.5-0.3B-Paddle 打卡任务.md
+++ b/pfcc/paddle-hardware/燧原科技-基于FastDeploy跑通ERNIE-4.5-0.3B-Paddle 打卡任务.md
@@ -12,7 +12,7 @@
 参与热身打卡活动并按照邮件模板格式将截图发送至 ext_paddle_oss@baidu.com + teemo.wang@enflame-tech.com + wenhao.zhang@enflame-tech.com
 
 ## 算力/环境支持
-为让开发者无后顾之忧，专注技术攻坚，燧原科技为所有报名本赛题的开发者提供每人200算力代金券专属福利，助力燧原科技GCU上的开发、调试与验证！ 算力券领取请联系邮箱：teemo.wang@enflame-tech.com，燧原科技将按需提供专属支持！
+为让开发者无后顾之忧，专注技术攻坚，燧原科技为所有报名本赛题的开发者提供每人200算力代金券专属福利，助力燧原科技GCU上的开发、调试与验证！ 算力券领取请联系邮箱：teemo.wang@enflame-tech.com + ext_paddle_oss@baidu.com，燧原科技将按需提供专属支持！
 > 平台地址：[GiteeAi 算力广场](https://ai.gitee.com/compute) \
 > 镜像选择: `vLLM / 0.8.0 / Python 3.10 / ef 1.5.0.604` 
 


### PR DESCRIPTION
## Summary
- 更新燧原科技打卡任务的"算力/环境支持"部分
- 将原来的"需在 Gitee AI 算力广场租赁燧原 S60 实例"替换为燧原科技提供的免费算力福利（每人200算力代金券）
- 算力券联系邮箱：teemo.wang@enflame-tech.com

## Test plan
- [x] 确认修改仅影响 `pfcc/paddle-hardware/燧原科技-基于FastDeploy跑通ERNIE-4.5-0.3B-Paddle 打卡任务.md` 的"算力/环境支持"段落
- [ ] Review rendered markdown on GitHub