### PR TITLE
[SWE-Paddle] Add task PaddlePaddle__Paddle-53534

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-53534/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-53534/README.md
@@ -1,0 +1,45 @@
+# PaddlePaddle__Paddle-53534
+
+This directory converts Paddle PR #53534 into a SWE-Paddle community task candidate.
+
+## Source
+
+| Field | Value |
+| --- | --- |
+| Repo | `PaddlePaddle/Paddle` |
+| PR | [53534](https://github.com/PaddlePaddle/Paddle/pull/53534) |
+| PR title | `【BugFix】fix err of api to_tensor, which caused by numpy version update` |
+| Base commit | `f74237cd73c35b8a63d7981a190a302d0ebcd03f` |
+| Merged at | `2023-05-08` |
+| Task type | `bug_fix` |
+| Resource | CPU |
+
+## Summary
+
+修复 static graph 中 `to_tensor` 在 NumPy 1.24+ array-construction semantics 下无法处理包含 Tensor/Variable 的 nested sequence，并改进 unsupported input type 的错误反馈。
+
+## Why This Is A Good SWE-Paddle Candidate
+
+- It covers a real compatibility regression caused by a NumPy behavior change.
+- It requires preserving static-graph Tensor/Variable handling while supporting nested sequences.
+- It validates output values, dtype conversion, `stop_gradient`, stack/squeeze behavior, and unsupported-type errors.
+- The verifier executes the checked-out `_to_tensor_static` implementation through Python AST with controlled Paddle and NumPy doubles.
+- The upstream unit-test change is intentionally excluded from `solution/code.patch`; this task uses an independent regression test.
+
+## Files
+
+- `proposal.md`: candidate proposal for maintainer triage.
+- `instruction.md`: self-contained problem statement for the coding agent.
+- `solution/code.patch`: production-only gold patch from the merged PR.
+- `tests/test.patch`: independent test patch exposing the target behavior.
+- `tests/test.sh`: minimal target test command.
+- `environment/README.md`: environment notes for reproduction.
+- `README.md`: task overview and verification entrypoint.
+
+## Verification
+
+```bash
+bash tests/test.sh
+```
+
+Expected behavior: applying `tests/test.patch` to `base_commit` should preserve existing numeric and Variable behavior while failing on NumPy 1.24-style nested-sequence conversion and unsupported mapping errors; applying both `tests/test.patch` and `solution/code.patch` should pass all target tests.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-53534/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-53534/environment/README.md
@@ -1,0 +1,29 @@
+# Environment Notes
+
+This candidate is part of the SWE-Paddle community task set.
+
+## Expected Environment
+
+- Repository: `PaddlePaddle/Paddle`
+- Base commit: `f74237cd73c35b8a63d7981a190a302d0ebcd03f`
+- Resource: CPU
+- GPU required: no
+- Build path: Paddle source checkout at the base commit. No Paddle rebuild or wheel installation is required; the verifier executes the checked-out Python implementation through AST.
+
+The verifier uses a controlled NumPy proxy to reproduce the NumPy 1.24+ behavior where array construction for a mixed Tensor/Variable sequence raises immediately. Controlled Paddle doubles implement `assign`, `cast`, `stack`, and `squeeze` so the test validates conversion behavior without importing a historical Paddle package.
+
+## Run Order
+
+1. Check out `PaddlePaddle/Paddle` at the base commit.
+2. Apply `tests/test.patch`.
+3. Run `bash tests/test.sh`; the target behavior should fail before the fix.
+4. Apply `solution/code.patch`.
+5. Run `bash tests/test.sh` again; the target behavior should pass after the gold patch.
+
+## Minimal Test Command
+
+```bash
+bash tests/test.sh
+```
+
+The verifier is responsible for deriving stable F2P and P2P node IDs from repeated runs.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-53534/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-53534/instruction.md
@@ -19,10 +19,6 @@
 - 了解 Paddle static graph 与 Tensor/Variable
 - 了解 dtype conversion 和 nested sequence handling
 
-## 参考资料
-
-- https://github.com/PaddlePaddle/Paddle/pull/53534
-
 ## Acceptance Criteria
 
 - The behavior described above should be fixed.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-53534/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-53534/instruction.md
@@ -1,0 +1,30 @@
+# 修复 static graph 中 to_tensor 的 NumPy 兼容性
+
+## 详细描述
+
+在 static graph 中，`to_tensor` 接收包含 Tensor/Variable 的 list 或 tuple 时，较新 NumPy 版本可能在构造 array 阶段直接报错，而不是返回 object array。这会导致原本可转换的 nested sequence 无法生成 Tensor。
+
+对于 dict 等不支持的输入类型，当前流程也可能在较晚阶段产生不清晰或不稳定的异常。
+
+## 验收说明
+
+- 包含 Tensor/Variable 的 nested sequence 在 NumPy 1.24+ semantics 下应正常转换
+- 转换结果应保留预期 value、dtype 和 `stop_gradient`
+- 普通 numeric sequence、已有 Variable 和显式 dtype conversion 的行为不得退化
+- unsupported input type 应给出明确且稳定的错误信息
+
+## 技术要求
+
+- 熟悉 Python 和 NumPy
+- 了解 Paddle static graph 与 Tensor/Variable
+- 了解 dtype conversion 和 nested sequence handling
+
+## 参考资料
+
+- https://github.com/PaddlePaddle/Paddle/pull/53534
+
+## Acceptance Criteria
+
+- The behavior described above should be fixed.
+- Existing valid behavior should remain unchanged.
+- Do not satisfy the task by deleting tests, weakening assertions, or bypassing validation broadly.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-53534/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-53534/proposal.md
@@ -1,0 +1,55 @@
+# Task Proposal: PaddlePaddle__Paddle-53534
+
+## 1. 来源信息
+
+- Instance ID：`PaddlePaddle__Paddle-53534`
+- PR 链接：https://github.com/PaddlePaddle/Paddle/pull/53534
+- PR 标题：`【BugFix】fix err of api to_tensor, which caused by numpy version update`
+- `base_commit`：`f74237cd73c35b8a63d7981a190a302d0ebcd03f`
+- merged 时间：`2023-05-08`
+- 你的身份：熟悉该模块的 contributor
+- 后续联系人：TBD
+
+## 2. 问题一句话
+
+修复 static graph 中 `to_tensor` 在 NumPy 1.24+ semantics 下无法转换包含 Tensor/Variable 的 nested sequence，并规范 unsupported input type 的错误反馈。
+
+## 3. 为什么适合作为 SWE-Paddle 样本
+
+- **真实性**：该任务来自已合入的 Paddle API BugFix PR，不是合成任务。
+- **代表性**：它覆盖 static graph、NumPy compatibility、Tensor/Variable recursion、dtype conversion 和 API error contract。
+- **边界清楚**：上游 merged commit 只修改一个 production file 和一个 unit-test file；SWE-Paddle solution 仅保留 production change，并使用独立 test patch。
+- **非平凡性**：修复需要同时兼容 NumPy 1.24+ 的直接异常和旧版本可能产生的 object array，同时保持既有 dtype 与 Variable 路径不变。
+- **区分度信号**：该任务能够区分只捕获 NumPy 异常的局部修复，与同时正确处理 recursive conversion、dtype、stack/squeeze 和 unsupported type contract 的完整修复。
+
+## 4. 任务类型和标签
+
+- 任务类型：`bug_fix`
+- 执行后端：`cpu`
+- 设备范围：`cpu_only`
+- 模块标签：`[to_tensor, static_graph, numpy, nested_sequence, dtype, python_api]`
+
+## 5. 验证思路
+
+- 目标测试命令：`bash tests/test.sh`
+- 目标测试文件：`test/legacy_test/test_to_tensor_numpy124_contract.py`
+- 修复前预期：numeric sequence 与 Variable/dtype P2P 应 pass；NumPy 1.24-style nested sequence 和 unsupported mapping F2P 应 fail。
+- 修复后预期：继续应用 `solution/code.patch` 后，两个 P2P 与两个 F2P 均应 pass。
+- P2P 候选：普通 float sequence 的 default dtype conversion，以及已有 Variable 的 passthrough/explicit cast。
+
+## 6. 环境与资源
+
+- 资源需求：CPU
+- Paddle 来源：`PaddlePaddle/Paddle` source checkout at `base_commit`
+- 是否能提供 Docker：暂无
+- patch 类型：Python-only production change
+- 环境建议：通过 AST 加载 source checkout 中的 `_to_tensor_static`，使用 controlled NumPy proxy 模拟 NumPy 1.24+ array-construction error，并使用 Paddle operation doubles 验证 observable behavior
+- 最小测试命令：`bash tests/test.sh`
+- 是否有 oracle 日志：由 SWE-Paddle verifier 结果另行维护
+
+## 7. 风险自查
+
+- 泄露风险：正式 `instruction.md` 描述 observable behavior，不指出具体 try/except、recursive helper 或修改行。
+- 环境风险：不依赖 Paddle wheel、GPU、C++ build、distributed runtime 或 external dataset。
+- flaky 风险：NumPy 1.24+ error 由 controlled proxy 稳定模拟，不依赖本机实际 NumPy minor version。
+- 拆分风险：nested sequence compatibility、dtype behavior 和 error contract 都属于同一个 `_to_tensor_static` conversion flow，适合作为一个样本。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-53534/solution/code.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-53534/solution/code.patch
@@ -1,0 +1,91 @@
+diff --git a/python/paddle/tensor/creation.py b/python/paddle/tensor/creation.py
+index ee546ffe17ea0d1f88d284bd418373c74cea7335..6fe3f97cd656ab107f1029d33f3cd55e695b0070 100644
+--- a/python/paddle/tensor/creation.py
++++ b/python/paddle/tensor/creation.py
+@@ -646,8 +646,10 @@ def _to_tensor_non_static(data, dtype=None, place=None, stop_gradient=True):
+ 
+ def _to_tensor_static(data, dtype=None, stop_gradient=None):
+ 
+-    if isinstance(data, Variable) and (dtype is None or dtype == data.dtype):
++    if isinstance(data, Variable):
+         output = data
++        if dtype is not None and dtype != data.dtype:
++            output = paddle.cast(output, dtype)
+     else:
+         if isinstance(data, np.number):  # Special case for numpy scalars
+             data = np.array(data)
+@@ -656,17 +658,37 @@ def _to_tensor_static(data, dtype=None, stop_gradient=None):
+             if np.isscalar(data) and not isinstance(data, str):
+                 data = np.array(data)
+             elif isinstance(data, (list, tuple)):
+-                data = np.array(data)
++                try:
++                    '''
++                    In numpy version >= 1.24.0, case like:
++                        np.array([Variable, 1, 2])
++                    is not supported, it will raise error (numpy returns an numpy array with dtype='object' in version <= 1.23.5)
++
++                    Thus, process nested structure in except block
++                    '''
++                    data = np.array(data)
++
++                    # for numpy version <= 1.23.5
++                    if data.dtype == 'object':
++                        raise RuntimeError("Numpy get dtype `object`.")
++
++                except:
++                    to_stack_list = [None] * len(data)
++                    for idx, d in enumerate(data):
++                        to_stack_list[idx] = _to_tensor_static(
++                            d, dtype, stop_gradient
++                        )
++                    data = paddle.stack(to_stack_list)
++                    data = paddle.squeeze(data, -1)
+ 
+-            if (
+-                isinstance(data, np.ndarray)
+-                and not dtype
+-                and data.dtype != 'object'
+-            ):
+-                if data.dtype in ['float16', 'float32', 'float64']:
+-                    data = data.astype(paddle.get_default_dtype())
+-                elif data.dtype in ['int32']:
+-                    data = data.astype('int64')
++            else:
++                raise RuntimeError(
++                    f"Do not support transform type `{type(data)}` to tensor"
++                )
++
++            # fix numpy default dtype
++            if data.dtype in ['float16', 'float32', 'float64']:
++                data = data.astype(paddle.get_default_dtype())
+ 
+         if dtype:
+             target_dtype = dtype
+@@ -674,24 +696,10 @@ def _to_tensor_static(data, dtype=None, stop_gradient=None):
+             target_dtype = data.dtype
+         else:
+             target_dtype = paddle.get_default_dtype()
+-
+         target_dtype = convert_dtype(target_dtype)
+ 
+-        if (
+-            isinstance(data, np.ndarray)
+-            and len(data.shape) > 0
+-            and any(isinstance(x, Variable) for x in data)
+-        ):
+-            to_stack_list = [None] * data.shape[0]
+-            for idx, d in enumerate(data):
+-                to_stack_list[idx] = _to_tensor_static(d, dtype, stop_gradient)
+-            data = paddle.stack(to_stack_list)
+-            data = paddle.squeeze(data, -1)
+-
+-        if not isinstance(data, Variable):
+-            output = assign(data)
+-        else:
+-            output = data
++        output = assign(data)
++
+         if convert_dtype(output.dtype) != target_dtype:
+             output = paddle.cast(output, target_dtype)
+ 

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-53534/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-53534/tests/test.patch
@@ -1,0 +1,208 @@
+diff --git a/test/legacy_test/test_to_tensor_numpy124_contract.py b/test/legacy_test/test_to_tensor_numpy124_contract.py
+new file mode 100644
+index 00000000000000..d84d97523827f0
+--- /dev/null
++++ b/test/legacy_test/test_to_tensor_numpy124_contract.py
+@@ -0,0 +1,202 @@
++# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++
++import ast
++import copy
++import types
++from pathlib import Path
++
++import numpy as _real_numpy
++import pytest
++
++
++_REPO_ROOT = Path(__file__).resolve().parents[2]
++_SOURCE_PATH = (
++    _REPO_ROOT / 'python' / 'paddle' / 'tensor' / 'creation.py'
++)
++
++
++class _Variable:
++    def __init__(self, value, dtype=None):
++        self.value = _real_numpy.array(value, dtype=dtype)
++        self.dtype = str(self.value.dtype)
++        self.shape = self.value.shape
++        self.stop_gradient = None
++
++    def __len__(self):
++        return len(self.value)
++
++    def __getitem__(self, index):
++        return self.value[index]
++
++    def astype(self, dtype):
++        return _Variable(self.value.astype(str(dtype)))
++
++
++class _Numpy124Proxy:
++    number = _real_numpy.number
++    ndarray = _real_numpy.ndarray
++    isscalar = staticmethod(_real_numpy.isscalar)
++
++    def array(self, data, *args, **kwargs):
++        if isinstance(data, (list, tuple)) and any(
++            isinstance(item, _Variable) for item in data
++        ):
++            raise ValueError(
++                'setting an array element with a sequence'
++            )
++        return _real_numpy.array(data, *args, **kwargs)
++
++    def __getattr__(self, name):
++        return getattr(_real_numpy, name)
++
++
++def _load_checkout_function():
++    source = _SOURCE_PATH.read_text(encoding='utf-8')
++    tree = ast.parse(source, filename=str(_SOURCE_PATH))
++
++    target = None
++    for node in tree.body:
++        if (
++            isinstance(node, ast.FunctionDef)
++            and node.name == '_to_tensor_static'
++        ):
++            target = copy.deepcopy(node)
++            target.decorator_list = []
++            break
++
++    assert target is not None
++
++    events = []
++
++    def assign(data):
++        events.append(('assign', type(data).__name__))
++        if isinstance(data, _Variable):
++            return _Variable(data.value.copy(), data.dtype)
++        if isinstance(data, dict):
++            raise TypeError('assign received unsupported data')
++        return _Variable(_real_numpy.array(data))
++
++    def cast(data, dtype):
++        events.append(('cast', data.dtype, str(dtype)))
++        return _Variable(data.value.astype(str(dtype)))
++
++    def stack(items):
++        events.append(('stack', len(items)))
++        return _Variable(
++            _real_numpy.stack([item.value for item in items], axis=0)
++        )
++
++    def squeeze(data, axis):
++        events.append(('squeeze', axis))
++        return _Variable(_real_numpy.squeeze(data.value, axis=axis))
++
++    paddle_double = types.SimpleNamespace(
++        get_default_dtype=lambda: 'float32',
++        cast=cast,
++        stack=stack,
++        squeeze=squeeze,
++    )
++
++    namespace = {
++        'Variable': _Variable,
++        'np': _Numpy124Proxy(),
++        'paddle': paddle_double,
++        'assign': assign,
++        'convert_dtype': lambda dtype: str(dtype),
++    }
++
++    module = ast.Module(body=[target], type_ignores=[])
++    ast.fix_missing_locations(module)
++    exec(
++        compile(module, str(_SOURCE_PATH), 'exec'),
++        namespace,
++        namespace,
++    )
++
++    return namespace['_to_tensor_static'], events
++
++
++def test_numeric_sequence_behavior_remains_valid():
++    function, events = _load_checkout_function()
++
++    result = function(
++        [1.0, 2.0, 3.0],
++        stop_gradient=False,
++    )
++
++    _real_numpy.testing.assert_array_equal(
++        result.value,
++        _real_numpy.array([1.0, 2.0, 3.0], dtype='float32'),
++    )
++    assert result.dtype == 'float32'
++    assert result.stop_gradient is False
++    assert not any(event[0] in {'stack', 'squeeze'} for event in events)
++
++
++def test_variable_passthrough_and_explicit_cast_remain_valid():
++    function, events = _load_checkout_function()
++    source = _Variable([1.5], dtype='float32')
++
++    same = function(source, stop_gradient=True)
++    converted = function(
++        source,
++        dtype='float64',
++        stop_gradient=False,
++    )
++
++    assert same is source
++    assert same.stop_gradient is True
++    assert converted is not source
++    assert converted.dtype == 'float64'
++    assert converted.stop_gradient is False
++    _real_numpy.testing.assert_array_equal(
++        converted.value,
++        _real_numpy.array([1.5], dtype='float64'),
++    )
++    assert ('cast', 'float32', 'float64') in events
++
++
++def test_nested_variable_sequence_uses_recursive_conversion():
++    function, events = _load_checkout_function()
++
++    result = function(
++        [
++            _Variable([1.0], dtype='float32'),
++            _Variable([2], dtype='int64'),
++            [1],
++        ],
++        dtype='float32',
++        stop_gradient=False,
++    )
++
++    _real_numpy.testing.assert_array_equal(
++        result.value,
++        _real_numpy.array([1.0, 2.0, 1.0], dtype='float32'),
++    )
++    assert result.shape == (3,)
++    assert result.dtype == 'float32'
++    assert result.stop_gradient is False
++    assert ('stack', 3) in events
++    assert ('squeeze', -1) in events
++
++
++def test_unsupported_mapping_has_clear_error():
++    function, _ = _load_checkout_function()
++
++    with pytest.raises(
++        RuntimeError,
++        match=r"Do not support transform type `<class 'dict'>` to tensor",
++    ):
++        function({1: 1})

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-53534/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-53534/tests/test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+python -m pytest test/legacy_test/test_to_tensor_numpy124_contract.py -q


### PR DESCRIPTION
## 关联

- SWE-Paddle 共建 issue: https://github.com/PaddlePaddle/Paddle/issues/79447
- 来源 PR: https://github.com/PaddlePaddle/Paddle/pull/53534

## 说明

- 新增 SWE-Paddle 任务 `PaddlePaddle__Paddle-53534`


## 验证设计

| 状态 | Numeric P2P | Variable/dtype P2P | Nested sequence F2P | Mapping error F2P |
| --- | --- | --- | --- | --- |
| Base + `tests/test.patch` | PASS | PASS | FAIL，符合预期 | FAIL，符合预期 |
| Base + test patch + `solution/code.patch` | PASS | PASS | PASS | PASS |

#### P2P：Numeric sequence

```
1 passed in 0.17s
.                                                                        [100%]
```

#### P2P：Variable passthrough 与 explicit cast

```
1 passed in 0.14s
.                                                                        [100%]
```

#### F2P：NumPy 1.24-style nested sequence

```
test\legacy_test\test_to_tensor_numpy124_contract.py:56: ValueError
=========================== short test summary info ===========================
FAILED test/legacy_test/test_to_tensor_numpy124_contract.py::test_nested_variable_sequence_uses_recursive_conversion
1 failed in 0.28s
F                                                                        [100%]
```

#### F2P：Unsupported mapping

```text
test\legacy_test\test_to_tensor_numpy124_contract.py:88: TypeError
=========================== short test summary info ===========================
FAILED test/legacy_test/test_to_tensor_numpy124_contract.py::test_unsupported_mapping_has_clear_error
1 failed in 0.32s
..FF                                                                     [100%]
```

## Solution tests/test.sh

```text
.                                                                        [100%]
1 passed in 0.15s
.                                                                        [100%]
1 passed in 0.11s
.                                                                        [100%]
1 passed in 0.11s
.                                                                        [100%]
1 passed in 0.11s
....                                                                     [100%]
4 passed in 0.16s
....                                                                     [100%]
4 passed in 0.19s
```
