### PR TITLE
[SWE-Paddle] Add task PaddlePaddle__Paddle-75274

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-75274/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-75274/README.md
@@ -1,0 +1,53 @@
+# PaddlePaddle__Paddle-75274
+
+This directory converts Paddle PR #75274 into a SWE-Paddle task candidate.
+
+## Source
+
+| Field | Value |
+| --- | --- |
+| Repository | `PaddlePaddle/Paddle` |
+| Upstream PR | [#75274](https://github.com/PaddlePaddle/Paddle/pull/75274) |
+| PR title | `【UnitTestFix No.10】fix test_normal.py` |
+| Base commit | `5d1846ae16a8cecad8545b83d53a56e1a0eebe73` |
+| Gold commit | `834096be299fe1a032989a98a98572900a760a60` |
+| Merged at | `2025-09-22` |
+| Task type | `bug_fix` |
+| Subtype | `unit_test_maintenance` |
+| Resource | CPU |
+| Target scope | One Python test file |
+
+## Summary
+
+修复 `normal` 算子单元测试对全局静态图/动态图状态的隐式依赖，使静态测试路径在不同执行顺序下都能正确构图和运行。
+
+## Why This Is A Good SWE-Paddle Candidate
+
+- The task is derived from a real merged bug-fix PR.
+- The broken artifact is the unit test implementation itself, so the gold patch legitimately modifies a test file.
+- The production scope is limited to one Python test module.
+- The verifier is independent of the repaired file and checks observable execution behavior.
+- Base failures reproduce the reported graph-mode errors instead of import, path, GPU, or network failures.
+- The task is deterministic and CPU-only.
+
+## Files
+
+- `proposal.md`: candidate rationale and validation plan.
+- `instruction.md`: self-contained issue statement.
+- `environment/README.md`: runtime and reproduction notes.
+- `solution/code.patch`: exact upstream test-maintenance change.
+- `tests/test.patch`: independent benchmark verifier.
+- `tests/test.sh`: minimal test command.
+
+## Validation Matrix
+
+| Revision state | Dygraph P2P | Scalar static F2P | Tensor static F2P |
+| --- | ---: | ---: | ---: |
+| Base + `tests/test.patch` | PASS | FAIL | FAIL |
+| Base + test patch + `solution/code.patch` | PASS | PASS | PASS |
+
+## Run
+
+```bash
+bash tests/test.sh
+```

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-75274/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-75274/environment/README.md
@@ -1,0 +1,38 @@
+# Environment Notes
+
+## Expected Environment
+
+- Repository: `PaddlePaddle/Paddle`
+- Base commit: `5d1846ae16a8cecad8545b83d53a56e1a0eebe73`
+- Gold commit: `834096be299fe1a032989a98a98572900a760a60`
+- Resource: CPU
+- Python dependencies: PaddlePaddle, NumPy, pytest
+- Paddle rebuild required: no
+
+The repaired artifact is `test/legacy_test/test_normal.py`. The independent verifier imports that module with a CPU-only `op_test` shim and invokes selected helper methods with `repeat_num = 2`. This preserves the graph-mode behavior under test while avoiding the original long-running statistical loop.
+
+## Run Order
+
+1. Check out the Base commit.
+2. Restore the exact Base blob for `test_normal.py`.
+3. Apply `tests/test.patch`.
+4. Run the P2P test; the existing dygraph path should pass.
+5. Run the two F2P tests; both static paths should fail on Base.
+6. Apply `solution/code.patch`.
+7. Verify the patched target blob matches the Gold commit.
+8. Run `bash tests/test.sh`; all verifier tests should pass.
+
+## Minimal Command
+
+```bash
+bash tests/test.sh
+```
+
+## Expected Matrix
+
+| State | P2P | Scalar F2P | Tensor F2P | Full test script |
+| --- | ---: | ---: | ---: | ---: |
+| Base + tests | PASS | FAIL | FAIL | FAIL |
+| Base + tests + solution | PASS | PASS | PASS | PASS |
+
+No GPU, distributed runtime, external service, or additional dataset is required.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-75274/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-75274/instruction.md
@@ -1,0 +1,29 @@
+# 修复 normal 单元测试的执行模式依赖
+
+## 详细描述
+
+`normal` 算子的部分单元测试依赖进程当前的静态图或动态图状态。当这些测试以不同顺序运行，或在其他测试改变全局执行模式后单独调用时，静态测试路径可能在错误的模式下创建输入和输出，进而出现构图、数据输入或执行器取值错误。 需要修复该测试实现，使静态和动态图测试路径能够独立运行，不依赖调用前遗留的全局模式状态。
+
+## 验收说明
+
+- 静态测试路径在调用前处于动态图模式时仍应能够正确构图和执行
+- 标量参数和 Tensor 参数场景都应得到覆盖
+- 静态测试结束后不得破坏后续动态图测试
+- 现有动态图测试行为应保持不变
+- 实数和复数测试结构应保持一致的模式隔离能力
+- 不得通过删除核心用例、弱化数值断言或跳过测试来规避失败
+
+## 技术要求
+
+- 熟悉 Paddle 静态图和动态图执行模式
+- 了解 `Program`、`program_guard`、`Executor` 和静态输入
+- 了解 Python 单元测试中的全局状态隔离
+- 了解 Paddle 单元测试开发流程
+
+## Acceptance Criteria
+
+- Static test helpers do not depend on the caller's current graph mode.
+- Scalar and tensor-parameter cases execute successfully.
+- Existing dygraph behavior remains valid.
+- Test ordering no longer determines whether the affected cases pass.
+- The fix does not remove or weaken the substantive normal-distribution checks.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-75274/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-75274/instruction.md
@@ -2,7 +2,7 @@
 
 ## 详细描述
 
-`normal` 算子的部分单元测试依赖进程当前的静态图或动态图状态。当这些测试以不同顺序运行，或在其他测试改变全局执行模式后单独调用时，静态测试路径可能在错误的模式下创建输入和输出，进而出现构图、数据输入或执行器取值错误。 需要修复该测试实现，使静态和动态图测试路径能够独立运行，不依赖调用前遗留的全局模式状态。
+`normal` 算子的部分单元测试依赖调用前遗留的全局 graph mode，导致测试结果受执行顺序影响。 本 issue 中，**graph mode isolation** 是指静态图和动态图测试路径应显式进入各自所需的执行模式，并在结束后恢复调用前的模式状态。`program_guard` 仅用于切换当前的 `main Program` 和 `startup Program`，不能替代 `paddle.enable_static()` 或 `paddle.disable_static()` 完成 graph mode 切换。 需要修复相关测试，使 scalar 参数、Tensor 参数以及 real 和 complex dtype 场景均可独立运行，不依赖其他测试遗留的全局状态。
 
 ## 验收说明
 

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-75274/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-75274/proposal.md
@@ -1,0 +1,62 @@
+# Task Proposal: PaddlePaddle__Paddle-75274
+
+## 1. 来源信息
+
+- Instance ID：`PaddlePaddle__Paddle-75274`
+- PR 链接：https://github.com/PaddlePaddle/Paddle/pull/75274
+- PR 标题：`【UnitTestFix No.10】fix test_normal.py`
+- `base_commit`：`5d1846ae16a8cecad8545b83d53a56e1a0eebe73`
+- merged 时间：`2025-09-22`
+- 你的身份：原 PR 作者
+- 后续联系人：@Echo-Nie
+
+## 2. 问题一句话
+
+修复 `normal` 单元测试对全局静态图/动态图状态的隐式依赖，避免测试顺序变化后在错误模式下构图或创建静态输入。
+
+## 3. 为什么适合作为 SWE-Paddle 样本
+
+- **真实性**：来自已合入的 Paddle bug-fix PR。
+- **目标明确**：本任务修复的工程对象就是单元测试实现，gold patch 修改测试文件符合原始 PR 目标。
+- **范围可控**：上游仅修改 `test/legacy_test/test_normal.py` 一个文件。
+- **独立判分**：`tests/test.patch` 新增独立 verifier，不覆盖 gold patch 的修改区域。
+- **行为验证**：verifier 实际执行目标测试类的静态和动态图路径，不做源码字符串匹配。
+- **确定性**：Base F2P 由执行模式错误触发；不依赖 GPU、网络、随机统计阈值或外部数据。
+- **回归保护**：P2P 验证未修改的动态图路径继续工作。
+
+## 4. 任务类型和标签
+
+- 任务类型：`bug_fix`
+- 子类型：`unit_test_maintenance`
+- 执行后端：`cpu`
+- 模块标签：`[normal, unittest, static_graph, dygraph, test_isolation]`
+
+## 5. 验证设计
+
+目标命令：
+
+```bash
+bash tests/test.sh
+```
+
+验证项：
+
+1. **P2P**：缩短采样次数后执行既有动态图辅助路径，确认输出形状正确。
+2. **F2P - scalar**：从动态图模式调用标量参数的静态辅助路径。
+3. **F2P - tensor**：从动态图模式调用 Tensor 参数的静态辅助路径。
+4. **Solution**：应用 gold patch 后重复上述验证，并检查目标文件 blob 与 Gold commit 完全一致。
+
+## 6. 环境与资源
+
+- 资源需求：CPU
+- Python 依赖：PaddlePaddle、NumPy、pytest
+- Paddle 重新编译：不需要
+- GPU、分布式运行、网络服务和数据集：不需要
+
+## 7. 风险自查
+
+- **答案泄露**：题面描述模式隔离要求，但不指定具体 API 调用位置、代码缩进结构或返回路径。
+- **测试重叠**：新增 verifier 与目标文件分离，不改写 gold patch 的目标代码。
+- **性能风险**：verifier 将原测试的采样次数降至 2，只检查执行路径和形状，不运行耗时统计测试。
+- **环境风险**：CPU helper 替代设备探测，仅用于独立 verifier，避免依赖本机 GPU。
+- **投机风险**：测试同时覆盖标量和 Tensor 静态路径，并保留动态图 P2P。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-75274/solution/code.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-75274/solution/code.patch
@@ -1,0 +1,143 @@
+diff --git a/test/legacy_test/test_normal.py b/test/legacy_test/test_normal.py
+index 5151a9f9411dc3ed9ae45d0652b7a754e53887cd..0e0a38a2b35fd87cbee5b60850f03dbd73a3bfab 100644
+--- a/test/legacy_test/test_normal.py
++++ b/test/legacy_test/test_normal.py
+@@ -64,15 +64,16 @@ class TestNormalAPI(unittest.TestCase):
+             return 'float32'
+ 
+     def static_api(self):
++        paddle.enable_static()
+         shape = self.get_shape()
+         ret_all_shape = copy.deepcopy(shape)
+         ret_all_shape.insert(0, self.repeat_num)
+         ret_all = np.zeros(ret_all_shape, self.dtype)
+         main_program = paddle.static.Program()
+-        if isinstance(self.mean, np.ndarray) and isinstance(
+-            self.std, np.ndarray
+-        ):
+-            with paddle.static.program_guard(main_program):
++        with paddle.static.program_guard(main_program):
++            if isinstance(self.mean, np.ndarray) and isinstance(
++                self.std, np.ndarray
++            ):
+                 mean = paddle.static.data(
+                     'Mean', self.mean.shape, self.mean.dtype
+                 )
+@@ -89,9 +90,7 @@ class TestNormalAPI(unittest.TestCase):
+                         fetch_list=[out],
+                     )
+                     ret_all[i] = ret[0]
+-            return ret_all
+-        elif isinstance(self.mean, np.ndarray):
+-            with paddle.static.program_guard(main_program):
++            elif isinstance(self.mean, np.ndarray):
+                 mean = paddle.static.data(
+                     'Mean', self.mean.shape, self.mean.dtype
+                 )
+@@ -101,9 +100,7 @@ class TestNormalAPI(unittest.TestCase):
+                 for i in range(self.repeat_num):
+                     ret = exe.run(feed={'Mean': self.mean}, fetch_list=[out])
+                     ret_all[i] = ret[0]
+-            return ret_all
+-        elif isinstance(self.std, np.ndarray):
+-            with paddle.static.program_guard(main_program):
++            elif isinstance(self.std, np.ndarray):
+                 std = paddle.static.data('Std', self.std.shape, self.std.dtype)
+                 out = paddle.normal(self.mean, std, self.shape)
+ 
+@@ -111,16 +108,15 @@ class TestNormalAPI(unittest.TestCase):
+                 for i in range(self.repeat_num):
+                     ret = exe.run(feed={'Std': self.std}, fetch_list=[out])
+                     ret_all[i] = ret[0]
+-            return ret_all
+-        else:
+-            with paddle.static.program_guard(main_program):
++            else:
+                 out = paddle.normal(self.mean, self.std, self.shape)
+ 
+                 exe = paddle.static.Executor(self.place)
+                 for i in range(self.repeat_num):
+                     ret = exe.run(fetch_list=[out])
+                     ret_all[i] = ret[0]
+-            return ret_all
++        paddle.disable_static()
++        return ret_all
+ 
+     def dygraph_api(self):
+         paddle.disable_static(self.place)
+@@ -218,7 +214,6 @@ class TestNormalErrors(unittest.TestCase):
+             self.assertRaises(TypeError, paddle.normal, mean=1.0, std=std)
+ 
+             self.assertRaises(TypeError, paddle.normal, shape=1)
+-
+             self.assertRaises(TypeError, paddle.normal, shape=[1.0])
+ 
+             shape = paddle.static.data('Shape', [100], 'float32')
+@@ -261,15 +256,16 @@ class TestNormalAPIComplex(unittest.TestCase):
+             return 'complex64'
+ 
+     def static_api(self):
++        paddle.enable_static()
+         shape = self.get_shape()
+         ret_all_shape = copy.deepcopy(shape)
+         ret_all_shape.insert(0, self.repeat_num)
+         ret_all = np.zeros(ret_all_shape, self.dtype)
+         main_program = paddle.static.Program()
+-        if isinstance(self.mean, np.ndarray) and isinstance(
+-            self.std, np.ndarray
+-        ):
+-            with paddle.static.program_guard(main_program):
++        with paddle.static.program_guard(main_program):
++            if isinstance(self.mean, np.ndarray) and isinstance(
++                self.std, np.ndarray
++            ):
+                 mean = paddle.static.data(
+                     'Mean', self.mean.shape, self.mean.dtype
+                 )
+@@ -286,9 +282,7 @@ class TestNormalAPIComplex(unittest.TestCase):
+                         fetch_list=[out],
+                     )
+                     ret_all[i] = ret[0]
+-            return ret_all
+-        elif isinstance(self.mean, np.ndarray):
+-            with paddle.static.program_guard(main_program):
++            elif isinstance(self.mean, np.ndarray):
+                 mean = paddle.static.data(
+                     'Mean', self.mean.shape, self.mean.dtype
+                 )
+@@ -298,9 +292,7 @@ class TestNormalAPIComplex(unittest.TestCase):
+                 for i in range(self.repeat_num):
+                     ret = exe.run(feed={'Mean': self.mean}, fetch_list=[out])
+                     ret_all[i] = ret[0]
+-            return ret_all
+-        elif isinstance(self.std, np.ndarray):
+-            with paddle.static.program_guard(main_program):
++            elif isinstance(self.std, np.ndarray):
+                 mean = paddle.static.data('Mean', self.std.shape, 'complex128')
+                 std = paddle.static.data('Std', self.std.shape, self.std.dtype)
+                 out = paddle.normal(mean, std, self.shape)
+@@ -317,20 +309,18 @@ class TestNormalAPIComplex(unittest.TestCase):
+                         fetch_list=[out],
+                     )
+                     ret_all[i] = ret[0]
+-            return ret_all
+-        else:
+-            with paddle.static.program_guard(main_program):
++            else:
+                 mean = paddle.static.data('Mean', (), 'complex128')
+                 out = paddle.normal(mean, self.std, self.shape)
+ 
+                 exe = paddle.static.Executor(self.place)
+                 for i in range(self.repeat_num):
+                     ret = exe.run(
+-                        feed={'Mean': np.array(self.mean)},
+-                        fetch_list=[out],
++                        feed={'Mean': np.array(self.mean)}, fetch_list=[out]
+                     )
+                     ret_all[i] = ret[0]
+-            return ret_all
++        paddle.disable_static()
++        return ret_all
+ 
+     def dygraph_api(self):
+         paddle.disable_static(self.place)

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-75274/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-75274/tests/test.patch
@@ -1,0 +1,92 @@
+diff --git a/test/legacy_test/test_normal_benchmark.py b/test/legacy_test/test_normal_benchmark.py
+new file mode 100644
+index 00000000000000..e93a6d87e1d6fd
+--- /dev/null
++++ b/test/legacy_test/test_normal_benchmark.py
+@@ -0,0 +1,86 @@
++# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++
++import importlib.util
++import sys
++import types
++from pathlib import Path
++
++import paddle
++import pytest
++
++
++_REPO_ROOT = Path(__file__).resolve().parents[2]
++_TARGET = _REPO_ROOT / 'test' / 'legacy_test' / 'test_normal.py'
++
++
++def _load_target_module():
++    cpu_op_test = types.ModuleType('op_test')
++    cpu_op_test.get_device_place = lambda: paddle.CPUPlace()
++    cpu_op_test.is_custom_device = lambda: False
++    sys.modules['op_test'] = cpu_op_test
++
++    spec = importlib.util.spec_from_file_location(
++        'test_normal_under_benchmark', _TARGET
++    )
++    module = importlib.util.module_from_spec(spec)
++    assert spec.loader is not None
++    spec.loader.exec_module(module)
++    return module
++
++
++target = _load_target_module()
++
++
++@pytest.fixture(autouse=True)
++def _restore_static_mode():
++    paddle.enable_static()
++    yield
++    paddle.enable_static()
++
++
++def _new_case(case_type):
++    case = case_type()
++    case.setUp()
++    case.repeat_num = 2
++    return case
++
++
++def test_dygraph_path_preserves_output_shape():
++    case = _new_case(target.TestNormalAPI)
++
++    result = case.dygraph_api()
++
++    assert result.shape == (2, 8, 12)
++    assert not paddle.in_dynamic_mode()
++
++
++def test_scalar_static_path_is_independent_of_initial_mode():
++    paddle.disable_static()
++    case = _new_case(target.TestNormalAPI)
++
++    result = case.static_api()
++
++    assert result.shape == (2, 8, 12)
++    assert paddle.in_dynamic_mode()
++
++
++def test_tensor_static_path_is_independent_of_initial_mode():
++    paddle.disable_static()
++    case = _new_case(target.TestNormalAPI_mean_is_tensor)
++
++    result = case.static_api()
++
++    assert result.shape == (2, 2, 3, 4, 5)
++    assert paddle.in_dynamic_mode()

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-75274/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-75274/tests/test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+python -m pytest test/legacy_test/test_normal_benchmark.py -q


