### PR TITLE
[SWE-Paddle] Add task PaddlePaddle__Paddle-70469

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-70469/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-70469/README.md
@@ -1,0 +1,53 @@
+# PaddlePaddle__Paddle-70469
+
+This directory converts Paddle PR #70469 into a SWE-Paddle community task candidate.
+
+## Source
+
+| Field | Value |
+| --- | --- |
+| Repo | `PaddlePaddle/Paddle` |
+| PR | [70469](https://github.com/PaddlePaddle/Paddle/pull/70469) |
+| PR title | `[BugFix] Fall back fused dropout add` |
+| Base commit | `052874d0c95fe9bcae0c3e0ac60d857b238e6d70` |
+| Gold commit | `5cc69a1b9adbb4b3f3ce30312c0b031be503dff4` |
+| Merged result | `2d1fe5871551c28d92c307f1bbd6d6b12aeeb8c2` |
+| Merged at | `2024-12-27` |
+| Task type | `bug_fix` |
+| Resource | CPU |
+
+## Summary
+
+为规避 `fused_dropout_add` fused execution path 中已知的 precision issue，暂时回退到标准 `dropout + add` 实现，并提供一次性 warning。
+
+## Why This Is A Good SWE-Paddle Candidate
+
+- It is derived from a real merged Distributed Strategy BugFix PR.
+- The production change is limited to one Python file.
+- The expected behavior is observable through output semantics, dispatch side effects, and warning behavior.
+- The verifier executes the checked-out implementation with controlled operator doubles instead of matching source text.
+- P2P coverage preserves the `p == 0` fast-result behavior.
+- The task runs deterministically on CPU without invoking the GPU-only fused kernel.
+
+## Files
+
+- `proposal.md`: candidate proposal for maintainer triage.
+- `instruction.md`: self-contained problem statement for the coding agent.
+- `solution/code.patch`: gold patch from the merged PR.
+- `tests/test.patch`: independent regression verifier.
+- `tests/test.sh`: minimal target test command.
+- `environment/README.md`: environment notes for reproduction.
+- `README.md`: task overview and verification entrypoint.
+
+## Verification
+
+```bash
+bash tests/test.sh
+```
+
+Expected behavior:
+
+- Applying `tests/test.patch` to `base_commit` keeps the `p == 0` P2P green.
+- Training fallback and warning-semantics tests fail on `base_commit`.
+- Applying both `tests/test.patch` and `solution/code.patch` makes all target tests pass.
+- The patched production file must match the Git blob from `gold_commit`.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-70469/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-70469/environment/README.md
@@ -1,0 +1,40 @@
+# Environment Notes
+
+## Expected Environment
+
+- Repository: `PaddlePaddle/Paddle`
+- Base commit: `052874d0c95fe9bcae0c3e0ac60d857b238e6d70`
+- Gold commit: `5cc69a1b9adbb4b3f3ce30312c0b031be503dff4`
+- Resource: CPU
+- Python dependencies: pytest
+- Paddle rebuild required: no
+
+The verifier extracts the target functions and module state from the checked-out `fused_dropout_add.py` through Python AST. It executes them with controlled Paddle and `_C_ops` doubles.
+
+The doubles make the reference `dropout + add` result deterministic and record whether the fused operator was invoked. This validates control flow and API semantics without requiring a GPU or executing the affected fused kernel.
+
+## Run Order
+
+1. Check out the Base commit.
+2. Restore the exact Base blob for `fused_dropout_add.py`.
+3. Apply `tests/test.patch`.
+4. Run the `p == 0` P2P; it should pass.
+5. Run the training-fallback and warning-once F2P tests; both should fail on Base.
+6. Apply `solution/code.patch`.
+7. Verify the target file blob matches the Gold commit.
+8. Run `bash tests/test.sh`; all verifier tests should pass.
+
+## Minimal Command
+
+```bash
+bash tests/test.sh
+```
+
+## Expected Matrix
+
+| State | `p == 0` P2P | Training fallback F2P | Warning/inference F2P | Full script |
+| --- | ---: | ---: | ---: | ---: |
+| Base + tests | PASS | FAIL | FAIL | FAIL |
+| Base + tests + solution | PASS | PASS | PASS | PASS |
+
+No GPU, CUDA runtime, fused kernel execution, external service, or dataset is required.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-70469/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-70469/instruction.md
@@ -1,0 +1,31 @@
+# `fused_dropout_add` 的结果可能与等价 `dropout + add` 不一致
+
+## 详细描述
+
+`paddle.incubate.nn.functional.fused_dropout_add` 在部分有效输入和执行场景中，可能产生与等价 `dropout + add` 组合不一致的数值结果。该差异会影响依赖数值一致性的 training 和 inference 流程。
+
+在 optimized implementation 中已知的 precision issue 得到彻底解决前，应暂时避开受影响的 fused execution path，并保证该 API 保持等价 `dropout + add` 的 functional semantics。
+
+当调用采用上述 compatibility behavior 时，应通过 warning 告知用户当前存在已知的 precision limitation。同一 module lifecycle 内不应重复发出相同 warning。
+
+## 验收标准
+
+- training 和 inference 场景均应保持等价 `dropout + add` 的 functional semantics
+- `p`、`training` 和 `mode` 参数应继续生效
+- 包括 `p == 0` 在内的现有有效参数组合应继续受支持，且结果不得退化
+- 应向用户发出说明 temporary precision limitation 的 warning
+- 同一 loaded module 中，相同 warning 最多发出一次
+
+## 技术要求
+
+- 熟悉 Python
+- 了解 Paddle functional API 和 dropout semantics
+- 了解 fused operator dispatch 与 fallback behavior
+- 了解 warning lifecycle 和 Paddle 单元测试开发流程
+
+## Acceptance Criteria
+
+- The API produces the same observable result as the equivalent dropout-then-add composition.
+- The fallback warning is emitted once per loaded module.
+- Existing valid argument combinations remain supported.
+- Do not satisfy the task by weakening tests or bypassing dropout semantics.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-70469/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-70469/proposal.md
@@ -1,0 +1,57 @@
+# Task Proposal: PaddlePaddle__Paddle-70469
+
+## 1. 来源信息
+
+- Instance ID：`PaddlePaddle__Paddle-70469`
+- PR 链接：https://github.com/PaddlePaddle/Paddle/pull/70469
+- PR 标题：`[BugFix] Fall back fused dropout add`
+- `base_commit`：`052874d0c95fe9bcae0c3e0ac60d857b238e6d70`
+- merged 时间：`2024-12-27`
+- 你的身份：熟悉该模块的 contributor
+- 后续联系人：TBD
+
+## 2. 问题一句话
+
+修复 `fused_dropout_add` 在已知 precision issue 尚未解决时仍进入 fused execution path，导致结果可能偏离标准 `dropout + add` semantics 的问题。
+
+## 3. 为什么适合作为 SWE-Paddle 样本
+
+- **真实性**：该任务来自已合入的 Paddle BugFix PR，不是合成任务。
+- **代表性**：它覆盖 fused functional API、operator dispatch、fallback semantics、参数传递和 warning lifecycle。
+- **边界清楚**：目标行为集中在 `fused_dropout_add` 的 Python API fallback，不需要修改底层 CUDA kernel 或 distributed runtime。
+- **非平凡性**：这个任务不只是替换一个 operator call。正确修复还需要保留 `p`、`training` 和 `mode` semantics，并实现 warning-once behavior。
+- **确定性**：verifier 可以使用 controlled dropout / fused-op doubles 验证 output、参数传递、dispatch side effect 和 warning count，不依赖真实 dropout randomness、GPU kernel 或统计容差。
+
+## 4. 任务类型和标签
+
+- 任务类型：`bug_fix`
+- 执行后端：`cpu`
+- 设备范围：`cpu_only`
+- 模块标签：`[fused_dropout_add, dropout, fallback, precision, warning, python_api]`
+
+## 5. 验证思路
+
+- 目标测试命令：`bash tests/test.sh`
+- 目标测试文件：`test/legacy_test/test_fused_dropout_add_fallback.py`
+- 修复前预期：在 `base_commit` 上应用 `tests/test.patch` 后，training fallback、inference fallback 和 warning-once 相关测试应 fail。
+- 修复后预期：继续应用 `solution/code.patch` 后，目标测试应 pass；输出应符合 controlled `dropout + add` reference，参数应被正确传递，受影响的 fused execution path 不应被调用，且 warning 在同一 loaded module 中最多发出一次。
+- P2P 候选：`p == 0` 等已有有效调用，可由 verifier 作为 regression guard，确认 fallback 不会破坏既有 semantics。
+
+## 6. 环境与资源
+
+- 资源需求：CPU
+- Paddle 来源：`PaddlePaddle/Paddle` source checkout at `base_commit`
+- 是否能提供 Docker：暂无
+- patch 类型：Python-only production change
+- 环境建议：通过 AST 加载 source checkout 中的目标 function，并使用 controlled dropout / fused-op doubles，避免依赖已安装 Paddle wheel 或真实 fused kernel
+- 最小测试命令：`bash tests/test.sh`
+- 是否有 oracle 日志：由 SWE-Paddle verifier 结果另行维护
+
+## 7. 风险自查
+
+- 泄露风险：正式 `instruction.md` 应描述 observable behavior、需要暂时避开的 affected execution path 和 warning contract，不直接指出目标文件、helper function、global state 名称或具体修改行。
+- spec-test alignment 风险：如果 verifier 检查 fused dispatch side effect，正式 instruction 必须明确说明在 precision issue 解决前应避开受影响的 fused execution path。
+- flaky 风险：测试应使用 controlled doubles 返回固定结果，不依赖真实 dropout randomness 或浮点统计容差。
+- 环境风险：该样本为 Python-only production change，可通过 source-level function loading 完成验证，不依赖 GPU、CUDA fused kernel 或 distributed launcher。
+- 误判风险：verifier 应以 behavioral tests 和 regression constraints 为准，不要求源码与 `gold_commit` 完全一致，也不检查特定 helper、global flag、AST 结构或精确修改行数。
+- 投机风险：training、inference、不同参数组合和 `p == 0` regression case 应分别覆盖，避免 agent 通过 hard-code 单一路径通过测试。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-70469/solution/code.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-70469/solution/code.patch
@@ -1,0 +1,40 @@
+diff --git a/python/paddle/incubate/nn/functional/fused_dropout_add.py b/python/paddle/incubate/nn/functional/fused_dropout_add.py
+index 127cc91d548119026009191e8e77aee8bc65dbf3..297e1fb998b4b09ea8565f44cb8eef38df83e480 100644
+--- a/python/paddle/incubate/nn/functional/fused_dropout_add.py
++++ b/python/paddle/incubate/nn/functional/fused_dropout_add.py
+@@ -12,12 +12,21 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ 
++import warnings
+ 
++import paddle
+ from paddle import _C_ops
+ from paddle.base import core
+ from paddle.common_ops_import import default_main_program
+ from paddle.framework import LayerHelper, in_dynamic_or_pir_mode
+ 
++flag = [False]
++
++
++def paddle_dropout_add(x, y, p=0.5, training=True, mode="upscale_in_train"):
++    tmp = paddle.nn.functional.dropout(x, p, training=training, mode=mode)
++    return tmp + y
++
+ 
+ def fused_dropout_add(
+     x, y, p=0.5, training=True, mode='upscale_in_train', name=None
+@@ -73,6 +82,13 @@ def fused_dropout_add(
+              [ 1.29453969,  0.07568165,  0.71947742, -0.71768606, -2.57172823,
+                1.89179027,  3.26482797,  1.10493207, -1.04569530, -1.04862499]])
+     """
++    if not flag[0]:
++        flag[0] = True
++        warnings.warn(
++            "Currently, fused_dropout_add maybe has precision problem, so it falls back to dropout + add. "
++        )
++    return paddle_dropout_add(x, y, p, training=training, mode=mode)
++
+     if isinstance(p, (int, float)):
+         # fast return for p == 0
+         if p == 0:

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-70469/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-70469/tests/test.patch
@@ -1,0 +1,220 @@
+diff --git a/test/legacy_test/test_fused_dropout_add_fallback.py b/test/legacy_test/test_fused_dropout_add_fallback.py
+new file mode 100644
+index 00000000000000..99f26b1ae35e83
+--- /dev/null
++++ b/test/legacy_test/test_fused_dropout_add_fallback.py
+@@ -0,0 +1,214 @@
++# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++
++import ast
++import copy
++import types
++import warnings
++from pathlib import Path
++
++import pytest
++
++
++_REPO_ROOT = Path(__file__).resolve().parents[2]
++_SOURCE_PATH = (
++    _REPO_ROOT
++    / 'python'
++    / 'paddle'
++    / 'incubate'
++    / 'nn'
++    / 'functional'
++    / 'fused_dropout_add.py'
++)
++
++
++class _Tensor:
++    def __init__(self, value):
++        self.value = float(value)
++
++    def __add__(self, other):
++        return _Tensor(self.value + other.value)
++
++
++def _load_checkout_function():
++    source = _SOURCE_PATH.read_text(encoding='utf-8')
++    tree = ast.parse(source, filename=str(_SOURCE_PATH))
++
++    selected = []
++    for node in tree.body:
++        if isinstance(node, ast.Assign):
++            names = {
++                target.id
++                for target in node.targets
++                if isinstance(target, ast.Name)
++            }
++            if 'flag' in names:
++                selected.append(copy.deepcopy(node))
++        elif isinstance(node, ast.FunctionDef) and node.name in {
++            'paddle_dropout_add',
++            'fused_dropout_add',
++        }:
++            selected.append(copy.deepcopy(node))
++
++    assert any(
++        isinstance(node, ast.FunctionDef)
++        and node.name == 'fused_dropout_add'
++        for node in selected
++    )
++
++    dropout_calls = []
++    fused_calls = []
++
++    def dropout(x, p, training=True, mode='upscale_in_train'):
++        dropout_calls.append(
++            {
++                'p': p,
++                'training': training,
++                'mode': mode,
++            }
++        )
++        if training:
++            value = (
++                x.value / (1.0 - p)
++                if mode == 'upscale_in_train'
++                else x.value
++            )
++        else:
++            value = (
++                x.value
++                if mode == 'upscale_in_train'
++                else x.value * (1.0 - p)
++            )
++        return _Tensor(value)
++
++    def fused_dropout_add(
++        x,
++        y,
++        seed_tensor,
++        p,
++        is_test,
++        mode,
++        seed,
++        fix_seed,
++    ):
++        fused_calls.append(
++            {
++                'p': p,
++                'is_test': is_test,
++                'mode': mode,
++            }
++        )
++        return _Tensor(1000.0), object()
++
++    paddle_double = types.SimpleNamespace(
++        nn=types.SimpleNamespace(
++            functional=types.SimpleNamespace(dropout=dropout)
++        )
++    )
++    c_ops_double = types.SimpleNamespace(
++        fused_dropout_add=fused_dropout_add
++    )
++
++    namespace = {
++        'warnings': warnings,
++        'paddle': paddle_double,
++        '_C_ops': c_ops_double,
++        'core': types.SimpleNamespace(),
++        'default_main_program': lambda: types.SimpleNamespace(
++            random_seed=0
++        ),
++        'LayerHelper': object,
++        'in_dynamic_or_pir_mode': lambda: True,
++    }
++
++    module = ast.Module(body=selected, type_ignores=[])
++    ast.fix_missing_locations(module)
++    exec(compile(module, str(_SOURCE_PATH), 'exec'), namespace, namespace)
++
++    return (
++        namespace['fused_dropout_add'],
++        dropout_calls,
++        fused_calls,
++    )
++
++
++def test_zero_probability_result_remains_valid():
++    function, _, fused_calls = _load_checkout_function()
++
++    result = function(_Tensor(2.0), _Tensor(3.0), p=0)
++
++    assert result.value == pytest.approx(5.0)
++    assert fused_calls == []
++
++
++def test_training_uses_reference_dropout_add_semantics():
++    function, dropout_calls, fused_calls = _load_checkout_function()
++
++    result = function(
++        _Tensor(2.0),
++        _Tensor(2.0),
++        p=0.5,
++        training=True,
++        mode='upscale_in_train',
++    )
++
++    assert result.value == pytest.approx(6.0)
++    assert dropout_calls == [
++        {
++            'p': 0.5,
++            'training': True,
++            'mode': 'upscale_in_train',
++        }
++    ]
++    assert fused_calls == []
++
++
++def test_inference_fallback_warns_once_and_preserves_arguments():
++    function, dropout_calls, fused_calls = _load_checkout_function()
++
++    with warnings.catch_warnings(record=True) as caught:
++        warnings.simplefilter('always')
++        first = function(
++            _Tensor(8.0),
++            _Tensor(2.0),
++            p=0.25,
++            training=False,
++            mode='downscale_in_infer',
++        )
++        second = function(
++            _Tensor(4.0),
++            _Tensor(1.0),
++            p=0.25,
++            training=False,
++            mode='downscale_in_infer',
++        )
++
++    assert first.value == pytest.approx(8.0)
++    assert second.value == pytest.approx(4.0)
++    assert dropout_calls == [
++        {
++            'p': 0.25,
++            'training': False,
++            'mode': 'downscale_in_infer',
++        },
++        {
++            'p': 0.25,
++            'training': False,
++            'mode': 'downscale_in_infer',
++        },
++    ]
++    assert fused_calls == []
++    assert len(caught) == 1
++    assert 'precision problem' in str(caught[0].message)
++    assert 'falls back to dropout + add' in str(caught[0].message)

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-70469/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-70469/tests/test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+python -m pytest test/legacy_test/test_fused_dropout_add_fallback.py -q


### PR DESCRIPTION
# 关联

- SWE-Paddle 共建 issue: https://github.com/PaddlePaddle/Paddle/issues/79447
- 来源 PR: https://github.com/PaddlePaddle/Paddle/pull/70469

## 说明

- 新增 SWE-Paddle 任务 `PaddlePaddle__Paddle-70469`
- 新增 `swe-paddle/tasks/PaddlePaddle__Paddle-70469/proposal.md`

该任务覆盖 `fused_dropout_add` 的 precision fallback 问题：API 在存在已知 precision issue 时仍进入 fused execution path，导致结果可能与标准 `dropout + add` semantics 不一致。

## 验证结果

| 状态 | `p == 0` P2P | Training fallback F2P | Warning/inference F2P |
| --- | --- | --- | --- |
| Base + `tests/test.patch` | PASS | FAIL，符合预期 | FAIL，符合预期 |
| Base + test patch + `solution/code.patch` | PASS | PASS | PASS |

#### Base P2P：`p == 0`

```text
.                                                                        [100%]
1 passed in 0.23s
Base P2P exit code: 0
```

#### Base F2P：Training fallback

```text
F                                                                        [100%]
================================== FAILURES ===================================
_____________ test_training_uses_reference_dropout_add_semantics ______________

>       assert result.value == pytest.approx(6.0)
E       assert 1000.0 == 6.0 ± 6.0e-06
E
E         Obtained: 1000.0
E         Expected: 6.0 ± 6.0e-06

FAILED test/legacy_test/test_fused_dropout_add_fallback.py::test_training_uses_reference_dropout_add_semantics
1 failed in 0.32s
```

#### Base F2P：Inference fallback 与 warning

```text
F                                                                        [100%]
================================== FAILURES ===================================
_________ test_inference_fallback_warns_once_and_preserves_arguments __________

>       assert first.value == pytest.approx(8.0)
E       assert 1000.0 == 8.0 ± 8.0e-06
E
E         Obtained: 1000.0
E         Expected: 8.0 ± 8.0e-06

FAILED test/legacy_test/test_fused_dropout_add_fallback.py::test_inference_fallback_warns_once_and_preserves_arguments
1 failed in 0.34s
```

#### Solution 独立测试

```text
Solution P2P:
1 passed, 1 warning in 0.22s

Solution training fallback F2P:
1 passed, 1 warning in 0.26s

Solution warning/inference F2P:
1 passed in 0.22s
```

#### `tests/test.sh`

```text
...                                                                      [100%]
3 passed, 2 warnings in 0.88s
Solution tests/test.sh exit code: 0
```