### PR TITLE
[SWE-Paddle] Add task package for Paddle #58219

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-58219/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-58219/README.md
@@ -1,0 +1,48 @@
+# PaddlePaddle__Paddle-58219
+
+This directory converts Paddle PR #58219 into a SWE-Paddle community task candidate.
+
+## Source
+
+| Field | Value |
+| --- | --- |
+| Repo | `PaddlePaddle/Paddle` |
+| PR | [58219](https://github.com/PaddlePaddle/Paddle/pull/58219) |
+| PR title | `[Hackathon 5th No.49][pir] add some operation - Part 3` |
+| Base commit | `4dbd3f7d8a3a54066939a2e1acc46fadadf65c11` |
+| PR head | `d682fcc85174d9921f7f4222359ed39faeb9e8ac` |
+| Merged at | `2023-10-23T03:41:44Z` (merge commit `edcfda9cd60bb6985bd34851e4501c7743d11d38`) |
+| Hackathon | `5th` task `49`, part 3 |
+| Task type | `feature_implementation` |
+| Resource | CPU |
+
+## Summary
+
+为 PIR 静态图中的 `OpResult` 补齐 `**`、`//`、`%`、`@` 运算能力，并修复
+`floor_divide` 未进入 PIR 分支的问题，使运算结果可由 CPU executor 正确执行。
+
+## Why This Sample
+
+- 来自已合入的 Paddle Hackathon PR，问题和修复都是真实框架研发内容。
+- 同时覆盖 Python 运算符重载、PIR `OpResult` 方法补齐和模式分发，不是机械改名。
+- gold patch 只有两个纯 Python 实现文件，CPU 即可验证，边界清晰。
+- 四个 F2P 与四个未修改的 P2P 位于同一测试文件，Run/Test/Fix 信号明确。
+
+## Files
+
+- `proposal.md`: candidate proposal and maintainer triage context.
+- `instruction.md`: self-contained problem statement for the coding agent.
+- `solution/code.patch`: gold patch from the merged PR (2 implementation files).
+- `tests/test.patch`: test patch exposing the four target operators.
+- `tests/test.sh`: target and regression test command.
+- `environment/README.md`: base commit, compatible runtime, and reproduction notes.
+
+## Verification
+
+```bash
+bash tests/test.sh
+```
+
+Expected behavior: with `tests/test.patch` applied to `base_commit`, the four new
+operator tests error while the four existing regression tests pass. After also
+applying `solution/code.patch`, all eight tests pass.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-58219/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-58219/environment/README.md
@@ -1,0 +1,67 @@
+# Environment Notes
+
+## Expected Environment
+
+- Repository: `PaddlePaddle/Paddle`
+- Base commit: `4dbd3f7d8a3a54066939a2e1acc46fadadf65c11`
+- Resource: CPU
+- GPU required: no
+- Network service or external model required: no
+- Suggested Python: 3.10
+- Test framework: Python `unittest`
+- Patch type: pure Python; no C++/CUDA/kernel rebuild is required once a compatible Paddle binary is available and the checkout's Python sources are loaded.
+
+## Verified Compatibility Environment
+
+The Run/Test/Fix behavior was reproduced with:
+
+- Image: `paddlepaddle/paddle:2.6.0`
+- Container platform: `linux/amd64`
+- Python: `3.10.13`
+- Paddle binary commit: `e032331bf78b0f9b51806c6761254c8b977f02b4`
+
+The image contains Python-layer PIR renames made after this task's base commit. The
+verification therefore used a runtime-only compatibility mapping between the old
+and new monkey-patch entrypoint names while loading the PR's before/after target
+logic. That mapping is environment glue and is not part of either task patch.
+An exact era-matched source build remains the preferred verifier environment.
+
+## Run Order (Run / Test / Fix)
+
+1. Check out `PaddlePaddle/Paddle` at the base commit.
+2. Prepare a compatible compiled Paddle runtime and ensure the checkout's
+   `python/` sources are the package under test.
+3. Apply `tests/test.patch`.
+4. Run `bash tests/test.sh`; the four new operator tests should error, while the
+   four existing regression tests should pass.
+5. Apply `solution/code.patch`.
+6. Run `bash tests/test.sh` again; all eight tests should pass. The gold patch is
+   Python-only, so no native rebuild is needed.
+
+## Minimal Test Command
+
+```bash
+python test/legacy_test/test_math_op_patch_pir.py -v
+```
+
+The script intentionally contains only the target test command. Checkout, patch
+application, binary selection, and Python source overlay belong to the verifier.
+
+## Expected Results
+
+- **Base + test patch**: `test_item`, `test_place`, `test_some_dim`, and
+  `test_math_exists` pass; `test_pow`, `test_floordiv`, `test_mod`, and
+  `test_matmul` error with unsupported-operator `TypeError`.
+- **Base + test patch + gold patch**: all eight tests pass.
+
+## Patch Provenance and Risks
+
+- GitHub records the PR base and head on non-linear histories. Do not regenerate
+  the patch with `git diff base_commit..head`, which includes unrelated develop
+  changes. The provided patches contain only the three files in GitHub's PR diff.
+- No exact wheel for the 2023 base commit is available in the current nightly
+  index; PIR Python/binary compatibility must be fixed by the verifier environment.
+- The original tests explicitly select CPU and use `assert_allclose`. Random
+  inputs have no fixed seed, but do not depend on a probabilistic threshold.
+- Scalar reverse power is outside this task because the original PR did not keep
+  that test enabled.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-58219/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-58219/instruction.md
@@ -1,0 +1,37 @@
+# 补齐 PIR OpResult 的常用二元运算符
+
+## 详细描述
+
+在 PIR 静态图中，`paddle.static.data` 等接口返回 `paddle.pir.OpResult`。该对象已有
+部分 Tensor 数学方法，但缺少若干常用 Python 二元运算符，导致合法的静态图表达式
+在构图阶段直接抛出 `TypeError`；其中整除接口还没有正确识别 PIR 执行模式。
+
+需要让 PIR `OpResult` 支持以下行为：
+
+- `x ** y` 执行逐元素幂运算，且现有的 `x.pow(2)` 调用继续可用。
+- `x // y`、`x.floor_divide(y)` 和 `x.__floordiv__(y)` 行为一致。
+- `x % y`、`x.mod(y)` 和 `x.__mod__(y)` 行为一致。
+- `x @ y`、`x.matmul(y)` 和 `x.__matmul__(y)` 行为一致。
+- 上述表达式构造出的 PIR 程序可在 CPU executor 中运行，结果与对应的 NumPy
+  或动态图计算一致。
+
+本任务不要求扩展原 PR 未验证的标量反向幂场景。
+
+## 验收说明
+
+- 四类运算均能在 PIR 静态图中完成构图和执行，不再因缺失运算符而报错。
+- float32 的幂和矩阵乘法、int64 的整除和取模结果正确。
+- 既有的 `item`、`place`、维度属性和其他数学方法保持可用。
+- 不允许通过删除测试、弱化断言、切回旧静态图或绕过 PIR executor 来通过任务。
+
+## 技术要求
+
+- 熟悉 Python 运算符协议。
+- 了解 Paddle PIR 静态图和 `OpResult` 的公开行为。
+- 修复应局限于必要的 Python API 行为，不修改算子数值语义或底层 kernel。
+
+## Acceptance Criteria
+
+- The PIR `OpResult` behavior described above should be implemented.
+- Existing valid `OpResult` methods and attributes should remain unchanged.
+- Do not satisfy the task by deleting tests, weakening assertions, leaving PIR mode, or bypassing execution.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-58219/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-58219/proposal.md
@@ -1,0 +1,72 @@
+# 任务提案：PaddlePaddle__Paddle-58219
+
+## 1. 来源信息
+
+- Instance ID：`PaddlePaddle__Paddle-58219`
+- PR 链接：https://github.com/PaddlePaddle/Paddle/pull/58219
+- PR 标题：`[Hackathon 5th No.49][pir] add some operation - Part 3`
+- `base_commit`：`4dbd3f7d8a3a54066939a2e1acc46fadadf65c11`（GitHub PR REST 返回的 `base.sha`）
+- PR head：`d682fcc85174d9921f7f4222359ed39faeb9e8ac`
+- merged 时间：`2023-10-23T03:41:44Z`（merge commit `edcfda9cd60bb6985bd34851e4501c7743d11d38`）
+- 你的身份：原 PR 作者（GitHub @gouzil）
+- 后续联系人：GitHub @gouzil
+
+## 2. 问题一句话
+
+PIR 静态图中的 `OpResult` 缺少幂、整除、取模和矩阵乘法运算符，使用 `**`、`//`、`%`、`@` 会直接报 `TypeError`；同时 `floor_divide` 未识别 PIR 模式，会错误进入旧静态图分支。
+
+## 3. 为什么适合作为 SWE-Paddle 样本
+
+- **真实性**：任务来自 Paddle Hackathon 5th No.49 的已合入 PR，是补齐 PIR `OpResult` Python 运算能力的真实开发任务，并经过 Paddle reviewer 审核。
+- **代表性**：覆盖 PIR 静态图、Python 运算符重载、`OpResult` monkey patch、动态图/PIR 模式分发和 executor 数值验证，代表 Paddle 从旧静态图迁移到 PIR 时常见的 API 语义补齐工作。
+- **边界清楚**：gold patch 只修改两个 Python 实现文件，目标是为 `OpResult` 注册 `__pow__`、`__rpow__`、`__floordiv__`、`__mod__`、`__matmul__`，并让 `floor_divide` 进入 PIR 分支；不修改 C++、kernel 或算子数值实现，也不包含同系列前两段 PR 已提供的 monkey-patch 基础设施。
+- **非平凡性**：模型需要同时找到共享的二元运算方法生成路径和 `floor_divide` 的模式分发问题。只补运算符名称而不修正 PIR 分支，或只改公开函数而不注册 `OpResult` dunder，均不能通过完整测试。
+- **验收边界**：沿用原 PR 已覆盖的 `OpResult`-`OpResult` 运算和 `x.pow(2)`；原测试中注释掉的标量反向幂场景不扩展为本任务要求。
+
+## 4. 任务类型和标签
+
+- 任务类型：`feature_implementation`
+- 执行后端：`cpu`
+- 设备范围：`cpu_only`
+- 模块标签：`[python_api, pir, static_graph, opresult, operator_overload, monkey_patch, legacy_test]`
+
+## 5. 验证思路
+
+- 目标测试文件：`test/legacy_test/test_math_op_patch_pir.py`
+- 目标测试命令：
+
+  ```bash
+  python test/legacy_test/test_math_op_patch_pir.py -v
+  ```
+
+- F2P 用例：
+  - `TestMathOpPatchesPir.test_pow`
+  - `TestMathOpPatchesPir.test_floordiv`
+  - `TestMathOpPatchesPir.test_mod`
+  - `TestMathOpPatchesPir.test_matmul`
+- 修复前预期：在 `base_commit` 上应用独立的测试补丁后，四个 F2P 均因 `OpResult` 不支持对应运算符而报 `TypeError`；四个存量 P2P 继续通过。
+- 修复后预期：继续应用仅含两个非测试文件改动的 gold patch 后，目标文件中的 8 个用例全部通过，四种运算的 PIR executor 结果与 NumPy/动态图结果一致。
+- P2P 候选：原文件中未被 PR 修改的 `test_item`、`test_place`、`test_some_dim`、`test_math_exists`。
+- 已完成的兼容性 Run/Test/Fix 预验证：base 为 `4 errors + 4 passes`，应用 gold 后为 `8 passes`；补丁通过 `git diff --check`。
+
+## 6. 环境与资源
+
+- 是否能提供 Docker：有；proposal 预验证使用官方 CPU 镜像
+- Dockerfile 或镜像地址：`paddlepaddle/paddle:2.6.0`，以 `--platform linux/amd64` 运行
+- Paddle 来源：`PaddlePaddle/Paddle` source checkout at `base_commit`；测试补丁和 gold patch 来自 #58219 的三文件 PR diff
+- 如果使用 wheel，请填写 wheel URL、Python 版本和平台标签：未找到与 `base_commit` 精确对应的历史 wheel；镜像内为 Paddle `2.6.0`（commit `e032331bf78b0f9b51806c6761254c8b977f02b4`）、Python `3.10.13`、Linux x86_64
+- OS / Python / CUDA / cuDNN / 其他关键依赖：Linux x86_64、Python 3.10、NumPy、`unittest`；CPU 测试，不依赖 CUDA/cuDNN
+- 硬件：CPU；本次在 macOS arm64 主机上通过 Docker amd64 仿真验证
+- patch 类型：纯 Python，不含 C++、CUDA、kernel 或 infermeta 编译改动
+- 最小测试命令：`python test/legacy_test/test_math_op_patch_pir.py -v`
+- 是否有 oracle 日志：有本次本地预验证输出；完整任务包阶段仍需由 SWE-Paddle verifier 归档正式日志
+- 兼容性说明：2.6.0 镜像的 Python 层已包含后续 PIR 命名变化，本次预验证仅在运行时适配 `monkey_patch_opresult` / `monkey_patch_value` 名称，并分别加载 PR 前后的目标逻辑；适配不进入 gold patch。完整任务包阶段应优先 source build 精确基线，或把该兼容环境固化后再复跑。
+
+## 7. 风险自查
+
+- 泄露风险：正式 `instruction.md` 只描述四种运算的可观察行为、PIR 静态图执行和数值结果，不应给出 monkey-patch 列表、共享 helper 或具体修改文件。
+- 环境风险：精确历史 wheel 已不在当前 nightly 索引。虽然 gold patch 是纯 Python，PIR Python API 与编译产物之间存在版本耦合，完整 verifier 仍需精确 source build 或固定兼容镜像。
+- flaky 风险：低。测试显式固定 CPU，整数除数非零，数值比较使用 `assert_allclose`；随机输入未固定 seed，但不依赖概率阈值或训练收敛。
+- 拆分风险：PR 同时加入四种运算，但它们共享同一 `OpResult` 二元运算注册机制和同一测试入口，按 PR 粒度保留为一个样本更自然。若拆分，会人为切割同一 gold patch。
+- 依赖风险：任务依赖 #57857、#58118 等同系列前序工作已存在于 base；这些基础能力不应重复纳入本任务。
+- patch 提取风险：GitHub 记录的 `base.sha` 与 PR head 不在同一线性祖先链上，直接执行 `git diff base_commit..head` 会混入 31 个无关文件。gold/test patch 必须从 GitHub 三文件 PR diff（等价于 merge-base `5e3974e5b391999f28e326b8c97f23284741934d` 到 head 的目标文件 diff）提取，并确认可干净应用到 `base_commit`。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-58219/solution/code.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-58219/solution/code.patch
@@ -1,0 +1,46 @@
+diff --git a/python/paddle/pir/math_op_patch.py b/python/paddle/pir/math_op_patch.py
+index ad7ecbc4a1..6f0acfaedb 100644
+--- a/python/paddle/pir/math_op_patch.py
++++ b/python/paddle/pir/math_op_patch.py
+@@ -368,6 +368,28 @@ def monkey_patch_opresult():
+             '__rtruediv__',
+             _binary_creator_('__rtruediv__', paddle.tensor.divide, True, None),
+         ),
++        (
++            '__pow__',
++            _binary_creator_('__pow__', paddle.tensor.pow, False, None),
++        ),
++        (
++            '__rpow__',
++            _binary_creator_('__rpow__', paddle.tensor.pow, True, None),
++        ),
++        (
++            '__floordiv__',
++            _binary_creator_(
++                '__floordiv__', paddle.tensor.floor_divide, False, None
++            ),
++        ),
++        (
++            '__mod__',
++            _binary_creator_('__mod__', paddle.tensor.remainder, False, None),
++        ),
++        (
++            '__matmul__',
++            _binary_creator_('__matmul__', paddle.tensor.matmul, False, None),
++        ),
+     ]
+ 
+     global _already_patch_opresult
+diff --git a/python/paddle/tensor/math.py b/python/paddle/tensor/math.py
+index acdd3a35b5..36e92aeabb 100644
+--- a/python/paddle/tensor/math.py
++++ b/python/paddle/tensor/math.py
+@@ -941,7 +941,7 @@ def floor_divide(x, y, name=None):
+             [2, 0, 2, 2])
+ 
+     """
+-    if in_dynamic_mode():
++    if in_dynamic_or_pir_mode():
+         return _C_ops.floor_divide(x, y)
+     else:
+         return _elementwise_op(LayerHelper('elementwise_floordiv', **locals()))

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-58219/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-58219/tests/test.patch
@@ -1,0 +1,158 @@
+diff --git a/test/legacy_test/test_math_op_patch_pir.py b/test/legacy_test/test_math_op_patch_pir.py
+index 1a0254b66d..9a7ab29ea4 100644
+--- a/test/legacy_test/test_math_op_patch_pir.py
++++ b/test/legacy_test/test_math_op_patch_pir.py
+@@ -16,12 +16,153 @@ import inspect
+ import unittest
+ import warnings
+ 
++import numpy as np
++
+ import paddle
++from paddle import base
+ 
+ paddle.enable_static()
++paddle.device.set_device("cpu")
++
++
++def new_program():
++    # TODO(gouzil): Optimize program code
++    main_program = paddle.static.Program()
++    startup_program = paddle.static.Program()
++    place = base.CPUPlace()
++    exe = base.Executor(place)
++    return (
++        main_program,
++        exe,
++        paddle.static.program_guard(
++            main_program=main_program, startup_program=startup_program
++        ),
++    )
+ 
+ 
+ class TestMathOpPatchesPir(unittest.TestCase):
++    def test_pow(self):
++        # Calculate results in dynamic graphs
++        paddle.disable_static()
++        x_np = np.random.random([10, 1024]).astype('float32')
++        y_np = np.random.random([10, 1024]).astype('float32')
++        res_np_b = x_np**y_np
++        res_np_c = paddle.pow(paddle.to_tensor(x_np), 2)
++        # TODO(gouzil): solve paddle.fill_constant problem
++        # res_np_d = x_np.__pow__(2)
++        # res_np_e = x_np.__rpow__(2)
++        paddle.enable_static()
++        # Calculate results under pir
++        with paddle.pir_utils.IrGuard():
++            main_program, exe, program_guard = new_program()
++            with program_guard:
++                x = paddle.static.data(
++                    name='x', shape=[10, 1024], dtype='float32'
++                )
++                y = paddle.static.data(
++                    name='y', shape=[10, 1024], dtype='float32'
++                )
++                b = x**y
++                c = x.pow(2)
++                # d = x.__pow__(2)
++                # e = x.__rpow__(2)
++                # TODO(gouzil): Why not use `paddle.static.default_main_program()`？
++                # Because different case do not isolate parameters (This is a known problem)
++                (b_np, c_np) = exe.run(
++                    main_program,
++                    feed={"x": x_np, "y": y_np},
++                    fetch_list=[b, c],
++                )
++                np.testing.assert_allclose(res_np_b, b_np, rtol=1e-05)
++                np.testing.assert_allclose(res_np_c, c_np, rtol=1e-05)
++                # np.testing.assert_allclose(res_np_d, d_np, rtol=1e-05)
++                # np.testing.assert_allclose(res_np_e, e_np, rtol=1e-05)
++
++    def test_mod(self):
++        paddle.disable_static()
++        x_np = np.random.randint(1, 100, size=[10, 1024], dtype=np.int64)
++        y_np = np.random.randint(1, 100, size=[10, 1024], dtype=np.int64)
++        res_np_b = x_np % y_np
++        res_np_c = paddle.mod(paddle.to_tensor(x_np), paddle.to_tensor(y_np))
++        res_np_d = x_np.__mod__(y_np)
++        paddle.enable_static()
++        with paddle.pir_utils.IrGuard():
++            main_program, exe, program_guard = new_program()
++            with program_guard:
++                x = paddle.static.data(
++                    name='x', shape=[10, 1024], dtype='int64'
++                )
++                y = paddle.static.data(
++                    name='y', shape=[10, 1024], dtype='int64'
++                )
++                b = x % y
++                c = x.mod(y)
++                d = x.__mod__(y)
++                (b_np, c_np, d_np) = exe.run(
++                    main_program,
++                    feed={"x": x_np, "y": y_np},
++                    fetch_list=[b, c, d],
++                )
++                np.testing.assert_allclose(res_np_b, b_np, atol=1e-05)
++                np.testing.assert_allclose(res_np_c, c_np, atol=1e-05)
++                np.testing.assert_allclose(res_np_d, d_np, atol=1e-05)
++
++    def test_matmul(self):
++        paddle.disable_static()
++        x_np = np.random.uniform(-1, 1, [2, 3]).astype('float32')
++        y_np = np.random.uniform(-1, 1, [3, 5]).astype('float32')
++        res_np_b = x_np @ y_np  # __matmul__
++        res_np_c = paddle.matmul(paddle.to_tensor(x_np), paddle.to_tensor(y_np))
++        res_np_d = x_np.__matmul__(y_np)
++        paddle.enable_static()
++        with paddle.pir_utils.IrGuard():
++            main_program, exe, program_guard = new_program()
++            with program_guard:
++                x = paddle.static.data(name='x', shape=[2, 3], dtype='float32')
++                y = paddle.static.data(name='y', shape=[3, 5], dtype='float32')
++                b = x @ y
++                c = x.matmul(y)
++                d = x.__matmul__(y)
++                (b_np, c_np, d_np) = exe.run(
++                    main_program,
++                    feed={"x": x_np, "y": y_np},
++                    fetch_list=[b, c, d],
++                )
++                np.testing.assert_allclose(res_np_b, b_np, atol=1e-05)
++                np.testing.assert_allclose(res_np_c, c_np, atol=1e-05)
++                np.testing.assert_allclose(res_np_d, d_np, atol=1e-05)
++
++    def test_floordiv(self):
++        paddle.disable_static()
++        x_np = np.full([10, 1024], 10, np.int64)
++        y_np = np.full([10, 1024], 2, np.int64)
++        res_np_b = x_np // y_np
++        res_np_c = paddle.floor_divide(
++            paddle.to_tensor(x_np), paddle.to_tensor(y_np)
++        )
++        res_np_d = x_np.__floordiv__(y_np)
++        paddle.enable_static()
++        with paddle.pir_utils.IrGuard():
++            main_program, exe, program_guard = new_program()
++            with program_guard:
++                x = paddle.static.data(
++                    name='x', shape=[10, 1024], dtype='int64'
++                )
++                y = paddle.static.data(
++                    name='y', shape=[10, 1024], dtype='int64'
++                )
++                b = x // y
++                c = x.floor_divide(y)
++                d = x.__floordiv__(y)
++                (b_np, c_np, d_np) = exe.run(
++                    main_program,
++                    feed={"x": x_np, "y": y_np},
++                    fetch_list=[b, c, d],
++                )
++                np.testing.assert_allclose(res_np_b, b_np, atol=1e-05)
++                np.testing.assert_allclose(res_np_c, c_np, atol=1e-05)
++                np.testing.assert_allclose(res_np_d, d_np, atol=1e-05)
++
+     def test_item(self):
+         with paddle.pir_utils.IrGuard():
+             x = paddle.static.data(name='x', shape=[3, 2, 1])

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-58219/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-58219/tests/test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run from the root of a PaddlePaddle/Paddle source checkout.
+python test/legacy_test/test_math_op_patch_pir.py -v


### PR DESCRIPTION
## 背景

[PaddlePaddle/Paddle#58219](https://github.com/PaddlePaddle/Paddle/pull/58219) 为 PIR 静态图中的 `OpResult` 补齐了幂、整除、取模和矩阵乘法运算。修复前，`**`、`//`、`%`、`@` 会在构图阶段因缺少对应运算符而抛出 `TypeError`；`floor_divide` 还会因为未识别 PIR 模式而进入旧静态图分支。

本 PR 将这项已合入的真实开发工作整理为 `PaddlePaddle__Paddle-58219` SWE-Paddle 任务包。

## 变更内容

- 增加 proposal、任务 README、自包含 instruction 和环境说明。
- 将原 PR 的非测试改动拆为 `solution/code.patch`：
  - `python/paddle/pir/math_op_patch.py`
  - `python/paddle/tensor/math.py`
- 将原 PR 的测试改动拆为 `tests/test.patch`：
  - `test/legacy_test/test_math_op_patch_pir.py`
- 增加 `tests/test.sh`，一次运行 4 个目标 F2P 和 4 个存量 P2P。
- 保留 PR 原有边界：CPU-only、纯 Python，不扩展原测试未启用的标量反向幂场景。

## Run / Test / Fix 验证

在 `base_commit=4dbd3f7d8a3a54066939a2e1acc46fadadf65c11` 上验证：

- 仅应用 `tests/test.patch`：8 个用例中 4 个目标用例按预期报 unsupported-operator `TypeError`，4 个存量回归用例通过。
- 再应用 `solution/code.patch`：8/8 用例通过。
- 两个 patch 均通过 `git apply --check`，合计修改 3 个 Paddle 文件，`+164/-1`。
- `test.sh` 通过 `bash -n`，任务目录包含标准 7 文件结构。

兼容性验证使用 `paddlepaddle/paddle:2.6.0`、Python 3.10.13、Linux amd64 CPU 环境。由于当前 nightly 索引没有与 2023 年基线精确对应的 wheel，环境说明记录了 PIR Python 层命名兼容处理；该处理不进入 gold patch。
