### PR TITLE
Add PFCC 69th meeting minutes

### DIFF
--- a/pfcc/meetings/2026/2026-06-04-meeting-minutes.md
+++ b/pfcc/meetings/2026/2026-06-04-meeting-minutes.md
@@ -1,0 +1,17 @@
+# Paddle Framework Contributor Club 六十九次会议纪要
+
+- 本次会议时间：2026/06/04 20:00-20:40 (GMT+08:00) 中国标准时间 - 北京
+- 本次会议接入方式：【腾讯会议】
+  - 会议密码：无
+  - [点击链接入会](https://meeting.tencent.com/dm/9chHYSytnaIj)，或添加至会议列表
+- 本次会议主席：[onecatcn](https://github.com/onecatcn)
+- 本次会议副主席：空缺
+
+## 会议议程
+
+1. AI coding 时代的上下文应该如何治理？为什么 AI 写代码的速度越来越快，但项目却在悄悄脱离掌控？ @[ailijian](https://github.com/ailijian)（30 mins）
+   - 分享者：AI coding 重度用户，鲸汤科技联合创始人兼 CTO，百度飞桨开发者技术专家（PPDE）
+   - 分享内容围绕 AI coding 带来的工程效率提升与上下文漂移风险展开，讨论代码、契约、测试、文档和 AI 上下文失去同步后对项目可信度、可审查性和可持续演进带来的挑战。
+   - 结合真实场景介绍了如何通过 harbor-spec 为 Agentic Coding 建立可验证的治理闭环，帮助团队在使用 AI 提升开发效率的同时保持工程过程可控。
+2. Q&A（10 mins）
+   - 与会成员围绕 AI coding 实践中的上下文治理、规范沉淀和工程协作方式进行了交流。


### PR DESCRIPTION
## Summary
- Add minutes for the 69th PFCC meeting held on 2026/06/04.
- Summarize the AI coding context governance sharing and Q&A discussion.

## Test plan
- Not applicable; documentation-only update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)