### PR TITLE
add 68th pfcc meeting agenda

### DIFF
--- a/pfcc/meetings/2026/2026-05-21-meeting-agenda.md
+++ b/pfcc/meetings/2026/2026-05-21-meeting-agenda.md
@@ -1,0 +1,14 @@
+# Paddle Framework Contributor Club 六十八次会议议程
+
+- 本次会议时间：2026/05/21 19:00-21:00 (GMT+08:00) 中国标准时间 - 北京
+- 本次会议接入方式：【腾讯会议】
+  - 会议密码：无
+  - [点击链接入会](https://meeting.tencent.com/dm/2wnqgCogdF72)，或添加至会议列表
+- 本次会议主席：[Kozmosa](https://github.com/Kozmosa)
+- 本次会议副主席：空缺
+
+## 会议议程
+1. 新人介绍 @hoobnn，@Tryorish
+2. 多模态 Agentic RL 稳定高效训练实践 by Yangruipis&Aurelius@小红书
+3. 多模态 RL 训练探索 by wangguanzhong@飞桨
+4. Q&A


### PR DESCRIPTION
# Paddle Framework Contributor Club 六十八次会议议程

- 本次会议时间：2026/05/21 19:00-21:00 (GMT+08:00) 中国标准时间 - 北京
- 本次会议接入方式：【腾讯会议】
  - 会议密码：无
  - [点击链接入会](https://meeting.tencent.com/dm/2wnqgCogdF72)，或添加至会议列表
- 本次会议主席：[Kozmosa](https://github.com/Kozmosa)
- 本次会议副主席：空缺

## 会议议程
1. 新人介绍 @hoobnn，@Tryorish
2. 多模态 Agentic RL 稳定高效训练实践 by Yangruipis&Aurelius@小红书
3. 多模态 RL 训练探索 by wangguanzhong@飞桨
4. Q&A