### PR TITLE
[SWE-Paddle] Add task PaddlePaddle__Paddle-56135

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-56135/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-56135/README.md
@@ -1,0 +1,45 @@
+# PaddlePaddle__Paddle-56135
+
+This directory converts Paddle PR #56135 into a SWE-Paddle community task candidate.
+
+## Source
+
+| Field | Value |
+| --- | --- |
+| Repo | `PaddlePaddle/Paddle` |
+| PR | [56135](https://github.com/PaddlePaddle/Paddle/pull/56135) |
+| PR title | `[BugFix] fix bmm op bugs in static mode with dynamic shape` |
+| Base commit | `4f2cf7fbcaca52bb9625dc6be944f552ea1d71d5` |
+| Merged at | `2023-08-16` |
+| Task type | `bug_fix` |
+| Resource | CPU |
+
+## Summary
+
+修复 `paddle.bmm` 在 static graph 下处理包含 unknown dimension 的 dynamic shape 时，错误拒绝合法输入或无法正确推导 output shape 的问题。
+
+## Why This Is A Good SWE-Paddle Candidate
+
+- It covers both Python static-graph validation and C++ infermeta behavior.
+- It requires consistent handling of unknown dimensions across two framework layers.
+- It preserves known-shape execution and known-incompatible-shape validation.
+- The C++ verifier compiles the exact checked-out `BmmInferMeta` function in a lightweight native harness.
+- It avoids a full Paddle rebuild while still executing the changed C++ control flow.
+
+## Files
+
+- `proposal.md`: candidate proposal for maintainer triage.
+- `instruction.md`: self-contained problem statement for the coding agent.
+- `solution/code.patch`: gold patch from the merged PR.
+- `tests/test.patch`: test patch exposing the target behavior.
+- `tests/test.sh`: minimal target test command.
+- `environment/README.md`: environment notes for reproduction.
+- `README.md`: task overview and verification entrypoint.
+
+## Verification
+
+```bash
+bash tests/test.sh
+```
+
+Expected behavior: applying `tests/test.patch` to `base_commit` should fail on the Python static-graph and C++ infermeta dynamic-shape behavior; applying both `tests/test.patch` and `solution/code.patch` should pass the target tests.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-56135/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-56135/environment/README.md
@@ -1,0 +1,29 @@
+# Environment Notes
+
+This candidate is part of the SWE-Paddle community task set.
+
+## Expected Environment
+
+- Repository: `PaddlePaddle/Paddle`
+- Base commit: `4f2cf7fbcaca52bb9625dc6be944f552ea1d71d5`
+- Resource: CPU
+- GPU required: no
+- Build path: Paddle source checkout at the base commit. A full Paddle build is not required; the verifier compiles only a lightweight C++17 harness containing the checked-out `BmmInferMeta` function.
+
+The local cross-validation script also reports the currently installed Paddle wheel, package location, and wheel commit for environment inventory. The installed wheel is not used as the oracle for historical infermeta behavior.
+
+## Run Order
+
+1. Check out `PaddlePaddle/Paddle` at the base commit.
+2. Apply `tests/test.patch`.
+3. Run `bash tests/test.sh`; the target behavior should fail before the fix.
+4. Apply `solution/code.patch`.
+5. Run `bash tests/test.sh` again; the target behavior should pass after the gold patch.
+
+## Minimal Test Command
+
+```bash
+bash tests/test.sh
+```
+
+The verifier is responsible for deriving stable F2P and P2P node IDs from repeated runs.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-56135/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-56135/instruction.md
@@ -1,0 +1,23 @@
+# 修复 static graph 下 bmm 对 dynamic shape 的支持
+
+## 详细描述
+
+在 static graph 中，`paddle.bmm` 的输入 shape 可能包含值为 `-1` 的 unknown dimension。当两个三维输入在 batch dimension 或 matrix inner dimension 中只有一侧为 unknown，而另一侧为已知值时，合法的 graph construction 可能被错误拒绝，或 output shape 无法正确使用已知 dimension。
+
+## 验收说明
+
+- unknown dimension 不应被当作已知的不匹配 dimension 拒绝
+- 能够确定的 output batch、row 和 column dimensions 应被正确保留
+- 已知且不兼容的 input shapes 仍应报错，known-shape 行为不得退化
+
+## 技术要求
+
+- 熟悉 Python 和 C++
+- 了解 Paddle static graph 与 infermeta
+- 了解 batched matrix multiplication 和 dynamic shape
+
+## Acceptance Criteria
+
+- The behavior described above should be fixed.
+- Existing valid behavior should remain unchanged.
+- Do not satisfy the task by deleting tests, weakening assertions, or bypassing validation broadly.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-56135/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-56135/proposal.md
@@ -1,0 +1,55 @@
+# Task Proposal: PaddlePaddle__Paddle-56135
+
+## 1. 来源信息
+
+- Instance ID：`PaddlePaddle__Paddle-56135`
+- PR 链接：https://github.com/PaddlePaddle/Paddle/pull/56135
+- PR 标题：`[BugFix] fix bmm op bugs in static mode with dynamic shape`
+- `base_commit`：`4f2cf7fbcaca52bb9625dc6be944f552ea1d71d5`
+- merged 时间：`2023-08-16`
+- 你的身份：熟悉该模块的 contributor
+- 后续联系人：TBD
+
+## 2. 问题一句话
+
+修复 `paddle.bmm` 在 static graph 下无法正确接受和推导包含 unknown dimension 的 dynamic shape 的问题。
+
+## 3. 为什么适合作为 SWE-Paddle 样本
+
+- **真实性**：该任务来自已合入的 Paddle BugFix PR，问题由 PaddleSOT 场景发现，不是合成任务。
+- **代表性**：它同时覆盖 Python API validation、C++ infermeta、static graph、dynamic shape 和 output shape propagation。
+- **边界清楚**：production change 只涉及 `bmm` 的 Python validation 与 `BmmInferMeta` 两个相互对应的实现位置。
+- **非平凡性**：只放宽 Python validation 不足以完成修复；C++ infermeta 还必须在 unknown 与 known dimension 共存时校验兼容性并传播可确定的 output dimension。
+- **区分度信号**：该任务要求同时修复 Python static graph validation 与 C++ infermeta 的 dynamic-shape contract，能够区分只处理单层逻辑的局部修复与真正跨层一致的完整修复。
+
+## 4. 任务类型和标签
+
+- 任务类型：`bug_fix`
+- 执行后端：`cpu`
+- 设备范围：`cpu_only`
+- 模块标签：`[bmm, static_graph, dynamic_shape, infermeta, python_api, cpp]`
+
+## 5. 验证思路
+
+- 目标测试命令：`bash tests/test.sh`
+- 目标测试文件：`test/legacy_test/test_bmm_dynamic_shape_contract.py`
+- 修复前预期：known-shape 和 known-incompatible-shape P2P 应 pass；Python static-graph dynamic-shape 与 C++ infermeta dynamic-shape 测试应 fail。
+- 修复后预期：继续应用 `solution/code.patch` 后，P2P 与两个 F2P 均应 pass。
+- P2P 候选：known compatible shapes 的 output shape，以及 known incompatible batch/inner dimensions 的错误校验。
+
+## 6. 环境与资源
+
+- 资源需求：CPU
+- Paddle 来源：`PaddlePaddle/Paddle` source checkout at `base_commit`
+- 是否能提供 Docker：暂无
+- patch 类型：Python + C++ infermeta
+- 环境建议：无需从头编译 Paddle；verifier 只编译 source checkout 中提取出的 `BmmInferMeta` lightweight harness，并复用本地 Python、pytest、setuptools 和 C++17 compiler
+- 最小测试命令：`bash tests/test.sh`
+- 是否有 oracle 日志：由 SWE-Paddle verifier 结果另行维护
+
+## 7. 风险自查
+
+- 泄露风险：正式 `instruction.md` 描述 unknown dimension 的可观察行为，不指出具体条件表达式或 helper 实现。
+- 环境风险：需要可用的 C++17 compiler，但不需要 Paddle source build、CUDA 或 GPU。
+- flaky 风险：测试使用固定 shapes，native harness 不包含并发、随机数或外部依赖。
+- 拆分风险：两个 production files 共同定义同一个 `bmm` dynamic-shape contract，不适合拆成两个独立样本。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-56135/solution/code.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-56135/solution/code.patch
@@ -1,0 +1,71 @@
+diff --git a/paddle/phi/infermeta/binary.cc b/paddle/phi/infermeta/binary.cc
+index cfc88c5c2d50d3dab060eea4fa83ac6aff487781..e65078f4b77ff2b125ec7fc3999085e9b12d5492 100644
+--- a/paddle/phi/infermeta/binary.cc
++++ b/paddle/phi/infermeta/binary.cc
+@@ -271,27 +271,27 @@ void BmmInferMeta(const MetaTensor& x, const MetaTensor& y, MetaTensor* out) {
+                         "Input(Y) of BmmOp must be 3-dimensional in BmmOp, "
+                         "but received Y's shape: [%s].",
+                         y_ndims));
+-  PADDLE_ENFORCE_EQ(
++  std::vector<int64_t> dim_out;
++  auto cal_shape_fn = [](int64_t x, int64_t y, const std::string& error_str) {
++    if (x == -1) {
++      return y;
++    } else if (y == -1) {
++      return x;
++    }
++    PADDLE_ENFORCE_EQ(x, y, phi::errors::InvalidArgument(error_str, x, y));
++    return x;
++  };
++  cal_shape_fn(x_dims[2],
++               y_dims[1],
++               "Input(X)'s width must be equal with Input(Y)'s height in BmmOp,"
++               "but receive X's width: [%s],"
++               "Y's height: [%s].");
++  dim_out.push_back(cal_shape_fn(
+       x_dims[0],
+       y_dims[0],
+-      phi::errors::InvalidArgument(
+-          "Input(X) and Input(Y) must have the same batch size in BmmOp, "
+-          "but received X's batch size: [%s],"
+-          "Y's batch size [%s]",
+-          x_dims[0],
+-          y_dims[0]));
+-  PADDLE_ENFORCE_EQ(
+-      x_dims[2],
+-      y_dims[1],
+-      phi::errors::InvalidArgument(
+-          "Input(X)'s width must be equal with Input(Y)'s height in BmmOp,"
+-          "but receive X's width: [%s],"
+-          "Y's height: [%s].",
+-          x_dims[2],
+-          y_dims[1]));
+-
+-  std::vector<int64_t> dim_out;
+-  dim_out.push_back(x_dims[0]);
++      "Input(X) and Input(Y) must have the same batch size in BmmOp, "
++      "but received X's batch size: [%s],"
++      "Y's batch size [%s]"));
+   dim_out.push_back(x_dims[1]);
+   dim_out.push_back(y_dims[2]);
+   out->set_dims(phi::make_ddim(dim_out));
+diff --git a/python/paddle/tensor/linalg.py b/python/paddle/tensor/linalg.py
+index 76ae5438cefbae221f3e8d0ad6f73cd679c6b5de..79488a63a0798d2165f69c0316082c8cdcd67688 100644
+--- a/python/paddle/tensor/linalg.py
++++ b/python/paddle/tensor/linalg.py
+@@ -1589,13 +1589,13 @@ def bmm(x, y, name=None):
+                     x_shape, y_shape
+                 )
+             )
+-        if x_shape[2] != y_shape[1]:
++        if x_shape[2] != -1 and y_shape[1] != -1 and x_shape[2] != y_shape[1]:
+             raise ValueError(
+                 "x's width must be equal with y's height. But received x's shape: {}, y's shape: {}".format(
+                     x_shape, y_shape
+                 )
+             )
+-        if x_shape[0] != y_shape[0]:
++        if x_shape[0] != -1 and y_shape[0] != -1 and x_shape[0] != y_shape[0]:
+             raise ValueError(
+                 "x's batch (shape[0]) must be equal with y's batch (shape[0]). But received x's shape: {}, y's shape: {}".format(
+                     x_shape, y_shape

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-56135/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-56135/tests/test.patch
@@ -1,0 +1,292 @@
+diff --git a/test/legacy_test/test_bmm_dynamic_shape_contract.py b/test/legacy_test/test_bmm_dynamic_shape_contract.py
+new file mode 100644
+index 00000000000000..69264c5caf457d
+--- /dev/null
++++ b/test/legacy_test/test_bmm_dynamic_shape_contract.py
+@@ -0,0 +1,286 @@
++import ast
++import copy
++import hashlib
++import os
++import shutil
++import subprocess
++import sys
++import tempfile
++import types
++from pathlib import Path
++
++import pytest
++
++_REPO_ROOT = Path(__file__).resolve().parents[2]
++_PY_SOURCE = _REPO_ROOT / 'python/paddle/tensor/linalg.py'
++_CPP_SOURCE = _REPO_ROOT / 'paddle/phi/infermeta/binary.cc'
++
++class _Tensor:
++    def __init__(self, shape, dtype='float32'):
++        self.shape = tuple(shape)
++        self.dtype = dtype
++
++class _Output:
++    def __init__(self, dtype):
++        self.dtype = dtype
++
++
++def _load_checkout_bmm():
++    tree = ast.parse(_PY_SOURCE.read_text(encoding='utf-8'), filename=str(_PY_SOURCE))
++    target = None
++    for node in tree.body:
++        if isinstance(node, ast.FunctionDef) and node.name == 'bmm':
++            target = copy.deepcopy(node)
++            target.decorator_list = []
++            break
++    assert target is not None
++    events = []
++    class _LayerHelper:
++        def __init__(self, *args, **kwargs):
++            pass
++        def create_variable_for_type_inference(self, dtype):
++            return _Output(dtype)
++        def append_op(self, **kwargs):
++            events.append(kwargs)
++    namespace = {
++        'in_dynamic_mode': lambda: False,
++        '_C_ops': types.SimpleNamespace(bmm=lambda x, y: None),
++        'LayerHelper': _LayerHelper,
++    }
++    module = ast.Module(body=[target], type_ignores=[])
++    ast.fix_missing_locations(module)
++    exec(compile(module, str(_PY_SOURCE), 'exec'), namespace, namespace)
++    return namespace['bmm'], events
++
++
++def _extract_cpp_function():
++    source = _CPP_SOURCE.read_text(encoding='utf-8')
++    marker = 'void BmmInferMeta('
++    start = source.index(marker)
++    brace = source.index('{', start)
++    depth = 0
++    i = brace
++    in_string = False
++    quote = ''
++    escape = False
++    while i < len(source):
++        ch = source[i]
++        if in_string:
++            if escape:
++                escape = False
++            elif ch == '\\':
++                escape = True
++            elif ch == quote:
++                in_string = False
++        else:
++            if ch in ('"', "'"):
++                in_string = True
++                quote = ch
++            elif ch == '{':
++                depth += 1
++            elif ch == '}':
++                depth -= 1
++                if depth == 0:
++                    return source[start:i+1]
++        i += 1
++    raise AssertionError('BmmInferMeta closing brace not found')
++
++
++def _render_cpp_harness(function_source):
++    return f'''\
++#include <cstdint>
++#include <iostream>
++#include <stdexcept>
++#include <string>
++#include <vector>
++
++namespace phi {{
++using DDim = std::vector<int64_t>;
++
++template <typename T>
++std::vector<int64_t> vectorize(const T& value) {{ return value; }}
++
++inline DDim make_ddim(const std::vector<int64_t>& value) {{ return value; }}
++
++namespace errors {{
++template <typename... Args>
++std::string InvalidArgument(const std::string& message, Args&&...) {{
++  return message;
++}}
++}}  // namespace errors
++
++struct MetaTensor {{
++  DDim dims_value;
++  DDim output_dims;
++  int dtype_value = 1;
++  int layout_value = 2;
++
++  MetaTensor() = default;
++  explicit MetaTensor(DDim dims) : dims_value(std::move(dims)) {{}}
++  const DDim& dims() const {{ return dims_value; }}
++  void set_dims(const DDim& dims) {{ output_dims = dims; }}
++  void share_lod(const MetaTensor&) {{}}
++  int dtype() const {{ return dtype_value; }}
++  void set_dtype(int dtype) {{ dtype_value = dtype; }}
++  int layout() const {{ return layout_value; }}
++  void set_layout(int layout) {{ layout_value = layout; }}
++}};
++}}  // namespace phi
++
++#define PADDLE_ENFORCE_EQ(lhs, rhs, error) \
++  do {{ \
++    if (!((lhs) == (rhs))) {{ \
++      throw std::invalid_argument(error); \
++    }} \
++  }} while (0)
++
++namespace phi {{
++{function_source}
++}}  // namespace phi
++
++static std::vector<int64_t> parse_dims(const char* text) {{
++  std::vector<int64_t> result;
++  std::string token;
++  for (const char* p = text;; ++p) {{
++    const char ch = *p;
++    if (ch == ',' || ch == '\\0') {{
++      result.push_back(std::stoll(token));
++      token.clear();
++      if (ch == '\\0') break;
++    }} else {{
++      token.push_back(ch);
++    }}
++  }}
++  return result;
++}}
++
++int main(int argc, char** argv) {{
++  if (argc != 3) return 64;
++  try {{
++    phi::MetaTensor x(parse_dims(argv[1]));
++    phi::MetaTensor y(parse_dims(argv[2]));
++    phi::MetaTensor out;
++    phi::BmmInferMeta(x, y, &out);
++    for (std::size_t i = 0; i < out.output_dims.size(); ++i) {{
++      if (i) std::cout << ',';
++      std::cout << out.output_dims[i];
++    }}
++    std::cout << '\\n';
++    return 0;
++  }} catch (const std::exception& error) {{
++    std::cerr << error.what() << '\\n';
++    return 2;
++  }}
++}}
++'''
++
++
++def _compile_with_setuptools(source_path, cache_dir):
++    from setuptools._distutils import ccompiler
++    from setuptools._distutils import sysconfig as du_sysconfig
++    compiler = ccompiler.new_compiler()
++    du_sysconfig.customize_compiler(compiler)
++    extra = ['/std:c++17', '/EHsc'] if compiler.compiler_type == 'msvc' else ['-std=c++17']
++    objects = compiler.compile([str(source_path)], output_dir=str(cache_dir), extra_postargs=extra)
++    output_name = 'bmm_infermeta_harness'
++    compiler.link_executable(
++        objects,
++        output_name,
++        output_dir=str(cache_dir),
++        target_lang='c++',
++    )
++    candidates = [cache_dir / output_name, cache_dir / f'{output_name}.exe']
++    for candidate in candidates:
++        if candidate.exists():
++            return candidate
++    raise RuntimeError(f'compiler did not create executable: {candidates}')
++
++
++def _compile_native(source_path, cache_dir):
++    output = cache_dir / ('bmm_infermeta_harness.exe' if os.name == 'nt' else 'bmm_infermeta_harness')
++    for name in ('g++', 'clang++'):
++        compiler = shutil.which(name)
++        if compiler:
++            completed = subprocess.run(
++                [compiler, '-std=c++17', '-O2', str(source_path), '-o', str(output)],
++                capture_output=True,
++                text=True,
++                check=False,
++            )
++            if completed.returncode == 0:
++                return output
++            raise RuntimeError(completed.stderr or completed.stdout)
++    return _compile_with_setuptools(source_path, cache_dir)
++
++
++def _native_harness():
++    function_source = _extract_cpp_function()
++    source = _render_cpp_harness(function_source)
++    cache_root = Path(os.environ.get('PR56135_CPP_CACHE', '.pytest_cache/pr56135-native'))
++    key = hashlib.sha256((source + sys.platform).encode()).hexdigest()[:20]
++    cache_dir = (cache_root / key).resolve()
++    cache_dir.mkdir(parents=True, exist_ok=True)
++    source_path = cache_dir / 'bmm_infermeta_harness.cc'
++    source_path.write_text(source, encoding='utf-8', newline='\n')
++    exe_candidates = [cache_dir / 'bmm_infermeta_harness', cache_dir / 'bmm_infermeta_harness.exe']
++    for exe in exe_candidates:
++        if exe.exists():
++            return exe
++    try:
++        return _compile_with_setuptools(source_path, cache_dir)
++    except Exception as error:
++        raise AssertionError(
++            'Unable to compile the lightweight BmmInferMeta harness. '
++            'Install or expose a C++17 compiler; a full Paddle build is not required. '
++            f'Original error: {error}'
++        ) from error
++
++
++def _run_infermeta(x_shape, y_shape):
++    exe = _native_harness()
++    completed = subprocess.run(
++        [str(exe), ','.join(map(str, x_shape)), ','.join(map(str, y_shape))],
++        capture_output=True,
++        text=True,
++        check=False,
++    )
++    return completed.returncode, completed.stdout.strip(), completed.stderr.strip()
++
++
++def test_known_shape_behavior_remains_valid():
++    bmm, events = _load_checkout_bmm()
++    result = bmm(_Tensor([2, 3, 4]), _Tensor([2, 4, 5]))
++    assert result.dtype == 'float32'
++    assert len(events) == 1
++    rc, out, err = _run_infermeta([2, 3, 4], [2, 4, 5])
++    assert (rc, out, err) == (0, '2,3,5', '')
++
++
++def test_known_incompatible_shapes_are_rejected():
++    bmm, _ = _load_checkout_bmm()
++    with pytest.raises(ValueError, match="width must be equal"):
++        bmm(_Tensor([2, 3, 4]), _Tensor([2, 6, 5]))
++    with pytest.raises(ValueError, match="batch"):
++        bmm(_Tensor([2, 3, 4]), _Tensor([7, 4, 5]))
++    rc, _, _ = _run_infermeta([2, 3, 4], [2, 6, 5])
++    assert rc != 0
++
++
++def test_python_static_bmm_accepts_unknown_dimensions():
++    bmm, events = _load_checkout_bmm()
++    first = bmm(_Tensor([-1, 3, 4]), _Tensor([2, 4, 5]))
++    second = bmm(_Tensor([2, 3, -1]), _Tensor([2, 4, 5]))
++    assert first.dtype == second.dtype == 'float32'
++    assert len(events) == 2
++
++
++def test_cpp_infermeta_resolves_unknown_dimensions():
++    cases = [
++        ((-1, 3, 4), (2, 4, 5), '2,3,5'),
++        ((2, 3, -1), (2, 4, 5), '2,3,5'),
++        ((2, 3, 4), (-1, 4, 5), '2,3,5'),
++    ]
++    for x_shape, y_shape, expected in cases:
++        rc, out, err = _run_infermeta(x_shape, y_shape)
++        assert rc == 0, err
++        assert out == expected

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-56135/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-56135/tests/test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+python -m pytest test/legacy_test/test_bmm_dynamic_shape_contract.py -q


### PR DESCRIPTION
# 关联

- SWE-Paddle 共建 issue: https://github.com/PaddlePaddle/Paddle/issues/79447
- 来源 PR: https://github.com/PaddlePaddle/Paddle/pull/56135

## 说明

- 新增 SWE-Paddle 任务 `PaddlePaddle__Paddle-56135`
- 新增 `swe-paddle/tasks/PaddlePaddle__Paddle-56135/proposal.md`

## 验证结果

| 状态 | Known-shape P2P | Invalid-shape P2P | Python dynamic-shape F2P | C++ infermeta F2P |
| --- | --- | --- | --- | --- |
| Base + `tests/test.patch` | PASS | PASS | FAIL，符合预期 | FAIL，符合预期 |
| Base + test patch + `solution/code.patch` | PASS | PASS | PASS | PASS |

#### Base P2P：Known compatible shapes

```text
.                                                                        [100%]
1 passed in 11.82s
Base known-shape P2P exit code: 0
```

known compatible shapes 能够正常构建，并推导出正确的 `bmm` output shape。

#### Base P2P：Known incompatible shapes

```text
.                                                                        [100%]
1 passed in 0.30s
Base invalid-shape P2P exit code: 0
```

已知且不兼容的 batch dimension 或 matrix inner dimension 仍会被正确拒绝。

#### Base F2P：Python static graph dynamic shape

```text
F                                                                        [100%]
================================== FAILURES ===================================
______________ test_python_static_bmm_accepts_unknown_dimensions ______________

>       first = bmm(_Tensor([-1, 3, 4]), _Tensor([2, 4, 5]))

E       ValueError: x's batch (shape[0]) must be equal with
E       y's batch (shape[0]). But received x's shape:
E       (-1, 3, 4), y's shape: (2, 4, 5)

FAILED test/legacy_test/test_bmm_dynamic_shape_contract.py::test_python_static_bmm_accepts_unknown_dimensions
1 failed in 0.40s
```

#### Base F2P：C++ infermeta dynamic shape

```text
F                                                                        [100%]
================================== FAILURES ===================================
_______________ test_cpp_infermeta_resolves_unknown_dimensions ________________

>           assert rc == 0, err
E           AssertionError: Input(X) and Input(Y) must have the same
E           batch size in BmmOp
E           assert 2 == 0

FAILED test/legacy_test/test_bmm_dynamic_shape_contract.py::test_cpp_infermeta_resolves_unknown_dimensions
1 failed in 0.38s
```

#### Solution 测试

```text
Solution known-shape P2P:
1 passed in 3.76s

Solution invalid-shape P2P:
1 passed in 0.27s

Solution Python dynamic-shape F2P:
1 passed in 0.27s

Solution C++ infermeta F2P:
1 passed in 0.27s
```


#### `tests/test.sh`

```text
....                                                                     [100%]
4 passed in 0.35s
Solution tests/test.sh exit code: 0
```