### PR TITLE
[SWE-Paddle] Add task PaddlePaddle__Paddle-50086

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-50086/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-50086/README.md
@@ -1,0 +1,45 @@
+# PaddlePaddle__Paddle-50086
+
+This directory converts Paddle PR #50086 into a SWE-Paddle community task candidate.
+
+## Source
+
+| Field | Value |
+| --- | --- |
+| Repo | `PaddlePaddle/Paddle` |
+| PR | [50086](https://github.com/PaddlePaddle/Paddle/pull/50086) |
+| PR title | `[BugFix][ConditionalBlock] fix judgement about scope validation` |
+| Base commit | `fe811625db37300f74064a52e80c130d7ae347ed` |
+| Merged at | `2023-02-09` |
+| Task type | `bug_fix` |
+| Resource | CPU |
+
+## Summary
+
+修复 `ConditionalBlock` 重复执行时复用已经失效的 child scope，导致 new executor 使用无效 execution scope 的问题。
+
+## Why This Is A Good SWE-Paddle Candidate
+
+- It covers C++ control-flow runtime state and scope lifecycle.
+- It requires reasoning about cached pointers, parent-child scope ownership, and repeated execution.
+- It preserves first-run and legacy-executor behavior while changing the new-executor lifecycle contract.
+- The verifier compiles the checked-out scope-selection logic in a lightweight native C++17 harness.
+- No full Paddle build, wheel installation, GPU, or distributed runtime is required.
+
+## Files
+
+- `proposal.md`: candidate proposal for maintainer triage.
+- `instruction.md`: self-contained problem statement for the coding agent.
+- `solution/code.patch`: gold patch from the merged PR.
+- `tests/test.patch`: independent test patch exposing the target behavior.
+- `tests/test.sh`: minimal target test command.
+- `environment/README.md`: environment notes for reproduction.
+- `README.md`: task overview and verification entrypoint.
+
+## Verification
+
+```bash
+bash tests/test.sh
+```
+
+Expected behavior: applying `tests/test.patch` to `base_commit` should preserve first-run and legacy-executor behavior while failing repeated-execution and stale-scope lifecycle tests; applying both `tests/test.patch` and `solution/code.patch` should pass all target tests.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-50086/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-50086/environment/README.md
@@ -1,0 +1,29 @@
+# Environment Notes
+
+This candidate is part of the SWE-Paddle community task set.
+
+## Expected Environment
+
+- Repository: `PaddlePaddle/Paddle`
+- Base commit: `fe811625db37300f74064a52e80c130d7ae347ed`
+- Resource: CPU
+- GPU required: no
+- Build path: Paddle source checkout at the base commit. A full Paddle build is not required; the verifier compiles a lightweight C++17 harness containing the checked-out scope-selection logic.
+
+The harness provides controlled `Scope` and scope-variable doubles. It models child creation, repeated execution, legacy executor behavior, and a stale cached child whose parent now contains a different valid child. The compiled executable is cached by source hash.
+
+## Run Order
+
+1. Check out `PaddlePaddle/Paddle` at the base commit.
+2. Apply `tests/test.patch`.
+3. Run `bash tests/test.sh`; the target behavior should fail before the fix.
+4. Apply `solution/code.patch`.
+5. Run `bash tests/test.sh` again; the target behavior should pass after the gold patch.
+
+## Minimal Test Command
+
+```bash
+bash tests/test.sh
+```
+
+The verifier is responsible for deriving stable F2P and P2P node IDs from repeated runs.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-50086/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-50086/instruction.md
@@ -1,0 +1,27 @@
+# 修复 ConditionalBlock 重复执行时的 scope lifecycle
+
+## 详细描述
+
+`ConditionalBlock` 可能在同一个 operator instance 上重复执行。外层 executor 的生命周期变化可能使上一次执行使用的 child scope 不再有效，但后续执行仍可能继续使用旧 scope，从而访问失效的 execution state。
+
+## 验收说明
+
+- 每次需要执行 sub-block 时都应获得当前有效且独立的 child scope
+- 外层 scope 的 children 被清理或替换后，不得继续使用此前的失效 scope
+- 首次执行以及 legacy executor 下的现有行为不得退化
+
+## 技术要求
+
+- 熟悉 C++
+- 了解 Paddle control-flow operator 和 Scope lifecycle
+- 了解 pointer ownership、cached runtime state 和 executor reuse
+
+## 参考资料
+
+- https://github.com/PaddlePaddle/Paddle/pull/50086
+
+## Acceptance Criteria
+
+- The behavior described above should be fixed.
+- Existing valid behavior should remain unchanged.
+- Do not satisfy the task by deleting tests, weakening assertions, or bypassing validation broadly.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-50086/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-50086/instruction.md
@@ -16,10 +16,6 @@
 - 了解 Paddle control-flow operator 和 Scope lifecycle
 - 了解 pointer ownership、cached runtime state 和 executor reuse
 
-## 参考资料
-
-- https://github.com/PaddlePaddle/Paddle/pull/50086
-
 ## Acceptance Criteria
 
 - The behavior described above should be fixed.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-50086/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-50086/proposal.md
@@ -1,0 +1,55 @@
+# Task Proposal: PaddlePaddle__Paddle-50086
+
+## 1. 来源信息
+
+- Instance ID：`PaddlePaddle__Paddle-50086`
+- PR 链接：https://github.com/PaddlePaddle/Paddle/pull/50086
+- PR 标题：`[BugFix][ConditionalBlock] fix judgement about scope validation`
+- `base_commit`：`fe811625db37300f74064a52e80c130d7ae347ed`
+- merged 时间：`2023-02-09`
+- 你的身份：熟悉该模块的 contributor
+- 后续联系人：TBD
+
+## 2. 问题一句话
+
+修复 `ConditionalBlock` 重复执行时可能复用已失效 child scope，导致 new executor 使用无效 execution state 的问题。
+
+## 3. 为什么适合作为 SWE-Paddle 样本
+
+- **真实性**：该任务来自已合入的 Paddle control-flow BugFix PR，不是合成任务。
+- **代表性**：它覆盖 C++ operator runtime、Scope ownership、executor cache 和 repeated execution lifecycle。
+- **边界清楚**：production change 只修改 `conditional_block_op.cc` 中 sub-block scope 的选择逻辑。
+- **非平凡性**：问题不能只通过判断 parent scope 是否仍有 children 解决，因为非空 children 无法证明缓存的具体 child scope 仍然有效。
+- **区分度信号**：该任务能够区分只处理 empty-scope 特例的局部修复，与在 repeated execution 和 stale cached pointer 场景下都保持 scope lifecycle 正确的完整修复。
+
+## 4. 任务类型和标签
+
+- 任务类型：`bug_fix`
+- 执行后端：`cpu`
+- 设备范围：`cpu_only`
+- 模块标签：`[conditional_block, control_flow, scope, executor, lifecycle, cpp]`
+
+## 5. 验证思路
+
+- 目标测试命令：`bash tests/test.sh`
+- 目标测试文件：`test/legacy_test/test_conditional_block_scope_lifecycle.py`
+- 修复前预期：首次执行和 legacy executor P2P 应 pass；new executor repeated execution 与 stale cached scope F2P 应 fail。
+- 修复后预期：继续应用 `solution/code.patch` 后，P2P 与两个 F2P 均应 pass。
+- P2P 候选：首次运行创建有效 child scope，以及 legacy executor 重复运行仍创建独立 scope。
+
+## 6. 环境与资源
+
+- 资源需求：CPU
+- Paddle 来源：`PaddlePaddle/Paddle` source checkout at `base_commit`
+- 是否能提供 Docker：暂无
+- patch 类型：C++ control-flow runtime change
+- 环境建议：无需完整编译 Paddle；verifier 从 checkout 中提取 scope-selection statement block，并在 lightweight C++17 harness 中执行真实控制流
+- 最小测试命令：`bash tests/test.sh`
+- 是否有 oracle 日志：由 SWE-Paddle verifier 结果另行维护
+
+## 7. 风险自查
+
+- 泄露风险：正式 `instruction.md` 描述 repeated execution 的 observable lifecycle contract，不指出具体条件表达式或修改行。
+- 环境风险：需要可用的 C++17 compiler，但不需要 Paddle source build、wheel、CUDA 或 GPU。
+- flaky 风险：测试使用 deterministic fake Scope ownership model，不依赖真实 allocator address reuse 或并发时序。
+- 拆分风险：该 PR 只修改一个 production file，目标集中在同一个 scope-selection behavior。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-50086/solution/code.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-50086/solution/code.patch
@@ -1,0 +1,24 @@
+diff --git a/paddle/fluid/operators/controlflow/conditional_block_op.cc b/paddle/fluid/operators/controlflow/conditional_block_op.cc
+index f11bf6612c8cab0131a20d1e08aaa1776ffddacf..f44a93e0c3549a7505b0a5772256ec88a636bd03 100644
+--- a/paddle/fluid/operators/controlflow/conditional_block_op.cc
++++ b/paddle/fluid/operators/controlflow/conditional_block_op.cc
+@@ -78,17 +78,8 @@ class ConditionalBlockOp : public ConditionalOp {
+               "got a null Scope variable. Please set the Scope variable."));
+ 
+       auto *scopes = scope_var->GetMutable<std::vector<framework::Scope *>>();
+-
+-      if (scopes->size() == 0 || !FLAGS_control_flow_use_new_executor) {
+-        scopes->resize(1);
+-        scopes->front() = &scope.NewScope();
+-      }
+-
+-      // We need to know whether the scope we cached is still valid.
+-      // If not, we need to create a new one.
+-      if (scope.kids().size() == 0) {
+-        scopes->front() = &scope.NewScope();
+-      }
++      scopes->resize(1);
++      scopes->front() = &scope.NewScope();
+ 
+       auto &cur_scope = *scopes->front();
+ #ifdef PADDLE_WITH_MKLDNN

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-50086/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-50086/tests/test.patch
@@ -1,0 +1,325 @@
+diff --git a/test/legacy_test/test_conditional_block_scope_lifecycle.py b/test/legacy_test/test_conditional_block_scope_lifecycle.py
+new file mode 100644
+index 00000000000000..bfe210ec11e2b3
+--- /dev/null
++++ b/test/legacy_test/test_conditional_block_scope_lifecycle.py
+@@ -0,0 +1,319 @@
++# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++
++import hashlib
++import os
++import shutil
++import subprocess
++import sys
++from pathlib import Path
++
++
++_REPO_ROOT = Path(__file__).resolve().parents[2]
++_SOURCE_PATH = (
++    _REPO_ROOT
++    / 'paddle'
++    / 'fluid'
++    / 'operators'
++    / 'controlflow'
++    / 'conditional_block_op.cc'
++)
++
++
++def _extract_scope_selection():
++    source = _SOURCE_PATH.read_text(encoding='utf-8')
++    start = source.index('auto *scopes =')
++    end_marker = 'auto &cur_scope = *scopes->front();'
++    end = source.index(end_marker, start) + len(end_marker)
++    return source[start:end]
++
++
++def _render_harness(statement_block):
++    template = r'''
++#include <cstddef>
++#include <iostream>
++#include <memory>
++#include <string>
++#include <utility>
++#include <vector>
++
++bool FLAGS_control_flow_use_new_executor = true;
++
++namespace framework {
++
++class Scope {
++ public:
++  explicit Scope(int id = 0) : id_(id) {}
++
++  Scope& NewScope() const {
++    auto child = std::make_unique<Scope>(next_child_id_++);
++    Scope* pointer = child.get();
++    storage_.push_back(std::move(child));
++    kids_.push_back(pointer);
++    return *pointer;
++  }
++
++  const std::vector<Scope*>& kids() const { return kids_; }
++
++  void RetireVisibleChildrenAndAddReplacement() const {
++    for (Scope* child : kids_) {
++      child->alive_ = false;
++    }
++    kids_.clear();
++    NewScope();
++  }
++
++  int id() const { return id_; }
++  bool alive() const { return alive_; }
++
++ private:
++  int id_ = 0;
++  bool alive_ = true;
++  mutable int next_child_id_ = 1;
++  mutable std::vector<std::unique_ptr<Scope>> storage_;
++  mutable std::vector<Scope*> kids_;
++};
++
++}  // namespace framework
++
++class Variable {
++ public:
++  template <typename T>
++  T* GetMutable();
++
++  std::vector<framework::Scope*> scopes;
++};
++
++template <>
++std::vector<framework::Scope*>*
++Variable::GetMutable<std::vector<framework::Scope*>>() {
++  return &scopes;
++}
++
++framework::Scope* SelectScope(const framework::Scope& scope,
++                              Variable* scope_var) {
++__STATEMENT_BLOCK__
++  return &cur_scope;
++}
++
++void PrintResult(framework::Scope* first,
++                 framework::Scope* second,
++                 const framework::Scope& parent,
++                 const Variable& variable) {
++  std::cout << first->id() << ','
++            << (second ? second->id() : -1) << ','
++            << first->alive() << ','
++            << (second ? second->alive() : false) << ','
++            << parent.kids().size() << ','
++            << variable.scopes.size() << ','
++            << (first == second) << '\n';
++}
++
++int main(int argc, char** argv) {
++  if (argc != 2) return 64;
++
++  const std::string scenario = argv[1];
++  framework::Scope parent;
++  Variable variable;
++
++  if (scenario == "first") {
++    FLAGS_control_flow_use_new_executor = true;
++    framework::Scope* first = SelectScope(parent, &variable);
++    PrintResult(first, nullptr, parent, variable);
++    return 0;
++  }
++
++  if (scenario == "legacy") {
++    FLAGS_control_flow_use_new_executor = false;
++    framework::Scope* first = SelectScope(parent, &variable);
++    framework::Scope* second = SelectScope(parent, &variable);
++    PrintResult(first, second, parent, variable);
++    return 0;
++  }
++
++  if (scenario == "repeated") {
++    FLAGS_control_flow_use_new_executor = true;
++    framework::Scope* first = SelectScope(parent, &variable);
++    framework::Scope* second = SelectScope(parent, &variable);
++    PrintResult(first, second, parent, variable);
++    return 0;
++  }
++
++  if (scenario == "stale") {
++    FLAGS_control_flow_use_new_executor = true;
++    framework::Scope* first = SelectScope(parent, &variable);
++    parent.RetireVisibleChildrenAndAddReplacement();
++    framework::Scope* second = SelectScope(parent, &variable);
++    PrintResult(first, second, parent, variable);
++    return 0;
++  }
++
++  return 65;
++}
++'''
++    return template.replace('__STATEMENT_BLOCK__', statement_block)
++
++
++def _compile_with_setuptools(source_path, cache_dir):
++    from setuptools._distutils import ccompiler
++    from setuptools._distutils import sysconfig as du_sysconfig
++
++    compiler = ccompiler.new_compiler()
++    du_sysconfig.customize_compiler(compiler)
++    extra = (
++        ['/std:c++17', '/EHsc']
++        if compiler.compiler_type == 'msvc'
++        else ['-std=c++17']
++    )
++    objects = compiler.compile(
++        [str(source_path)],
++        output_dir=str(cache_dir),
++        extra_postargs=extra,
++    )
++    output_name = 'conditional_scope_harness'
++    compiler.link_executable(
++        objects,
++        output_name,
++        output_dir=str(cache_dir),
++        target_lang='c++',
++    )
++
++    for candidate in (
++        cache_dir / output_name,
++        cache_dir / f'{output_name}.exe',
++    ):
++        if candidate.exists():
++            return candidate
++
++    raise RuntimeError('setuptools compiler did not create executable')
++
++
++def _compile_native(source_path, cache_dir):
++    output = cache_dir / (
++        'conditional_scope_harness.exe'
++        if os.name == 'nt'
++        else 'conditional_scope_harness'
++    )
++
++    for name in ('g++', 'clang++'):
++        compiler = shutil.which(name)
++        if compiler:
++            completed = subprocess.run(
++                [
++                    compiler,
++                    '-std=c++17',
++                    '-O2',
++                    str(source_path),
++                    '-o',
++                    str(output),
++                ],
++                capture_output=True,
++                text=True,
++                check=False,
++            )
++            if completed.returncode == 0:
++                return output
++            raise RuntimeError(completed.stderr or completed.stdout)
++
++    return _compile_with_setuptools(source_path, cache_dir)
++
++
++def _harness():
++    statements = _extract_scope_selection()
++    source = _render_harness(statements)
++    cache_root = Path(
++        os.environ.get(
++            'PR50086_CPP_CACHE',
++            '.pytest_cache/pr50086-native',
++        )
++    )
++    key = hashlib.sha256(
++        (source + sys.platform).encode()
++    ).hexdigest()[:20]
++    cache_dir = (cache_root / key).resolve()
++    cache_dir.mkdir(parents=True, exist_ok=True)
++
++    source_path = cache_dir / 'conditional_scope_harness.cc'
++    source_path.write_text(source, encoding='utf-8', newline='\n')
++
++    for candidate in (
++        cache_dir / 'conditional_scope_harness',
++        cache_dir / 'conditional_scope_harness.exe',
++    ):
++        if candidate.exists():
++            return candidate
++
++    try:
++        return _compile_native(source_path, cache_dir)
++    except Exception as error:
++        raise AssertionError(
++            'Unable to compile the lightweight ConditionalBlock scope '
++            'harness. Install or expose a C++17 compiler; a full Paddle '
++            f'build is not required. Original error: {error}'
++        ) from error
++
++
++def _run_scenario(name):
++    completed = subprocess.run(
++        [str(_harness()), name],
++        capture_output=True,
++        text=True,
++        check=False,
++    )
++    assert completed.returncode == 0, completed.stderr
++    values = [int(value) for value in completed.stdout.strip().split(',')]
++    return {
++        'first_id': values[0],
++        'second_id': values[1],
++        'first_alive': bool(values[2]),
++        'second_alive': bool(values[3]),
++        'visible_children': values[4],
++        'scope_slots': values[5],
++        'same_pointer': bool(values[6]),
++    }
++
++
++def test_first_run_and_legacy_executor_behavior_remain_valid():
++    first = _run_scenario('first')
++    legacy = _run_scenario('legacy')
++
++    assert first['first_alive']
++    assert first['visible_children'] == 1
++    assert first['scope_slots'] == 1
++
++    assert legacy['first_alive']
++    assert legacy['second_alive']
++    assert not legacy['same_pointer']
++    assert legacy['visible_children'] == 2
++    assert legacy['scope_slots'] == 1
++
++
++def test_new_executor_repeated_run_uses_fresh_child_scope():
++    result = _run_scenario('repeated')
++
++    assert result['first_alive']
++    assert result['second_alive']
++    assert not result['same_pointer']
++    assert result['visible_children'] == 2
++    assert result['scope_slots'] == 1
++
++
++def test_stale_cached_scope_is_not_reused():
++    result = _run_scenario('stale')
++
++    assert not result['first_alive']
++    assert result['second_alive']
++    assert not result['same_pointer']
++    assert result['visible_children'] == 2
++    assert result['scope_slots'] == 1

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-50086/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-50086/tests/test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+python -m pytest test/legacy_test/test_conditional_block_scope_lifecycle.py -q


