### PR TITLE
add 67th pfcc meeting agenda

### DIFF
--- a/pfcc/meetings/2026/2026-04-27-meeting-agenda.md
+++ b/pfcc/meetings/2026/2026-04-27-meeting-agenda.md
@@ -1,0 +1,13 @@
+# Paddle Framework Contributor Club 六十七次会议议程
+
+- 本次会议时间：2026/4/27 19:00-21:00 (GMT+08:00) 中国标准时间 - 北京
+- 本次会议接入方式：【腾讯会议】
+  - 会议密码：无
+  - [点击链接入会](https://meeting.tencent.com/dm/Czm0Wp4rBJ86)，或添加至会议列表
+- 本次会议主席：[gravel-01](https://github.com/gravel-01)
+- 本次会议副主席：空缺
+
+## 会议议程
+分享环节：用 AI 把想法变成产品——从 0 到第一个用户
+1. 主题分享：我是怎么做出有人用的东西的  [@helloworldpxy](https://github.com/helloworldpxy)
+2. 主题分享："真有人靠独立开发赚钱了吗" [@GobinFan](https://github.com/GobinFan)


### PR DESCRIPTION
# Paddle Framework Contributor Club 六十七次会议议程

- 本次会议时间：2026/4/27 19:00-21:00 (GMT+08:00) 中国标准时间 - 北京
- 本次会议接入方式：【腾讯会议】
  - 会议密码：无
  - [点击链接入会](https://meeting.tencent.com/dm/Czm0Wp4rBJ86)，或添加至会议列表
- 本次会议主席：[gravel-01](https://github.com/gravel-01)
- 本次会议副主席：空缺

## 会议议程
分享环节：用 AI 把想法变成产品——从 0 到第一个用户
1. 主题分享：我是怎么做出有人用的东西的  [@helloworldpxy](https://github.com/helloworldpxy)
2. 主题分享："真有人靠独立开发赚钱了吗" [@GobinFan](https://github.com/GobinFan)
