### PR TITLE
[SWE-Paddle] Add SWE-Paddle task for Paddle PR 76259

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-76259/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-76259/README.md
@@ -1,0 +1,38 @@
+# PaddlePaddle__Paddle-76259
+
+This directory converts Paddle PR #76259 into a SWE-Paddle community task candidate.
+
+## Source
+
+| Field | Value |
+| --- | --- |
+| Repo | `PaddlePaddle/Paddle` |
+| PR | [76259](https://github.com/PaddlePaddle/Paddle/pull/76259) |
+| PR title | `[Bug fixes] Fix Windows UTF-8 path support for Paddle Inference model/json files` |
+| Base commit | `fcf3b100085b10efed4c1fb8880b1df1fd5241d6` |
+| Gold commit | `59670139385c14790ecd3c764d819eff63821978` |
+| Merged at | `2025-11-06` |
+| Track | `bug_fix` |
+| Task type | `windows_inference_path` |
+| Resource | Windows CPU / MSVC |
+
+## Summary
+
+Paddle Inference accepts model and configuration paths as UTF-8 strings. On Windows, existing files or directories whose path contains non-ASCII characters can be misclassified as missing when narrow filesystem APIs are used. This task asks the agent to preserve ordinary ASCII-path behavior while fixing UTF-8 non-ASCII path handling on Windows.
+
+## Files
+
+- `proposal.md`: candidate proposal for maintainer triage.
+- `instruction.md`: self-contained problem statement for the coding agent.
+- `environment/README.md`: environment notes for reproduction.
+- `solution/code.patch`: gold patch from the merged PR.
+- `tests/test.patch`: test patch exposing the target behavior.
+- `tests/test.sh`: minimal target test command.
+
+## Verification
+
+```bash
+bash tests/test.sh
+```
+
+Expected behavior: applying `tests/test.patch` to `base_commit` should fail on the UTF-8 Windows path behavior while preserving the ASCII-path guard. Applying both `tests/test.patch` and `solution/code.patch` should pass the target tests.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-76259/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-76259/environment/README.md
@@ -1,0 +1,64 @@
+# Environment Notes
+
+This candidate is a Windows-specific SWE-Paddle task for Paddle Inference path handling.
+
+## Expected Environment
+
+- Repository: `PaddlePaddle/Paddle`
+- Base commit: `fcf3b100085b10efed4c1fb8880b1df1fd5241d6`
+- Resource: Windows CPU
+- GPU required: no
+- Compiler: MSVC x64
+- Recommended generator: Ninja
+- Build path: Paddle source checkout at the base commit. This task targets a C++ Inference API helper, so a source build or equivalent compiled environment is required.
+
+Linux-only verification is insufficient because the target bug is in Windows filesystem path handling.
+
+## Run Order
+
+1. Check out `PaddlePaddle/Paddle` at the base commit.
+2. Apply `tests/test.patch`.
+3. Configure a Windows CPU build with the target-only switch enabled.
+4. Build the target C++ test.
+5. Run `bash tests/test.sh`; the UTF-8 path behavior should fail before the fix while the ASCII-path guard should pass.
+6. Apply `solution/code.patch`.
+7. Rebuild the target C++ test.
+8. Run `bash tests/test.sh` again; the target tests should pass after the gold patch.
+
+## Suggested Build Command
+
+```bash
+cmake -S . -B build   -G Ninja   -DCMAKE_BUILD_TYPE=Release   -DCMAKE_C_COMPILER=cl.exe   -DCMAKE_CXX_COMPILER=cl.exe   -DPADDLE_INFERENCE_UTF8_PATH_TEST_ONLY:BOOL=ON   -DWITH_TESTING:BOOL=ON   -DWITH_INFERENCE_API_TEST:BOOL=OFF   -DON_INFER:BOOL=ON
+```
+
+Build the target:
+
+```bash
+cmake --build build --target inference_api_path_test --parallel 2
+```
+
+Some Windows builds may require preparing third-party headers before the target build:
+
+```bash
+cmake --build build --target extern_dirent --parallel 1
+```
+
+## Minimal Test Command
+
+```bash
+bash tests/test.sh
+```
+
+By default, the test script runs both target CTest cases. A verifier may set `TEST_REGEX` to run P2P and F2P separately, for example:
+
+```bash
+TEST_REGEX='^inference_api_path_p2p_test$' bash tests/test.sh
+TEST_REGEX='^inference_api_utf8_path_f2p_test$' bash tests/test.sh
+```
+
+## Expected Results
+
+| State | P2P | F2P |
+| --- | --- | --- |
+| `base + tests/test.patch` | PASS | FAIL |
+| `base + tests/test.patch + solution/code.patch` | PASS | PASS |

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-76259/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-76259/instruction.md
@@ -1,0 +1,34 @@
+# 修复 Windows 下 Paddle Inference 的 UTF-8 路径识别问题
+
+## 详细描述
+
+Paddle Inference 的配置接口会接收模型文件、参数文件和配置文件路径。这些路径以字符串形式传入，并可能包含 UTF-8 编码的非 ASCII 字符，例如中文目录名。
+
+在 Windows 上，存在这样一种问题：文件或目录实际存在，但当路径中包含非 ASCII 字符时，路径校验逻辑可能错误地认为该文件或目录不存在。结果是用户无法在包含中文等非 ASCII 字符的目录下正常加载 Inference 模型或配置。
+
+## 复现方式
+
+在 Windows 环境中创建一个包含非 ASCII 字符的目录，并在其中创建一个普通文件。将该目录路径和文件路径以 UTF-8 字符串形式传给 Paddle Inference 的路径校验流程。
+
+修复前，ASCII 路径应继续保持原有行为，但 UTF-8 非 ASCII 路径可能无法被正确识别。
+
+## 验收说明
+
+- 已存在的 ASCII 文件和目录仍应被正确识别。
+- 缺失的 ASCII 文件仍应被正确识别为不存在。
+- Windows 上包含 UTF-8 非 ASCII 字符的已存在文件和目录应被正确识别。
+- 非 Windows 平台的既有行为不应被改变。
+- 修复应限定在路径处理语义内，不能通过删除校验、弱化断言、硬编码测试路径或把所有路径都视为存在来通过测试。
+
+## 技术要求
+
+- 熟悉 C++。
+- 了解 Windows 文件系统路径编码。
+- 了解 Paddle Inference 基础配置和路径校验流程。
+
+## Acceptance Criteria
+
+- The behavior described above should be fixed.
+- Existing valid behavior should remain unchanged.
+- Missing paths should still be rejected.
+- The solution should not bypass validation broadly or weaken the target tests.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-76259/solution/code.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-76259/solution/code.patch
@@ -1,0 +1,52 @@
+diff --git a/paddle/fluid/inference/api/helper.h b/paddle/fluid/inference/api/helper.h
+index 99b29f191810d1..df2ddcd7a8642c 100644
+--- a/paddle/fluid/inference/api/helper.h
++++ b/paddle/fluid/inference/api/helper.h
+@@ -15,7 +15,10 @@
+ #pragma once
+ #include <algorithm>
+ #include <fstream>
+-
++#ifdef _WIN32
++#include <codecvt>
++#include <windows.h>
++#endif
+ #include <iostream>
+ #if !defined(_WIN32)
+ #include <sys/stat.h>
+@@ -425,13 +428,26 @@ static void PrintTime(int batch_size,
+ }
+
+ static bool IsFileExists(const std::string &path) {
+-  std::ifstream file(path);
++#ifdef _WIN32
++  std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
++  std::wstring wpath = converter.from_bytes(path);
++  std::ifstream file(wpath, std::ios::binary);
++#else
++  std::ifstream file(path, std::ios::binary);
++#endif
+   bool exists = file.is_open();
+   file.close();
+   return exists;
+ }
+
+ static bool IsDirectory(const std::string &path) {
++#ifdef _WIN32
++  std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
++  std::wstring wpath = converter.from_bytes(path);
++  DWORD attr = GetFileAttributesW(wpath.c_str());
++  if (attr == INVALID_FILE_ATTRIBUTES) return false;
++  return (attr & FILE_ATTRIBUTE_DIRECTORY);
++#else
+   struct stat info;
+   if (stat(path.c_str(), &info) != 0) {
+     return false;
+@@ -439,6 +455,7 @@ static bool IsDirectory(const std::string &path) {
+     return true;
+   }
+   return false;
++#endif
+ }
+
+ void RegisterAllCustomOperator(bool use_pir);

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-76259/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-76259/tests/test.patch
@@ -1,0 +1,213 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2f5c0a2..0b785a1 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -41,6 +41,17 @@ endif()
+ 
+ project(paddle CXX C)
+ 
++if(PADDLE_INFERENCE_UTF8_PATH_TEST_ONLY)
++  set(CMAKE_DISABLE_FIND_PACKAGE_CUDA TRUE CACHE BOOL "" FORCE)
++  set(CUDA_FOUND OFF CACHE BOOL "" FORCE)
++  set(WITH_GPU OFF CACHE BOOL "Disable GPU for UTF-8 path verification" FORCE)
++  set(WITH_CRYPTO OFF CACHE BOOL "Disable crypto for UTF-8 path verification" FORCE)
++  set(WITH_PYTHON OFF CACHE BOOL "Disable Python for UTF-8 path verification" FORCE)
++  set(BUILD_WHL_PACKAGE OFF CACHE BOOL "Disable wheel package for UTF-8 path verification" FORCE)
++  set(WITH_NCCL OFF CACHE BOOL "Disable NCCL for UTF-8 path verification" FORCE)
++  set(WITH_DISTRIBUTE OFF CACHE BOOL "Disable distributed for UTF-8 path verification" FORCE)
++endif()
++
+ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+   if(WIN32)
+     # windows not support flag sanitize=address
+diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
+index 63a76c4..5ecac50 100644
+--- a/test/CMakeLists.txt
++++ b/test/CMakeLists.txt
+@@ -1,3 +1,8 @@
++if(WIN32 AND PADDLE_INFERENCE_UTF8_PATH_TEST_ONLY)
++  add_subdirectory(cpp)
++  return()
++endif()
++
+ remove_definitions(-DPADDLE_DLL_EXPORT)
+ set(CC_TESTS_DIR ${PADDLE_BINARY_DIR}/test/cpp CACHE INTERNAL "c++ tests directory")
+ set(PYTHON_TESTS_DIR ${PADDLE_BINARY_DIR}/test CACHE INTERNAL "python tests directory")
+diff --git a/test/cpp/CMakeLists.txt b/test/cpp/CMakeLists.txt
+index 65226ca..479580b 100644
+--- a/test/cpp/CMakeLists.txt
++++ b/test/cpp/CMakeLists.txt
+@@ -1,3 +1,8 @@
++if(WIN32 AND PADDLE_INFERENCE_UTF8_PATH_TEST_ONLY)
++  add_subdirectory(inference)
++  return()
++endif()
++
+ if(NOT WITH_CPP_TEST)
+   return()
+ endif()
+diff --git a/test/cpp/inference/CMakeLists.txt b/test/cpp/inference/CMakeLists.txt
+index 13b9d57..435b962 100644
+--- a/test/cpp/inference/CMakeLists.txt
++++ b/test/cpp/inference/CMakeLists.txt
+@@ -1,5 +1,10 @@
+ add_definitions(-DPADDLE_DLL_EXPORT)
+ 
++if(WIN32 AND PADDLE_INFERENCE_UTF8_PATH_TEST_ONLY)
++  add_subdirectory(api)
++  return()
++endif()
++
+ if(WITH_TESTING)
+   include(test.cmake) # some generic cmake function for inference
+   include(test_cases.cmake)
+diff --git a/test/cpp/inference/api/CMakeLists.txt b/test/cpp/inference/api/CMakeLists.txt
+index 4236f11..f558dae 100644
+--- a/test/cpp/inference/api/CMakeLists.txt
++++ b/test/cpp/inference/api/CMakeLists.txt
+@@ -3,6 +3,25 @@
+ # of build folder by 30G.
+ 
+ set(inference_api_tester_deps paddle_inference_api analysis_config)
++
++if(WIN32 AND PADDLE_INFERENCE_UTF8_PATH_TEST_ONLY)
++  cc_test_old(
++    inference_api_path_test
++    SRCS utf8_path_test.cc
++    DEPS ${inference_api_tester_deps} common)
++
++  add_test(
++    NAME inference_api_path_p2p_test
++    COMMAND $<TARGET_FILE:inference_api_path_test>
++            "--gtest_filter=InferencePath.P2P*")
++
++  add_test(
++    NAME inference_api_utf8_path_f2p_test
++    COMMAND $<TARGET_FILE:inference_api_path_test>
++            "--gtest_filter=InferencePath.F2P*")
++
++  return()
++endif()
+ 
+ if(NOT WIN32)
+   cc_test(
+diff --git a/test/cpp/inference/api/utf8_path_test.cc b/test/cpp/inference/api/utf8_path_test.cc
+new file mode 100644
+index 0000000..705d81e
+--- /dev/null
++++ b/test/cpp/inference/api/utf8_path_test.cc
+@@ -0,0 +1,116 @@
++/* Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
++
++Licensed under the Apache License, Version 2.0 (the "License");
++you may not use this file except in compliance with the License.
++You may obtain a copy of the License at
++
++http://www.apache.org/licenses/LICENSE-2.0
++
++Unless required by applicable law or agreed to in writing, software
++distributed under the License is distributed on an "AS IS" BASIS,
++WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++See the License for the specific language governing permissions and
++limitations under the License. */
++
++#include <windows.h>
++
++#include <string>
++
++#include "gtest/gtest.h"
++#include "paddle/fluid/inference/api/helper.h"
++
++namespace {
++
++std::string WideToUtf8(const std::wstring& value) {
++  if (value.empty()) {
++    return {};
++  }
++
++  int size = WideCharToMultiByte(CP_UTF8,
++                                 0,
++                                 value.data(),
++                                 static_cast<int>(value.size()),
++                                 nullptr,
++                                 0,
++                                 nullptr,
++                                 nullptr);
++  if (size <= 0) {
++    return {};
++  }
++
++  std::string result(size, '\0');
++  int converted = WideCharToMultiByte(CP_UTF8,
++                                      0,
++                                      value.data(),
++                                      static_cast<int>(value.size()),
++                                      &result[0],
++                                      size,
++                                      nullptr,
++                                      nullptr);
++  return converted == size ? result : std::string();
++}
++
++std::wstring TestPath(const wchar_t* name) {
++  wchar_t buffer[MAX_PATH];
++  DWORD len = GetCurrentDirectoryW(MAX_PATH, buffer);
++  EXPECT_GT(len, 0UL);
++  EXPECT_LT(len, static_cast<DWORD>(MAX_PATH));
++
++  std::wstring base(buffer, len);
++  if (!base.empty() && base.back() != L'\\') {
++    base += L"\\";
++  }
++  return base + name + std::to_wstring(GetCurrentProcessId());
++}
++
++void Cleanup(const std::wstring& dir, const std::wstring& file) {
++  DeleteFileW(file.c_str());
++  RemoveDirectoryW(dir.c_str());
++}
++
++void Touch(const std::wstring& file) {
++  HANDLE handle = CreateFileW(file.c_str(),
++                              GENERIC_WRITE,
++                              0,
++                              nullptr,
++                              CREATE_ALWAYS,
++                              FILE_ATTRIBUTE_NORMAL,
++                              nullptr);
++  ASSERT_NE(handle, INVALID_HANDLE_VALUE);
++  CloseHandle(handle);
++}
++
++}  // namespace
++
++TEST(InferencePath, P2PAsciiPathsKeepExistingBehavior) {
++  std::wstring dir = TestPath(L"paddle_ascii_");
++  std::wstring file = dir + L"\\inference.pdmodel";
++  std::wstring missing = dir + L"\\missing.pdmodel";
++
++  Cleanup(dir, file);
++  ASSERT_TRUE(CreateDirectoryW(dir.c_str(), nullptr));
++  Touch(file);
++
++  EXPECT_TRUE(paddle::inference::IsDirectory(WideToUtf8(dir)));
++  EXPECT_TRUE(paddle::inference::IsFileExists(WideToUtf8(file)));
++  EXPECT_FALSE(paddle::inference::IsDirectory(WideToUtf8(file)));
++  EXPECT_FALSE(paddle::inference::IsFileExists(WideToUtf8(missing)));
++
++  Cleanup(dir, file);
++}
++
++TEST(InferencePath, F2PUtf8PathsAreRecognizedOnWindows) {
++  std::wstring dir = TestPath(L"paddle_utf8_\u6A21\u578B\u8DEF\u5F84_");
++  std::wstring file = dir + L"\\inference.pdmodel";
++
++  Cleanup(dir, file);
++  ASSERT_TRUE(CreateDirectoryW(dir.c_str(), nullptr));
++  Touch(file);
++
++  EXPECT_TRUE(paddle::inference::IsDirectory(WideToUtf8(dir)));
++  EXPECT_TRUE(paddle::inference::IsFileExists(WideToUtf8(file)));
++
++  Cleanup(dir, file);
++}

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-76259/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-76259/tests/test.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BUILD_DIR="${BUILD_DIR:-build}"
+BUILD_CONFIG="${BUILD_CONFIG:-Release}"
+TEST_REGEX="${TEST_REGEX:-^inference_api_(path_p2p|utf8_path_f2p)_test$}"
+
+if [[ -d "${BUILD_DIR}" ]]; then
+  while IFS= read -r dll_dir; do
+    case ":${PATH}:" in *":${dll_dir}:"*) ;; *) export PATH="${dll_dir}:${PATH}" ;; esac
+  done < <(find "${BUILD_DIR}" -type f -iname '*.dll' -exec dirname {} \; 2>/dev/null | sort -u)
+fi
+
+ctest --test-dir "${BUILD_DIR}" -C "${BUILD_CONFIG}" -R "${TEST_REGEX}" --output-on-failure


### PR DESCRIPTION
### 关联

- SWE-Paddle 共建 issue: PaddlePaddle/Paddle#79447
- 来源 PR: PaddlePaddle/Paddle#76259

### 说明

补齐 `PaddlePaddle__Paddle-76259` 完整任务包：

`instruction.md` / `solution/code.patch` / `tests/test.patch` / `tests/test.sh` / `environment/README.md` / `README.md` 

- 任务类型: bug_fix（Windows Paddle Inference UTF-8 / 非 ASCII 路径识别）
- 平台范围: Windows；该问题属于 Inference 文件系统路径处理，不是 CPU kernel 问题
- 验证资源: windows_cpu 足够复现与验证，因为测试只依赖 C++ Inference path helper 行为
- 需 source build（C++ Inference 测试目标），非纯 wheel 测试
- `instruction.md` 已做去泄露处理：不包含源 PR 链接、具体修复文件、根因诊断或实现路径
- `tests/test.sh` 保持最小职责：只运行目标 CTest

### 本地验证

已在 Windows + MSVC + Ninja 环境下完成本地 F2P / P2P 验证。

| 状态 | P2P | F2P |
| --- | --- | --- |
| `base + tests/test.patch` | PASS | FAIL as expected |
| `base + tests/test.patch + solution/code.patch` | PASS | PASS |

验证说明：

- P2P: `inference_api_path_p2p_test`，确认 ASCII 路径下已有文件/目录识别行为保持不变
- F2P: `inference_api_utf8_path_f2p_test`，确认 Windows UTF-8 / 非 ASCII 路径在 base commit 上失败，应用 gold patch 后通过
- base commit: `fcf3b100085b10efed4c1fb8880b1df1fd5241d6`

@sunzhongkai588 