### PR TITLE
[SWE-Paddle] Add task PaddlePaddle__Paddle-59909

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-59909/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-59909/README.md
@@ -1,0 +1,44 @@
+# PaddlePaddle__Paddle-59909
+
+This directory converts Paddle PR #59909 into a SWE-Paddle community task candidate.
+
+## Source
+
+| Field | Value |
+| --- | --- |
+| Repo | `PaddlePaddle/Paddle` |
+| PR | [59909](https://github.com/PaddlePaddle/Paddle/pull/59909) |
+| PR title | `[BugFix]Fix bug in parallel-mode select because of pure sharding` |
+| Base commit | `6279a6784b35d96b910053b55ff6f763153e454a` |
+| Merged at | `2023-12-12` |
+| Task type | `bug_fix` |
+| Resource | CPU |
+
+## Summary
+
+修复 hybrid parallel topology 在 sharding 与 data parallel 同时启用时错误选择 `DATA_PARALLEL` 的问题。
+
+## Why This Is A Good SWE-Paddle Candidate
+
+- It covers hybrid parallel topology and runtime parallel mode selection.
+- It requires correct handling of sharding combined with data parallel.
+- It preserves existing data parallel, pure sharding, tensor parallel, and pipeline parallel behavior.
+- The target behavior can be verified deterministically on CPU without distributed communication.
+
+## Files
+
+- `proposal.md`: candidate proposal for maintainer triage.
+- `instruction.md`: self-contained problem statement for the coding agent.
+- `solution/code.patch`: gold patch from the merged PR.
+- `tests/test.patch`: test patch exposing the target behavior.
+- `tests/test.sh`: minimal target test command.
+- `environment/README.md`: environment notes for reproduction.
+- `README.md`: task overview and verification entrypoint.
+
+## Verification
+
+```bash
+bash tests/test.sh
+```
+
+Expected behavior: applying `tests/test.patch` to `base_commit` should fail on the target sharding-plus-data-parallel behavior; applying both `tests/test.patch` and `solution/code.patch` should pass the target tests.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-59909/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-59909/environment/README.md
@@ -1,0 +1,27 @@
+# Environment Notes
+
+This candidate is part of the SWE-Paddle community task set.
+
+## Expected Environment
+
+- Repository: `PaddlePaddle/Paddle`
+- Base commit: `6279a6784b35d96b910053b55ff6f763153e454a`
+- Resource: CPU
+- GPU required: no
+- Build path: Paddle source checkout at the base commit. The verifier may load the target Python definitions through AST without rebuilding Paddle.
+
+## Run Order
+
+1. Check out `PaddlePaddle/Paddle` at the base commit.
+2. Apply `tests/test.patch`.
+3. Run `bash tests/test.sh`; the target behavior should fail before the fix.
+4. Apply `solution/code.patch`.
+5. Run `bash tests/test.sh` again; the target behavior should pass after the gold patch.
+
+## Minimal Test Command
+
+```bash
+bash tests/test.sh
+```
+
+The verifier is responsible for deriving stable F2P and P2P node IDs from repeated runs.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-59909/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-59909/instruction.md
@@ -1,0 +1,23 @@
+# 修复 hybrid parallel topology 的 parallel mode 选择
+
+## 详细描述
+
+当 tensor parallel 和 pipeline parallel 均未启用，而 sharding 与 data parallel 同时启用时，hybrid parallel topology 可能错误选择 `DATA_PARALLEL`，导致后续逻辑无法按照实际启用的 sharding strategy 运行。
+
+## 验收说明
+
+- sharding degree 大于 1 时，即使同时启用 data parallel，也应选择 `SHARDING_PARALLEL`
+- 仅启用 data parallel 时应继续选择 `DATA_PARALLEL`
+- tensor parallel 和 pipeline parallel 的现有 mode selection 不得退化
+
+## 技术要求
+
+- 熟悉 Python
+- 了解 Paddle hybrid parallel topology
+- 了解 data parallel、tensor parallel、pipeline parallel 和 sharding
+
+## Acceptance Criteria
+
+- The behavior described above should be fixed.
+- Existing valid behavior should remain unchanged.
+- Do not satisfy the task by deleting tests, weakening assertions, or bypassing validation broadly.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-59909/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-59909/proposal.md
@@ -1,0 +1,54 @@
+# Task Proposal: PaddlePaddle__Paddle-59909
+
+## 1. 来源信息
+
+- Instance ID：`PaddlePaddle__Paddle-59909`
+- PR 链接：https://github.com/PaddlePaddle/Paddle/pull/59909
+- PR 标题：`[BugFix]Fix bug in parallel-mode select because of pure sharding`
+- `base_commit`：`6279a6784b35d96b910053b55ff6f763153e454a`
+- merged 时间：`2023-12-12`
+- 你的身份：熟悉该模块的 contributor
+- 后续联系人：TBD
+
+## 2. 问题一句话
+
+修复 hybrid parallel topology 在 sharding 与 data parallel 同时启用时错误选择 `DATA_PARALLEL` 的问题。
+
+## 3. 为什么适合作为 SWE-Paddle 样本
+
+- **真实性**：该任务来自已合入的 Paddle BugFix PR，不是合成任务。
+- **代表性**：它覆盖 hybrid parallel topology、parallel degree composition 和 runtime mode selection。
+- **边界清楚**：目标行为集中在 `get_parallel_mode` 对 data parallel、tensor parallel、pipeline parallel 和 sharding degree 的分类。
+- **非平凡性**：修复需要正确处理多种 parallel strategy 的共存关系，同时保持已有 mode selection 行为不变。
+
+## 4. 任务类型和标签
+
+- 任务类型：`bug_fix`
+- 执行后端：`cpu`
+- 设备范围：`cpu_only`
+- 模块标签：`[distributed, fleet, hybrid_parallel, topology, sharding, parallel_mode]`
+
+## 5. 验证思路
+
+- 目标测试命令：`bash tests/test.sh`
+- 目标测试文件：`test/legacy_test/test_hybrid_parallel_mode_selection.py`
+- 修复前预期：在 `base_commit` 上应用 `tests/test.patch` 后，sharding 与 data parallel 共存的目标测试应 fail。
+- 修复后预期：继续应用 `solution/code.patch` 后，目标测试应 pass。
+- P2P 候选：data parallel、pure sharding、tensor parallel 和 pipeline parallel 的现有 mode-selection 用例。
+
+## 6. 环境与资源
+
+- 资源需求：CPU
+- Paddle 来源：`PaddlePaddle/Paddle` source checkout at `base_commit`
+- 是否能提供 Docker：暂无
+- patch 类型：Python-only production change
+- 环境建议：该样本可通过 AST 加载 source checkout 中的 `ParallelMode` 和 `get_parallel_mode`，不需要初始化 distributed process group
+- 最小测试命令：`bash tests/test.sh`
+- 是否有 oracle 日志：由 SWE-Paddle verifier 结果另行维护
+
+## 7. 风险自查
+
+- 泄露风险：正式 `instruction.md` 描述目标行为和验收标准，不直接指出具体条件顺序或修改行。
+- 环境风险：该样本不依赖 Paddle runtime、GPU、NCCL 或 distributed launcher。
+- flaky 风险：测试仅执行 pure Python mode selection，不涉及线程、进程或 collective communication。
+- 拆分风险：该 PR 的目标集中在 hybrid parallel mode selection，适合作为一个样本。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-59909/solution/code.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-59909/solution/code.patch
@@ -1,0 +1,38 @@
+diff --git a/python/paddle/distributed/fleet/base/topology.py b/python/paddle/distributed/fleet/base/topology.py
+index d181db5c8720235ebf69f73831229af92a5c46df..a595342b917edc62f0492b278038b51766ee4bfd 100644
+--- a/python/paddle/distributed/fleet/base/topology.py
++++ b/python/paddle/distributed/fleet/base/topology.py
+@@ -238,20 +238,26 @@ class HybridCommunicateGroup:
+         # NOTE when sharding conjugates with other parallel, sharding should act like a optimizer and
+         # adding its parallel logic within that parallelism
+         # when use sharding alone, it should have its own parallelism for its parallel logic
+-        # TODO modify 3 others parallel to support sharding
+         if (
+-            self._mp_degree == 1
+-            and self._pp_degree == 1
+-            and self._dp_degree == 1
++            self._pp_degree == 1
++            and self._mp_degree == 1
++            and self._sharding_degree == 1
++            and self._dp_degree > 1
++        ):
++            return ParallelMode.DATA_PARALLEL
++        elif (
++            self._pp_degree == 1
++            and self._mp_degree == 1
+             and self._sharding_degree > 1
+         ):
++            # sharding may coexist with dp
+             return ParallelMode.SHARDING_PARALLEL
+-        elif self._mp_degree == 1 and self._pp_degree == 1:
+-            return ParallelMode.DATA_PARALLEL
+-        elif self._mp_degree > 1 and self._pp_degree == 1:
++        elif self._pp_degree == 1 and self._mp_degree > 1:
++            # tp may coexist with sep、dp and sharding
+             # initialize the seed
+             return ParallelMode.TENSOR_PARALLEL
+         elif self._pp_degree > 1:
++            # pp may coexist with mp、sep、dp and sharding
+             return ParallelMode.PIPELINE_PARALLEL
+ 
+     def _check_vaild_topo(self):

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-59909/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-59909/tests/test.patch
@@ -1,0 +1,122 @@
+diff --git a/test/legacy_test/test_hybrid_parallel_mode_selection.py b/test/legacy_test/test_hybrid_parallel_mode_selection.py
+new file mode 100644
+index 00000000000000..9edef404f2f197
+--- /dev/null
++++ b/test/legacy_test/test_hybrid_parallel_mode_selection.py
+@@ -0,0 +1,116 @@
++# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++
++import ast
++import copy
++import types
++from pathlib import Path
++
++
++_REPO_ROOT = Path(__file__).resolve().parents[2]
++_SOURCE_PATH = (
++    _REPO_ROOT
++    / 'python'
++    / 'paddle'
++    / 'distributed'
++    / 'fleet'
++    / 'base'
++    / 'topology.py'
++)
++
++
++def _load_checkout_mode_selector():
++    source = _SOURCE_PATH.read_text(encoding='utf-8')
++    tree = ast.parse(source, filename=str(_SOURCE_PATH))
++
++    parallel_mode = None
++    selector = None
++
++    for node in tree.body:
++        if isinstance(node, ast.ClassDef) and node.name == 'ParallelMode':
++            parallel_mode = copy.deepcopy(node)
++        elif (
++            isinstance(node, ast.ClassDef)
++            and node.name == 'HybridCommunicateGroup'
++        ):
++            for member in node.body:
++                if (
++                    isinstance(member, ast.FunctionDef)
++                    and member.name == 'get_parallel_mode'
++                ):
++                    selector = copy.deepcopy(member)
++                    selector.name = '_get_parallel_mode'
++                    selector.decorator_list = []
++                    break
++
++    assert parallel_mode is not None
++    assert selector is not None
++
++    namespace = {}
++    module = ast.Module(
++        body=[parallel_mode, selector],
++        type_ignores=[],
++    )
++    ast.fix_missing_locations(module)
++    exec(compile(module, str(_SOURCE_PATH), 'exec'), namespace, namespace)
++
++    return namespace['ParallelMode'], namespace['_get_parallel_mode']
++
++
++def _classify(dp, sharding, mp=1, pp=1):
++    parallel_mode, selector = _load_checkout_mode_selector()
++    topology = types.SimpleNamespace(
++        _dp_degree=dp,
++        _sharding_degree=sharding,
++        _mp_degree=mp,
++        _pp_degree=pp,
++    )
++    return selector(topology), parallel_mode
++
++
++def test_existing_data_and_pure_sharding_modes():
++    data_result, mode = _classify(dp=4, sharding=1)
++    sharding_result, _ = _classify(dp=1, sharding=4)
++
++    assert data_result == mode.DATA_PARALLEL
++    assert sharding_result == mode.SHARDING_PARALLEL
++
++
++def test_tensor_and_pipeline_modes_take_precedence():
++    tensor_result, mode = _classify(
++        dp=2,
++        sharding=2,
++        mp=2,
++        pp=1,
++    )
++    pipeline_result, _ = _classify(
++        dp=2,
++        sharding=2,
++        mp=2,
++        pp=2,
++    )
++
++    assert tensor_result == mode.TENSOR_PARALLEL
++    assert pipeline_result == mode.PIPELINE_PARALLEL
++
++
++def test_sharding_with_data_parallel_uses_sharding_mode():
++    result, mode = _classify(
++        dp=2,
++        sharding=4,
++        mp=1,
++        pp=1,
++    )
++
++    assert result == mode.SHARDING_PARALLEL

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-59909/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-59909/tests/test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+python -m pytest test/legacy_test/test_hybrid_parallel_mode_selection.py -q


### PR DESCRIPTION
# 关联

- SWE-Paddle 共建 issue: https://github.com/PaddlePaddle/Paddle/issues/79447
- 来源 PR: https://github.com/PaddlePaddle/Paddle/pull/59909

@sunzhongkai588 

## 说明

- 新增 SWE-Paddle 任务 `PaddlePaddle__Paddle-59909`
- 新增 `swe-paddle/tasks/PaddlePaddle__Paddle-59909/proposal.md`

该任务覆盖 hybrid parallel topology 在 sharding 与 data parallel 同时启用时错误选择 `DATA_PARALLEL` 的问题。

## 验证结果

| 状态 | Existing modes P2P | Precedence P2P | Sharding + DP F2P |
| --- | --- | --- | --- |
| Base + `tests/test.patch` | PASS | PASS | FAIL，符合预期 |
| Base + test patch + `solution/code.patch` | PASS | PASS | PASS |

#### Base P2P：Existing parallel modes

```text
.                                                                        [100%]
1 passed in 0.03s
Base existing P2P exit code: 0
```

data parallel 和 pure sharding 的现有 mode selection 保持正常。

#### Base P2P：Tensor/Pipeline precedence

```text
.                                                                        [100%]
1 passed in 0.03s
Base precedence P2P exit code: 0
```

tensor parallel 和 pipeline parallel 的 mode precedence 保持正常。

#### Base F2P：Sharding 与 data parallel 共存

```text
F                                                                        [100%]
================================== FAILURES ===================================
_____________ test_sharding_with_data_parallel_uses_sharding_mode _____________

>       assert result == mode.SHARDING_PARALLEL
E       AssertionError: assert 0 == 3
E        +  where 3 = <class 'ParallelMode'>.SHARDING_PARALLEL

FAILED test/legacy_test/test_hybrid_parallel_mode_selection.py::test_sharding_with_data_parallel_uses_sharding_mode
1 failed in 0.17s
Base sharding+DP F2P exit code: 1
```

Base 在 sharding degree 大于 1 且同时启用 data parallel 时错误返回 `DATA_PARALLEL`。

#### Solution 测试

```text
Solution existing modes P2P:
1 passed in 0.03s

Solution precedence P2P:
1 passed in 0.03s

Solution sharding+DP F2P:
1 passed in 0.03s
```

#### `tests/test.sh`

```text
...                                                                      [100%]
3 passed in 0.04s
Solution tests/test.sh exit code: 0
```