### PR DESCRIPTION
## 关联

- SWE-Paddle 共建 issue: https://github.com/PaddlePaddle/Paddle/issues/79447
- 来源 PR: https://github.com/PaddlePaddle/Paddle/pull/50086

## 说明

- 新增 SWE-Paddle 任务 `PaddlePaddle__Paddle-50086`

@sunzhongkai588 

## 验证结果

| 状态 | First/legacy P2P | Repeated-run F2P | Stale-scope F2P |
| --- | --- | --- | --- |
| Base + `tests/test.patch` | PASS | FAIL，符合预期 | FAIL，符合预期 |
| Base + test patch + `solution/code.patch` | PASS | PASS | PASS |

#### Base P2P：首次执行与 legacy executor

```text
.                                                                        [100%]
1 passed in 4.01s
Base first/legacy P2P exit code: 0
```

#### Base F2P：New executor repeated execution

```text
F                                                                        [100%]
================================== FAILURES ===================================
____________ test_new_executor_repeated_run_uses_fresh_child_scope ____________

>       assert not result['same_pointer']
E       assert not True

FAILED test/legacy_test/test_conditional_block_scope_lifecycle.py::test_new_executor_repeated_run_uses_fresh_child_scope
1 failed in 0.07s
Base repeated-run F2P exit code: 1
```

#### Base F2P：Stale cached scope

```text
F                                                                        [100%]
================================== FAILURES ===================================
____________________ test_stale_cached_scope_is_not_reused ____________________

>       assert result['second_alive']
E       assert False

FAILED test/legacy_test/test_conditional_block_scope_lifecycle.py::test_stale_cached_scope_is_not_reused
1 failed in 0.18s
Base stale-scope F2P exit code: 1
```

#### Base 完整任务脚本

```text
.FF                                                                      [100%]
2 failed, 1 passed in 0.21s
Base tests/test.sh exit code: 1
```

#### Solution 测试

```text
Solution first/legacy P2P:
1 passed in 0.80s

Solution repeated-run F2P:
1 passed in 0.03s

Solution stale-scope F2P:
1 passed in 0.02s
```

#### `tests/test.sh`

```text
...                                                                      [100%]
3 passed in 0.07s
Solution tests/test.sh exit code: 0
```