### PR TITLE
[SWE-Paddle] Add SWE-Paddle task for Paddle PR 79369

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79369/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79369/README.md
@@ -1,0 +1,44 @@
+# PaddlePaddle__Paddle-79369
+
+This directory converts Paddle PR #79369 into a SWE-Paddle community task candidate.
+
+## Source
+
+| Field | Value |
+| --- | --- |
+| Repo | `PaddlePaddle/Paddle` |
+| PR | [79369](https://github.com/PaddlePaddle/Paddle/pull/79369) |
+| PR title | `【BugFix】Fix bug of check_memory_usage` |
+| Base commit | `199073cd2021dd05efd8b0fe79797b838f68df41` |
+| Gold commit | `adcaaa8f06fd435bd99452f2205f6ef49a53d19f` |
+| Merged at | `2026-06-25` |
+| Task type | `bug_fix` |
+| Resource | CPU |
+
+## Summary
+
+完善 Fleet `check_memory_usage` 在 CPU 运行环境中的内存日志行为。
+
+## Why This Is A Good Candidate
+
+- It comes from a merged Paddle bug-fix PR.
+- The production change is isolated to one Python utility function.
+- The target behavior is deterministic and covered with mocked device and system interfaces.
+- It requires no GPU, distributed launch, external service, or C++ rebuild.
+
+## Files
+
+- `proposal.md`: candidate proposal for maintainer triage.
+- `instruction.md`: self-contained problem statement for the coding agent.
+- `solution/code.patch`: gold patch from the merged PR.
+- `tests/test.patch`: regression tests exposing the target behavior.
+- `tests/test.sh`: minimal target test command.
+- `environment/README.md`: environment notes for reproduction.
+
+## Verification
+
+```bash
+bash tests/test.sh
+```
+
+Expected behavior: after applying `tests/test.patch` to the base commit, the P2P test passes and the F2P test fails. After also applying `solution/code.patch`, both tests pass.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79369/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79369/environment/README.md
@@ -1,0 +1,28 @@
+# Environment Notes
+
+## Expected Environment
+
+- Repository: `PaddlePaddle/Paddle`
+- Base commit: `199073cd2021dd05efd8b0fe79797b838f68df41`
+- Resource: CPU
+- GPU required: no
+- Distributed multi-process execution required: no
+- External model or network service: no
+- Test framework: `pytest`
+- Build requirement: Python-only patch; no C++ rebuild is required.
+
+## Run Order
+
+1. Check out Paddle at the base commit.
+2. Apply `tests/test.patch`.
+3. Run `bash tests/test.sh`; the P2P test should pass and the F2P test should fail.
+4. Apply `solution/code.patch` and ensure the patched Python source is loaded.
+5. Run `bash tests/test.sh` again; both tests should pass.
+
+## Minimal Test Command
+
+```bash
+bash tests/test.sh
+```
+
+The verifier is responsible for providing a compatible Paddle runtime and loading the checkout's patched Python source.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79369/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79369/instruction.md
@@ -1,0 +1,24 @@
+# 完善 Fleet 内存使用日志
+
+## 详细描述
+
+完善 Fleet `check_memory_usage` 在 CPU 运行环境中的内存信息采集和日志输出，确保不同设备能力下能够稳定执行。
+
+## 验收说明
+
+- 保留已有的 GPU、pinned memory 和系统内存日志行为
+- CPU 运行环境下的内存日志流程应正常完成
+- 系统内存信息应继续被正确采集和记录
+- 在对应单测中覆盖目标场景和已有日志行为
+
+## 技术要求
+
+- 熟悉 Python 和单元测试
+- 了解 Paddle 设备 API 与 Fleet 工具模块
+- 了解 mock 在外部接口隔离中的使用
+
+## Acceptance Criteria
+
+- The behavior described above should be fixed.
+- Existing valid behavior should remain unchanged.
+- Do not satisfy the task by deleting tests, weakening assertions, or bypassing validation broadly.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79369/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79369/proposal.md
@@ -1,0 +1,50 @@
+# Task Proposal: PaddlePaddle__Paddle-79369
+
+## 1. 来源信息
+
+- Instance ID：`PaddlePaddle__Paddle-79369`
+- PR 链接：https://github.com/PaddlePaddle/Paddle/pull/79369
+- PR 标题：`【BugFix】Fix bug of check_memory_usage`
+- `base_commit`：`199073cd2021dd05efd8b0fe79797b838f68df41`
+- 任务类型：`bug_fix`
+- 后续联系人：TBD
+
+## 2. 问题一句话
+
+完善 Fleet `check_memory_usage` 在 CPU 运行环境中的内存日志行为。
+
+## 3. 为什么适合作为 SWE-Paddle 样本
+
+- **真实性**：来自 Paddle 主仓已合入的真实 bug-fix。
+- **边界清楚**：生产代码修改集中在一个 Python 工具函数。
+- **行为明确**：修复前目标场景稳定失败，修复后正常完成。
+- **验证成本低**：不依赖 GPU、分布式多进程、外部服务或 C++ 编译。
+
+## 4. 任务类型和标签
+
+- 任务类型：`bug_fix`
+- 执行后端：`cpu`
+- 设备范围：`cpu_only`
+- 模块标签：`[distributed, fleet, logging, memory, python]`
+
+## 5. 验证思路
+
+- 目标命令：`bash tests/test.sh`
+- 目标文件：`test/legacy_test/test_check_memory_usage.py`
+- P2P：验证已有设备和系统内存日志流程保持可用。
+- F2P：验证 CPU 运行环境下的目标日志场景能够正常完成。
+- 修复前：P2P 通过，F2P 失败。
+- 修复后：P2P 与 F2P 均通过。
+
+## 6. 环境与资源
+
+- 资源需求：CPU
+- GPU、分布式多进程、网络服务和外部模型：不需要
+- patch 类型：Python 工具函数修改 + Python legacy test
+- 构建要求：Python-only patch，无需重新编译 C++ core
+
+## 7. 风险自查
+
+- 泄露风险：任务说明只描述目标行为和验收标准，不暴露具体修改位置。
+- 环境风险：设备接口和系统命令由测试 mock 隔离。
+- flaky 风险：断言只依赖确定性的 mock 调用和日志内容。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79369/solution/code.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79369/solution/code.patch
@@ -1,0 +1,32 @@
+diff --git a/python/paddle/distributed/fleet/utils/log_util.py b/python/paddle/distributed/fleet/utils/log_util.py
+index c83797c365..ffe1a6864d 100644
+--- a/python/paddle/distributed/fleet/utils/log_util.py
++++ b/python/paddle/distributed/fleet/utils/log_util.py
+@@ -161,27 +161,6 @@ def check_memory_usage(msg=""):
+             mem_msg += f"\n{key}: {mem_dict[key]}GB"
+         logger.info(mem_msg)
+ 
+-    if hasattr(paddle.device, 'cpu') and hasattr(
+-        paddle.device.cpu, 'max_memory_allocated'
+-    ):
+-        mem_dict = {}
+-        mem_dict['max_memory_allocated_size'] = (
+-            paddle.device.cpu.max_memory_allocated() / GB
+-        )
+-        mem_dict['max_memory_reserved_size'] = (
+-            paddle.device.cpu.max_memory_reserved() / GB
+-        )
+-        mem_dict['memory_allocated_size'] = (
+-            paddle.device.cpu.memory_allocated() / GB
+-        )
+-        mem_dict['memory_reserved_size'] = (
+-            paddle.device.cpu.memory_reserved() / GB
+-        )
+-        mem_msg = f"checking cpu memory usage {msg}:"
+-        for key in mem_dict:
+-            mem_msg += f"\n{key}: {mem_dict[key]}GB"
+-        logger.info(mem_msg)
+-
+     # Execute the command and get the output
+     result = subprocess.run(["free", "-h"], capture_output=True, text=True)
+     lines = result.stdout.strip().split('\n')

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79369/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79369/tests/test.patch
@@ -1,0 +1,104 @@
+diff --git a/test/legacy_test/test_check_memory_usage.py b/test/legacy_test/test_check_memory_usage.py
+new file mode 100644
+index 0000000..9a50200
+--- /dev/null
++++ b/test/legacy_test/test_check_memory_usage.py
+@@ -0,0 +1,98 @@
++# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++
++import subprocess
++import unittest
++from contextlib import ExitStack
++from types import SimpleNamespace
++from unittest.mock import Mock, patch
++
++from paddle.distributed.fleet.utils import log_util
++
++
++FREE_OUTPUT = """\
++              total        used        free      shared  buff/cache   available
++Mem:           16Gi       4Gi       8Gi       0Gi       4Gi        12Gi
++Swap:           2Gi       0Gi       2Gi
++"""
++
++
++class TestCheckMemoryUsage(unittest.TestCase):
++    def _runtime_patches(self, cpu_device):
++        stack = ExitStack()
++        cuda = log_util.paddle.device.cuda
++        for name in (
++            'max_memory_allocated',
++            'max_memory_reserved',
++            'memory_allocated',
++            'memory_reserved',
++            'max_pinned_memory_allocated',
++            'max_pinned_memory_reserved',
++            'pinned_memory_allocated',
++            'pinned_memory_reserved',
++        ):
++            stack.enter_context(
++                patch.object(cuda, name, return_value=0, create=True)
++            )
++
++        stack.enter_context(
++            patch.object(log_util.paddle.device, 'cpu', cpu_device)
++        )
++        stack.enter_context(
++            patch.object(
++                log_util.subprocess,
++                'run',
++                return_value=subprocess.CompletedProcess(
++                    args=['free', '-h'],
++                    returncode=0,
++                    stdout=FREE_OUTPUT,
++                    stderr='',
++                ),
++            )
++        )
++        return stack
++
++    def test_existing_memory_logging(self):
++        with self._runtime_patches(SimpleNamespace()), patch.object(
++            log_util.logger, 'info'
++        ) as info:
++            log_util.check_memory_usage('unit-test')
++
++        messages = [str(call.args[0]) for call in info.call_args_list]
++        self.assertTrue(
++            any('checking gpu memory usage unit-test' in msg for msg in messages)
++        )
++        self.assertTrue(
++            any('checking CPU memory usage: unit-test' in msg for msg in messages)
++        )
++
++    def test_unsupported_cpu_allocator_api(self):
++        unsupported = Mock(side_effect=RuntimeError('unsupported CPU memory API'))
++        cpu_device = SimpleNamespace(
++            max_memory_allocated=unsupported,
++            max_memory_reserved=unsupported,
++            memory_allocated=unsupported,
++            memory_reserved=unsupported,
++        )
++
++        with self._runtime_patches(cpu_device), patch.object(
++            log_util.logger, 'info'
++        ):
++            log_util.check_memory_usage('unit-test')
++
++        unsupported.assert_not_called()
++
++
++if __name__ == '__main__':
++    unittest.main()

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79369/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79369/tests/test.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python -m pytest -q \
+  test/legacy_test/test_check_memory_usage.py::TestCheckMemoryUsage::test_existing_memory_logging \
+  test/legacy_test/test_check_memory_usage.py::TestCheckMemoryUsage::test_unsupported_cpu_allocator_api


### PR DESCRIPTION
## 关联

- SWE-Paddle 共建 issue: https://github.com/PaddlePaddle/Paddle/issues/79447
- 来源 PR: https://github.com/PaddlePaddle/Paddle/pull/79369

## 说明

- 提交 `swe-paddle/tasks/PaddlePaddle__Paddle-79369/proposal.md`
- 新增 SWE-Paddle 任务 `PaddlePaddle__Paddle-79369`。

该任务覆盖 Fleet `check_memory_usage` 在 CPU 运行环境中的内存日志行为。任务为 Python-only，可在 CPU 环境验证，不依赖 GPU、分布式多进程或外部服务。

## 验证结果

| 状态 | P2P | F2P |
| --- | --- | --- |
| Base + `tests/test.patch` | PASS | FAIL，符合预期 |
| Base + test patch + `solution/code.patch` | PASS | PASS |

#### F2P：修复前

```text
F                                                                        [100%]
================================== FAILURES ===================================
___________ TestCheckMemoryUsage.test_unsupported_cpu_allocator_api ___________
>           log_util.check_memory_usage('unit-test')
E               RuntimeError: unsupported CPU memory API
=========================== short test summary info ===========================
FAILED test_check_memory_usage.py::TestCheckMemoryUsage::test_unsupported_cpu_allocator_api
1 failed in 1.29s
```

#### P2P

```text
.                                                                        [100%]
1 passed in 1.01s
Solution P2P exit code: 0
```

#### F2P：应用 solution 后

```text
.                                                                        [100%]
1 passed in 0.91s
Solution F2P exit code: 0
```

#### Solution 组合测试

```text
..                                                                       [100%]
2 passed in 0.95s
Solution combined test exit code: 0
```

@sunzhongkai588 