### PR TITLE
[SWE-Paddle] Add proposal for PaddlePaddle__Paddle-78301 

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78301/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78301/proposal.md
@@ -1,0 +1,79 @@
+# 任务提案：PaddlePaddle__Paddle-78301
+
+## 1. 来源信息
+
+- Instance ID：`PaddlePaddle__Paddle-78301`
+- PR 链接：https://github.com/PaddlePaddle/Paddle/pull/78301
+- PR 标题：`[API Compatibility] align paddle.nn.Layer.to/paddle.Tensor.to -part`
+- 后续相关 PR（仅作背景，不纳入本任务的 gold patch 和验收范围）：
+  - https://github.com/PaddlePaddle/Paddle/pull/78593：`[API Compatibility] Fix api nn.Layer.to and Tensor.to`
+  - https://github.com/PaddlePaddle/Paddle/pull/78651：`[API Compatibility] Simplify the code for Module.to`
+  - https://github.com/PaddlePaddle/Paddle/pull/78839：`[API Compatibility] resolve type assertion for nn.Module.to`
+- `base_commit`：`fd041ffe2d941d7219090cb12f6ffb10860dc851`（squash 合入 commit `d6e41b70154ba52525884afdc15c2a9d763a2cae` 的父提交）
+- merged 时间：`2026-04-03T07:08:36Z`
+- 你的身份：原 PR 作者（GitHub @Manfredss）
+- 后续联系人：GitHub @Manfredss
+
+## 2. 问题一句话
+
+`paddle.nn.Layer.to` 与 `paddle.Tensor.to` 原有的参数顺序和调用重载不完整，无法覆盖常见的 dtype、device、参考 Tensor、阻塞选项和 `copy` 参数调用形式。该 PR 统一两个 API 的参数解析入口，补齐位置参数和关键字参数组合，并保持 Layer 原地转换及返回自身的行为。
+
+## 3. 为什么适合作为 SWE-Paddle 样本
+
+- **真实性**：这是已合入的 Paddle API Compatibility 真实研发 PR，目标描述为对齐 `paddle.nn.Layer.to` 与 `paddle.Tensor.to` 的参数顺序，后续还产生了独立的修正 PR。当前样本只复现 #78301 合入时的真实改动和测试，不把后续修正混入 gold patch。
+- **代表性**：覆盖 Paddle Python API 兼容性中的典型问题，包括多重调用签名、位置参数与关键字参数解析、dtype/device 识别、`blocking` 与 `non_blocking` 冲突，以及 `copy` 参数处理。
+- **边界清楚**：目标仅限 #78301 合入版本中两个公开 API 的参数解析和 Layer 转换行为；要求支持 dtype、device、参考 Tensor 的位置或关键字调用，支持无参数调用，正确处理错误输入，并保持 Layer 返回自身和子层递归转换。后续 PR #78593、#78651、#78839 的额外行为不属于本任务。
+- **非平凡性**：这不是简单修改函数签名。实现需要让 Tensor 和 Layer 共用一套解析规则，区分 dtype、device 和 Tensor 参数，处理可选位置参数、关键字参数、`copy` 及阻塞选项，并保持现有递归转换逻辑和对象身份语义。
+
+## 4. 任务类型和标签
+
+- 任务类型：`feature_enhancement`
+- 执行后端：`cpu`
+- 设备范围：`cpu_only`
+- 模块标签：`[python_api, api_compatibility, tensor, nn_layer, dtype, device, argument_parsing, legacy_test]`
+
+## 5. 验证思路
+
+- 目标测试文件：
+  - `test/legacy_test/test_api_compatibility_part3.py`
+  - `test/legacy_test/test_base_layer.py`
+- 目标测试类：`TestLayerAndTensorToAPI`；P2P 护栏为 `TestLayerTo::test_main`
+- 目标测试命令：
+
+  ```bash
+  python -m pytest \
+    test/legacy_test/test_api_compatibility_part3.py::TestLayerAndTensorToAPI \
+    test/legacy_test/test_base_layer.py::TestLayerTo::test_main \
+    -q
+  ```
+
+- 关键 F2P 场景：
+  - `Layer.to` 和 `Tensor.to` 接受 dtype、device、参考 Tensor 的位置参数，以及对应的关键字参数组合。
+  - 支持 `blocking`、`non_blocking` 和 `copy` 的合法调用形式；测试补丁应至少增加一个 `Tensor.to(dtype='float64', copy=True)` 或等价的 `copy` smoke case。新增 benchmark 测试可以补充原 PR 未覆盖的边界，但不能引入 #78593 之后的语义。
+  - 同时设置互相冲突的阻塞参数时抛出 `TypeError`；无参数调用保持合法；参数过多或未知关键字抛出 `TypeError`；无法识别的首个位置参数抛出 `ValueError`。
+  - `Layer.to` 返回原对象，并对子层执行一致的转换。
+  - 按 #78301 合入时的行为，使用 dtype 转换 Layer 时，测试中的整数 buffer 也会转换到目标 dtype。后续 #78839 对这一行为的修正不纳入本任务。
+- 修复前预期：在 `base_commit` 上应用围绕 #78301 目标行为构造的 `tests/test.patch` 后，新增兼容性用例应出现失败或错误。例如 dtype 作为首个位置参数时会被错误解释为 device，部分位置参数组合、无参数调用或阻塞参数冲突无法按目标行为执行，且新增的 Layer/Tensor 统一调用场景不能全部通过。
+- 修复后预期：继续应用仅来自 #78301 非测试文件的 `solution/code.patch` 后，`TestLayerAndTensorToAPI` 及指定的既有 Layer 回归测试全部通过，并满足 #78301 合入时的参数解析和转换行为。
+- P2P 候选：`test/legacy_test/test_base_layer.py::TestLayerTo::test_main` 在 #78301 中未被修改，可作为 Layer.to 既有行为回归护栏；完整任务包阶段还应从同模块中挑选未被 `test.patch` 修改、且在 base 和修复后都通过的存量用例。
+
+## 6. 环境与资源
+
+- 是否能提供 Docker：无；proposal 通过后可依据维护组 verifier 基础环境补充
+- Dockerfile 或镜像地址：暂无
+- Paddle 来源：`PaddlePaddle/Paddle` source checkout at `base_commit`，优先使用源码构建；本任务不使用未经确认的历史 wheel
+- 如果使用 wheel，请填写 wheel URL、Python 版本和平台标签：不使用；暂无与该 `base_commit` 对应的固定 wheel URL
+- OS / Python / CUDA / cuDNN / 其他关键依赖：建议 Linux x86_64、Paddle 该 commit 支持的 Python 3 版本；目标测试为 CPU 测试，不依赖 CUDA/cuDNN；测试框架为 `pytest`
+- 已验证构建环境：原 PR 在 Windows 主机上修改、构建并测试，环境为 Win11 Home、Python 3.12、CMake 3.18.6、VS 2022、CUDA 12.9、cuDNN 9.12.0
+- 硬件：目标 verifier 使用 CPU 即可；原 PR 验证机器为 9800X3D + RTX 5070Ti，GPU 不是本任务要求
+- patch 类型：纯 Python，不含 C++、CUDA、kernel 或 infermeta 编译改动
+- 最小测试命令：`python -m pytest test/legacy_test/test_api_compatibility_part3.py::TestLayerAndTensorToAPI -q`
+- 是否有 oracle 日志：无；后续由 SWE-Paddle Run/Test/Fix verifier 记录
+
+## 7. 风险自查
+
+- 泄露风险：正式 `instruction.md` 只描述可观察的 API 调用形式、异常类型、返回对象和转换结果，不应给出共享解析函数、具体修改文件或实现分支等答案路径。
+- 环境风险：任务对应历史 commit，暂无固定 wheel 或 Docker 镜像。虽然 patch 只涉及 Python，但运行 Paddle 测试仍需要与 `base_commit` 匹配的已编译核心，必要时需 source build。
+- flaky 风险：目标用例主要检查 dtype、device、异常类型、对象身份和参数解析，不依赖随机数、数值精度统计或多卡同步，预计无明显 flaky 风险。
+- 拆分风险：本任务严格对应单个已合入 PR #78301。#78593、#78651、#78839 是同一 API 方向上的后续 PR，但不纳入本实例，避免把多个 merge commit 的改动人工合成为不对应单一 PR 的 gold patch。若社区希望评测完整后续语义，应分别为后续 PR 建立 proposal，并分别确认其 F2P 测试和 base commit。
+- 其他不确定点：后续 PR 标题使用 `Module.to`，Paddle 对外公开类名为 `paddle.nn.Layer`；本提案和测试统一使用实际公开 API 名称。完整任务包阶段需在基线 checkout 上验证 `code.patch` 与 `test.patch` 的应用顺序，并确认 F2P/P2P 的 Run/Test/Fix 结果。


### PR DESCRIPTION
## Summary                             

- Add the SWE-Paddle proposal for PaddlePaddle/Paddle#78301.
- Define the task scope, F2P/P2P verification plan, environment, and risks.
- Keep follow-up PRs as background while limiting the gold patch to #78301.