### PR DESCRIPTION
## 关联

- SWE-Paddle 共建 issue: https://github.com/PaddlePaddle/Paddle/issues/79447
- 来源 PR: https://github.com/PaddlePaddle/Paddle/pull/75274

@sunzhongkai588 

## 说明

新增 SWE-Paddle 任务 `PaddlePaddle__Paddle-75274`。


## 验证矩阵

| 状态 | 动态图 P2P | 标量静态 F2P | Tensor 静态 F2P | `tests/test.sh` |
| --- | --- | --- | --- | --- |
| Base + `tests/test.patch` | PASS | FAIL，符合预期 | FAIL，符合预期 | FAIL，符合预期 |
| Base + test patch + `solution/code.patch` | PASS | PASS | PASS | PASS |

## Base 验证

### P2P：动态图路径

```text
.                                                                        [100%]
1 passed in 1.03s
```

现有动态图测试路径保持正常。

### F2P：标量参数静态路径

```text
>       result = case.static_api()

test\legacy_test\test_normal.py:121: in static_api
    ret = exe.run(fetch_list=[out])

E   AttributeError: 'Tensor' object has no attribute 'desc'

FAILED test/legacy_test/test_normal_benchmark.py::test_scalar_static_path_is_independent_of_initial_mode
1 failed, 1 warning in 1.68s
```

Base 在动态图模式下生成了动态图 Tensor，并将其错误传给静态 Executor。

### F2P：Tensor 参数静态路径

```text
>       result = case.static_api()

test\legacy_test\test_normal.py:95: in static_api
    mean = paddle.static.data(

E   AssertionError: 'data()' is only supported in static graph mode.
E   Please call 'paddle.enable_static()' before this api.

FAILED test/legacy_test/test_normal_benchmark.py::test_tensor_static_path_is_independent_of_initial_mode
1 failed in 1.81s
```

Base 在动态图模式下调用了仅支持静态图的 `paddle.static.data()`。

### Base 完整任务脚本

```text
.FF                                                                      [100%]
2 failed, 1 passed, 1 warning in 1.91s
```

## Solution 验证

### 独立测试

```text
Solution P2P:
1 passed in 0.91s

Solution scalar F2P:
1 passed in 0.98s

Solution tensor F2P:
1 passed in 1.07s
```

### Solution 完整测试

```text
...                                                                      [100%]
3 passed in 1.06s
```

### `tests/test.sh`

```text
...                                                                      [100%]
3 passed in 1.02s
```