### PR TITLE
[SWE-Paddle] Complete task package for PaddlePaddle__Paddle-76736

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-76736/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-76736/README.md
@@ -1,0 +1,52 @@
+# PaddlePaddle__Paddle-76736
+
+This directory converts the merged `atan2` API compatibility work into a reproducible SWE-Paddle task package.
+
+## Source
+
+| Field | Value |
+| --- | --- |
+| Repository | `PaddlePaddle/Paddle` |
+| Source PR | [#76736](https://github.com/PaddlePaddle/Paddle/pull/76736) |
+| PR title | `[API Compatibility No.33] Cpp sink for atan2 -part` |
+| Base commit | `7743e779aff3e35b8bd748b2c69b9332f5d8dfd7` |
+| Squash commit | `3e4695db8fc3a19e9e055709941ad2b99f7f6c5f` |
+| Merged at | `2026-02-05T06:21:01Z` |
+| Author/contact | GitHub `@Manfredss` |
+| Task type | `feature_enhancement` |
+| Target resource | CPU only |
+
+## Task Value
+
+The task exercises a coherent public API change across generated bindings, argument aliases, Tensor methods, output assignment, broadcasting, gradient reduction, dtype behavior, and empty tensors. It is representative of framework work where Python-visible behavior depends on build-time metadata and compiled operator code rather than a Python-only wrapper.
+
+## Package Inventory
+
+- `proposal.md`: approved task proposal.
+- `instruction.md`: observable requirements presented to the coding agent.
+- `environment/README.md`: pinned environment, rebuild requirements, execution order, and known risks.
+- `solution/code.patch`: gold implementation patch containing the nine non-test sections from the squash commit.
+- `tests/test.patch`: focused two-file test patch against the pinned base.
+- `tests/test.sh`: stable CPU pytest entry point with each node isolated in its own process.
+
+## Verification
+
+From the root of a Paddle source checkout at the base commit, apply `tests/test.patch`, build Paddle from source, and run:
+
+```bash
+bash tests/test.sh
+```
+
+`PYTHON_BIN` may select the interpreter used by the source build:
+
+```bash
+PYTHON_BIN=/path/to/python bash tests/test.sh
+```
+
+On the base commit, existing positional/`x`-`y` API, broadcasting, empty-Tensor, integer-output, and broadcast-gradient guards are expected to pass. Alias, `out`, and Tensor-method checks are expected to fail because those public forms are not yet supported. After applying `solution/code.patch` and rebuilding, every selected node is expected to pass.
+
+A source rebuild is mandatory. The gold patch changes build-time API metadata and compiled CPU/CUDA operator code; an installed wheel or Python overlay cannot represent the fixed state. The CUDA section is retained for fidelity even though the verifier target is CPU.
+
+## Test Curation
+
+The gold patch preserves all nine non-test sections from the merged commit without editing implementation hunks. The test patch intentionally excludes unrelated `asinh`/`atan` additions from `test_activation_op.py` and excludes the whitespace-only merged hunk in `test_atan2_op.py`. It retains the merged `atan2` compatibility class and adds deterministic public tests for Tensor methods and numerical broadcast gradients.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-76736/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-76736/environment/README.md
@@ -1,0 +1,56 @@
+# Environment Notes
+
+## Pinned Source
+
+- Repository: `PaddlePaddle/Paddle`
+- Base commit: `7743e779aff3e35b8bd748b2c69b9332f5d8dfd7`
+- Reference squash commit: `3e4695db8fc3a19e9e055709941ad2b99f7f6c5f`
+- Target backend: CPU
+- GPU required: no
+
+The original PR author built and tested the change on Windows 11 Home with Python 3.12, CMake 3.18.6, Visual Studio 2022, CUDA 12.9, and cuDNN 9.12.0. The author machine used a Ryzen 7 9800X3D and RTX 5070 Ti; that GPU is not a verifier requirement.
+
+## Build Requirement
+
+A clean source build is mandatory. The solution changes build-time API configuration, generated Python/C++ bindings, infermeta behavior, and compiled forward/backward kernels. Reusing an unrelated wheel, copying Python files over an installed package, or running against a build from another revision does not represent either the pinned base or fixed state.
+
+The verifier should use its normal Paddle source-build procedure and ensure that the selected `PYTHON_BIN` imports the freshly built package. Although verification is CPU-only, the CUDA implementation section remains in the gold patch because it is part of the coherent merged solution.
+
+## Run/Test/Fix Order
+
+### Run the base
+
+1. Check out the exact base commit in a clean Paddle worktree.
+2. Apply `tests/test.patch` and build that source revision.
+3. Run `bash tests/test.sh` from the Paddle repository root.
+4. Classify existing positional/keyword, broadcasting, empty-Tensor, integer-output, and gradient nodes as pass-to-pass guards. Alias, `out`, and Tensor-method nodes should fail only with unsupported public-call errors such as `TypeError` or `AttributeError`; import, linkage, or environment failures are invalid results.
+
+### Test the gold solution
+
+1. Return to a clean checkout of the same base commit.
+2. Apply `tests/test.patch`, then `solution/code.patch`.
+3. Reconfigure or rebuild as required so build-time generation and all affected C++ sources are refreshed.
+4. Run `bash tests/test.sh`; every selected node must pass.
+5. Repeat the focused suite when practical to rule out global-mode contamination.
+
+### Fix an attempted solution
+
+1. Start from the pinned base with `tests/test.patch` applied.
+2. Implement only the observable requirements in `instruction.md`.
+3. Rebuild after changes that affect generated bindings or compiled operator behavior.
+4. Run `bash tests/test.sh` and require all nodes to pass.
+
+## Test Runner Notes
+
+- `PYTHON_BIN` defaults to `python` and may be overridden.
+- `test/legacy_test` is prepended to `PYTHONPATH` so legacy test utilities resolve.
+- Every pytest node runs in a separate process because these tests switch Paddle between static and dynamic modes globally.
+- The selected nodes use CPU behavior; no CUDA test is required.
+
+## Verification Status and Risks
+
+During package authoring, commit ancestry, patch boundaries, patch fidelity, Python syntax, shell syntax, and clean application against exact base file contents were checked. The nine fixed source files are also compared with their squash-commit versions during structural validation.
+
+A Linux Paddle source configure/build and behavioral base/fixed pytest run were not executed in the community repository workspace because it does not contain a trustworthy Paddle source build for the pinned revision. Those steps remain pending for the SWE-Paddle Run/Test/Fix verifier and must not be inferred from structural checks.
+
+Primary environment risks are stale generated bindings, importing a wheel instead of the fresh build, and legacy tests leaking global static/dynamic mode. The required rebuild, import-path check, and per-node pytest processes address these risks.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-76736/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-76736/instruction.md
@@ -1,0 +1,15 @@
+# Extend `paddle.atan2` API compatibility
+
+Update `paddle.atan2` so that its public behavior is consistent across supported call styles while preserving all existing valid calls.
+
+## Requirements
+
+- Continue to support positional calls such as `paddle.atan2(x, y)` and keyword calls using `x` and `y` in both dynamic and static execution.
+- Accept `input` as an alias for `x` and `other` as an alias for `y`.
+- Accept an `out` Tensor in dynamic execution and write the same result into it that would otherwise be returned normally.
+- Expose equivalent Tensor methods so that `x.atan2(y)` and `x.atan2(other=y)` produce the same values as `paddle.atan2(x, y)`.
+- Follow NumPy-compatible broadcasting for inputs with different shapes.
+- Compute correct gradients for broadcast inputs and return each gradient with the corresponding original input shape.
+- Produce `float64` output for supported integer inputs.
+- Handle valid empty-Tensor inputs without changing the expected output shape or dtype.
+- Match `numpy.arctan2` numerically for the supported public call forms and preserve existing behavior for calls that were already valid.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-76736/solution/code.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-76736/solution/code.patch
@@ -1,0 +1,530 @@
+diff --git a/paddle/phi/infermeta/binary.cc b/paddle/phi/infermeta/binary.cc
+index 3522c419c37c65..65e78362be09e6 100644
+--- a/paddle/phi/infermeta/binary.cc
++++ b/paddle/phi/infermeta/binary.cc
+@@ -191,32 +191,9 @@ void ArrayReadInferMeta(const MetaTensor& array,
+ }
+ 
+ void Atan2InferMeta(const MetaTensor& x, const MetaTensor& y, MetaTensor* out) {
+-  const auto& x_dims = x.dims();
+-  const auto& y_dims = y.dims();
+-
+-  PADDLE_ENFORCE_EQ(
+-      x_dims.size(),
+-      y_dims.size(),
+-      common::errors::InvalidArgument("The rank (%d) of X shall be same as "
+-                                      "rank (%d) of Y.",
+-                                      x_dims.size(),
+-                                      y_dims.size()));
+-
+-  if (x_dims.size() > 0)
+-    PADDLE_ENFORCE_LE(x_dims[0],
+-                      y_dims[0],
+-                      common::errors::InvalidArgument(
+-                          "The count (%d) of elements of X shall not "
+-                          "greater than count (%d) of elements of Y.",
+-                          x_dims[0],
+-                          y_dims[0]));
+-
+-  out->share_meta(x);
+-  if (x.dtype() == DataType::INT32 || x.dtype() == DataType::INT64 ||
+-      y.dtype() == DataType::INT32 || y.dtype() == DataType::INT64) {
++  ElementwiseInferMeta(x, y, out);
++  if (out->dtype() == DataType::INT32 || out->dtype() == DataType::INT64) {
+     out->set_dtype(DataType::FLOAT64);
+-  } else {
+-    out->set_dtype(x.dtype());
+   }
+ }
+ 
+diff --git a/paddle/phi/kernels/funcs/eigen/broadcast.cc b/paddle/phi/kernels/funcs/eigen/broadcast.cc
+index 4c453706007615..d383b9c60b77cb 100644
+--- a/paddle/phi/kernels/funcs/eigen/broadcast.cc
++++ b/paddle/phi/kernels/funcs/eigen/broadcast.cc
+@@ -71,7 +71,8 @@ struct EigenBroadcastGrad<Eigen::DefaultDevice, T, Rank> {
+   template struct FUNCTOR<Eigen::DefaultDevice, T, 5>; \
+   template struct FUNCTOR<Eigen::DefaultDevice, T, 6>; \
+   template struct FUNCTOR<Eigen::DefaultDevice, T, 7>; \
+-  template struct FUNCTOR<Eigen::DefaultDevice, T, 8>
++  template struct FUNCTOR<Eigen::DefaultDevice, T, 8>; \
++  template struct FUNCTOR<Eigen::DefaultDevice, T, 9>
+ INSTANTIATION(EigenBroadcast, bool);
+ INSTANTIATION(EigenBroadcast, dtype::float16);
+ INSTANTIATION(EigenBroadcast, dtype::bfloat16);
+diff --git a/paddle/phi/kernels/funcs/eigen/broadcast.cu b/paddle/phi/kernels/funcs/eigen/broadcast.cu
+index 08a1e41d759a0c..e98ed973e9290e 100644
+--- a/paddle/phi/kernels/funcs/eigen/broadcast.cu
++++ b/paddle/phi/kernels/funcs/eigen/broadcast.cu
+@@ -70,7 +70,8 @@ struct EigenBroadcastGrad<Eigen::GpuDevice, T, Rank> {
+   template struct FUNCTOR<Eigen::GpuDevice, T, 5>; \
+   template struct FUNCTOR<Eigen::GpuDevice, T, 6>; \
+   template struct FUNCTOR<Eigen::GpuDevice, T, 7>; \
+-  template struct FUNCTOR<Eigen::GpuDevice, T, 8>
++  template struct FUNCTOR<Eigen::GpuDevice, T, 8>; \
++  template struct FUNCTOR<Eigen::GpuDevice, T, 9>
+ INSTANTIATION(EigenBroadcast, bool);
+ INSTANTIATION(EigenBroadcast, dtype::float16);
+ INSTANTIATION(EigenBroadcast, dtype::bfloat16);
+diff --git a/paddle/phi/kernels/impl/atan2_grad_kernel_impl.h b/paddle/phi/kernels/impl/atan2_grad_kernel_impl.h
+index f5773eb8057caa..dcd338ff2be992 100644
+--- a/paddle/phi/kernels/impl/atan2_grad_kernel_impl.h
++++ b/paddle/phi/kernels/impl/atan2_grad_kernel_impl.h
+@@ -15,9 +15,12 @@
+ #pragma once
+ 
+ #include "paddle/phi/core/dense_tensor.h"
++#include "paddle/phi/core/tensor_utils.h"
+ #include "paddle/phi/kernels/atan2_grad_kernel.h"
++#include "paddle/phi/kernels/broadcast_tensors_kernel.h"
+ #include "paddle/phi/kernels/full_kernel.h"
+ #include "paddle/phi/kernels/funcs/for_range.h"
++#include "paddle/phi/kernels/reduce_sum_kernel.h"
+ 
+ namespace phi {
+ 
+@@ -84,34 +87,119 @@ void Atan2GradKernel(const Context& dev_ctx,
+                      const DenseTensor& out_grad,
+                      DenseTensor* x_grad,
+                      DenseTensor* y_grad) {
+-  auto numel = x.numel();
+-  auto x_data = x.data<T>();
+-  auto y_data = y.data<T>();
+-  auto out_grad_data = out_grad.data<T>();
+-
+   if (out_grad.numel() == 0) {
+-    dev_ctx.template Alloc<T>(x_grad);
+-    dev_ctx.template Alloc<T>(y_grad);
+-    if (x_grad && x_grad->numel() != 0) {
+-      Full<T, Context>(dev_ctx, x_grad->dims(), 0, x_grad);
++    if (x_grad) {
++      dev_ctx.template Alloc<T>(x_grad);
++      if (x_grad->numel() != 0) {
++        phi::Full<T, Context>(dev_ctx,
++                              phi::IntArray(common::vectorize(x_grad->dims())),
++                              0,
++                              x_grad);
++      }
+     }
+-    if (y_grad && y_grad->numel() != 0) {
+-      Full<T, Context>(dev_ctx, y_grad->dims(), 0, y_grad);
++    if (y_grad) {
++      dev_ctx.template Alloc<T>(y_grad);
++      if (y_grad->numel() != 0) {
++        phi::Full<T, Context>(dev_ctx,
++                              phi::IntArray(common::vectorize(y_grad->dims())),
++                              0,
++                              y_grad);
++      }
+     }
+     return;
+   }
+ 
+-  auto* x_grad_data =
+-      x_grad ? dev_ctx.template Alloc<T>(x_grad, size_t(x.numel() * sizeof(T)))
+-             : nullptr;
+-  auto* y_grad_data =
+-      y_grad ? dev_ctx.template Alloc<T>(y_grad, size_t(y.numel() * sizeof(T)))
+-             : nullptr;
+-
+-  funcs::ForRange<Context> for_range(dev_ctx, numel);
+-  phi::Atan2GradFunctor<T> functor(
+-      x_data, y_data, out_grad_data, x_grad_data, y_grad_data, numel);
+-  for_range(functor);
++  if (x.dims() == y.dims() && x.dims() == out_grad.dims()) {
++    auto numel = x.numel();
++    auto x_data = x.data<T>();
++    auto y_data = y.data<T>();
++    auto out_grad_data = out_grad.data<T>();
++
++    auto* x_grad_data = x_grad ? dev_ctx.template Alloc<T>(
++                                     x_grad, size_t(x.numel() * sizeof(T)))
++                               : nullptr;
++    auto* y_grad_data = y_grad ? dev_ctx.template Alloc<T>(
++                                     y_grad, size_t(y.numel() * sizeof(T)))
++                               : nullptr;
++
++    phi::funcs::ForRange<Context> for_range(dev_ctx, numel);
++    phi::Atan2GradFunctor<T> functor(
++        x_data, y_data, out_grad_data, x_grad_data, y_grad_data, numel);
++    for_range(functor);
++  } else {
++    DenseTensor b_x, b_y;
++    b_x.Resize(out_grad.dims());
++    b_y.Resize(out_grad.dims());
++
++    std::vector<const DenseTensor*> inputs = {&x, &y};
++    std::vector<DenseTensor*> outputs = {&b_x, &b_y};
++    phi::BroadcastTensorsKernel<T, Context>(dev_ctx, inputs, outputs);
++
++    DenseTensor dx_b, dy_b;
++    T* dx_b_data = nullptr;
++    T* dy_b_data = nullptr;
++    std::vector<int64_t> x_axes, y_axes;
++
++    if (x_grad) {
++      int in_rank = x.dims().size();
++      int out_rank = out_grad.dims().size();
++      int diff = out_rank - in_rank;
++      for (int i = 0; i < diff; ++i) x_axes.push_back(i);
++      for (int i = 0; i < in_rank; ++i) {
++        if (x.dims()[i] == 1 && out_grad.dims()[i + diff] > 1) {
++          x_axes.push_back(i + diff);
++        }
++      }
++      if (x_axes.empty()) {
++        dev_ctx.template Alloc<T>(x_grad);
++        dx_b_data = x_grad->data<T>();
++      } else {
++        dx_b.Resize(out_grad.dims());
++        dx_b_data = dev_ctx.template Alloc<T>(&dx_b);
++      }
++    }
++
++    if (y_grad) {
++      int in_rank = y.dims().size();
++      int out_rank = out_grad.dims().size();
++      int diff = out_rank - in_rank;
++      for (int i = 0; i < diff; ++i) y_axes.push_back(i);
++      for (int i = 0; i < in_rank; ++i) {
++        if (y.dims()[i] == 1 && out_grad.dims()[i + diff] > 1) {
++          y_axes.push_back(i + diff);
++        }
++      }
++      if (y_axes.empty()) {
++        dev_ctx.template Alloc<T>(y_grad);
++        dy_b_data = y_grad->data<T>();
++      } else {
++        dy_b.Resize(out_grad.dims());
++        dy_b_data = dev_ctx.template Alloc<T>(&dy_b);
++      }
++    }
++
++    auto numel = out_grad.numel();
++    phi::funcs::ForRange<Context> for_range(dev_ctx, numel);
++    phi::Atan2GradFunctor<T> functor(b_x.data<T>(),
++                                     b_y.data<T>(),
++                                     out_grad.data<T>(),
++                                     dx_b_data,
++                                     dy_b_data,
++                                     numel);
++    for_range(functor);
++
++    if (x_grad && !x_axes.empty()) {
++      phi::SumKernel<T, Context>(
++          dev_ctx, dx_b, phi::IntArray(x_axes), x_grad->dtype(), false, x_grad);
++      x_grad->Resize(x.dims());
++    }
++
++    if (y_grad && !y_axes.empty()) {
++      phi::SumKernel<T, Context>(
++          dev_ctx, dy_b, phi::IntArray(y_axes), y_grad->dtype(), false, y_grad);
++      y_grad->Resize(y.dims());
++    }
++  }
+ }
+ 
+ }  // namespace phi
+diff --git a/paddle/phi/kernels/impl/atan2_kernel_impl.h b/paddle/phi/kernels/impl/atan2_kernel_impl.h
+index 382011c1b6bf43..a2fbc3c9e51bfd 100644
+--- a/paddle/phi/kernels/impl/atan2_kernel_impl.h
++++ b/paddle/phi/kernels/impl/atan2_kernel_impl.h
+@@ -18,6 +18,7 @@
+ #include "paddle/phi/core/device_context.h"
+ #include "paddle/phi/kernels/atan2_kernel.h"
+ #include "paddle/phi/kernels/broadcast_tensors_kernel.h"
++#include "paddle/phi/kernels/funcs/common_shape.h"
+ #include "paddle/phi/kernels/funcs/for_range.h"
+ 
+ namespace phi {
+@@ -55,6 +56,38 @@ struct Atan2Functor {
+   int64_t numel_;
+ };
+ 
++template <>
++struct Atan2Functor<int32_t> {
++  Atan2Functor(const int32_t* x1, const int32_t* x2, double* out, int64_t numel)
++      : x1_(x1), x2_(x2), out_(out), numel_(numel) {}
++
++  HOSTDEVICE void operator()(int64_t idx) const {
++    out_[idx] =
++        ::atan2(static_cast<double>(x1_[idx]), static_cast<double>(x2_[idx]));
++  }
++
++  const int32_t* x1_;
++  const int32_t* x2_;
++  double* out_;
++  int64_t numel_;
++};
++
++template <>
++struct Atan2Functor<int64_t> {
++  Atan2Functor(const int64_t* x1, const int64_t* x2, double* out, int64_t numel)
++      : x1_(x1), x2_(x2), out_(out), numel_(numel) {}
++
++  HOSTDEVICE void operator()(int64_t idx) const {
++    out_[idx] =
++        ::atan2(static_cast<double>(x1_[idx]), static_cast<double>(x2_[idx]));
++  }
++
++  const int64_t* x1_;
++  const int64_t* x2_;
++  double* out_;
++  int64_t numel_;
++};
++
+ template <>
+ struct Atan2Functor<double> {
+   Atan2Functor(const double* x1, const double* x2, double* out, int64_t numel)
+@@ -75,19 +108,35 @@ void Atan2Kernel(const Context& dev_ctx,
+                  const DenseTensor& x,
+                  const DenseTensor& y,
+                  DenseTensor* out) {
+-  if (x.numel() == 0 || y.numel() == 0) {
+-    dev_ctx.template Alloc<typename Atan2Out<T>::type>(out);
+-    return;
+-  }
++  dev_ctx.template Alloc<typename Atan2Out<T>::type>(out);
++  if (out->numel() == 0) return;
+ 
+-  const auto numel = out->numel();
+-  const auto* x_data = x.data<T>();
+-  const auto* y_data = y.data<T>();
++  if (x.dims() == y.dims()) {
++    const auto numel = out->numel();
++    const auto* x_data = x.data<T>();
++    const auto* y_data = y.data<T>();
+ 
+-  auto* out_data = dev_ctx.template Alloc<typename Atan2Out<T>::type>(out);
+-  funcs::ForRange<Context> for_range(dev_ctx, numel);
+-  phi::Atan2Functor<T> functor(x_data, y_data, out_data, numel);
+-  for_range(functor);
++    auto* out_data = out->data<typename Atan2Out<T>::type>();
++    phi::funcs::ForRange<Context> for_range(dev_ctx, numel);
++    phi::Atan2Functor<T> functor(x_data, y_data, out_data, numel);
++    for_range(functor);
++  } else {
++    DenseTensor b_x, b_y;
++    // Calculate broadcasted dims
++    b_x.Resize(out->dims());
++    b_y.Resize(out->dims());
++    std::vector<const DenseTensor*> inputs = {&x, &y};
++    std::vector<DenseTensor*> outputs = {&b_x, &b_y};
++    phi::BroadcastTensorsKernel<T, Context>(dev_ctx, inputs, outputs);
++
++    const auto numel = out->numel();
++    const auto* x_data = b_x.data<T>();
++    const auto* y_data = b_y.data<T>();
++    auto* out_data = out->data<typename Atan2Out<T>::type>();
++    phi::funcs::ForRange<Context> for_range(dev_ctx, numel);
++    phi::Atan2Functor<T> functor(x_data, y_data, out_data, numel);
++    for_range(functor);
++  }
+ }
+ 
+ }  // namespace phi
+diff --git a/paddle/phi/kernels/impl/broadcast_tensors_kernel_impl.h b/paddle/phi/kernels/impl/broadcast_tensors_kernel_impl.h
+index 6ec3ae89670468..cc5ef1f7fcec6b 100644
+--- a/paddle/phi/kernels/impl/broadcast_tensors_kernel_impl.h
++++ b/paddle/phi/kernels/impl/broadcast_tensors_kernel_impl.h
+@@ -114,10 +114,13 @@ void BroadcastTensorsKernel(const Context& dev_ctx,
+         SWITCH_OUT_RANK_CASE(4)
+         SWITCH_OUT_RANK_CASE(5)
+         SWITCH_OUT_RANK_CASE(6)
++        SWITCH_OUT_RANK_CASE(7)
++        SWITCH_OUT_RANK_CASE(8)
++        SWITCH_OUT_RANK_CASE(9)
+       default: {
+         PADDLE_THROW(common::errors::InvalidArgument(
+             "Target tensor rank out of range. "
+-            "Maximum supported rank for broadcast is: 6"));
++            "Maximum supported rank for broadcast is: 9"));
+       }
+     }
+   }
+diff --git a/paddle/phi/ops/yaml/python_api_info.yaml b/paddle/phi/ops/yaml/python_api_info.yaml
+index 277d3ada573d5a..87181605c3f75c 100644
+--- a/paddle/phi/ops/yaml/python_api_info.yaml
++++ b/paddle/phi/ops/yaml/python_api_info.yaml
+@@ -80,6 +80,11 @@
+   args_alias :
+     use_default_mapping : True
+ 
++- op : atan2
++  name : [paddle.atan2, paddle.Tensor.atan2]
++  args_alias :
++    use_default_mapping : True
++
+ - op : atanh
+   name : [paddle.atanh, paddle.Tensor.atanh]
+   args_alias :
+diff --git a/python/paddle/_paddle_docs.py b/python/paddle/_paddle_docs.py
+index 9bc7e656ee77bb..7f48e3f18c0cb7 100644
+--- a/python/paddle/_paddle_docs.py
++++ b/python/paddle/_paddle_docs.py
+@@ -774,6 +774,69 @@ def atanh(
+ """,
+ )
+ 
++add_doc_and_signature(
++    "atan2",
++    r"""Element-wise arctangent of x/y with consideration of the quadrant.
++
++    Equation:
++        .. math::
++
++            atan2(x,y)=\left\{\begin{matrix}
++            & tan^{-1}(\frac{x}{y}) & y > 0 \\
++            & tan^{-1}(\frac{x}{y}) + \pi & x>=0, y < 0 \\
++            & tan^{-1}(\frac{x}{y}) - \pi & x<0, y < 0 \\
++            & +\frac{\pi}{2} & x>0, y = 0 \\
++            & -\frac{\pi}{2} & x<0, y = 0 \\
++            &\text{undefined} & x=0, y = 0
++            \end{matrix}\right.
++
++    .. note::
++        Alias Support: The parameter name ``input`` can be used as an alias for ``x``, and the parameter name ``other`` can be used as an alias for ``y``.
++        For example, ``atan2(input=tensor_x, other=tensor_y)`` is equivalent to ``atan2(x=tensor_x, y=tensor_y)``.
++
++    Args:
++        x (Tensor): An N-D Tensor, the data type is int32, int64, float16, float32, float64.
++            Alias: ``input``.
++        y (Tensor): An N-D Tensor, must have the same type as `x`.
++            Alias: ``other``.
++        name (str|None, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
++        out (Tensor|None, optional): The output Tensor. If set, the result will be stored in this Tensor. Default is None.
++
++    Returns:
++        out (Tensor): An N-D Tensor, the shape and data type is the same with input (The output data type is float64 when the input data type is int).
++
++    Examples:
++        .. code-block:: python
++
++            >>> import paddle
++
++            >>> x = paddle.to_tensor([-1, +1, +1, -1]).astype('float32')
++            >>> x
++            Tensor(shape=[4], dtype=float32, place=Place(cpu), stop_gradient=True,
++            [-1,  1,  1, -1])
++
++            >>> y = paddle.to_tensor([-1, -1, +1, +1]).astype('float32')
++            >>> y
++            Tensor(shape=[4], dtype=float32, place=Place(cpu), stop_gradient=True,
++            [-1,  -1,  1, 1])
++
++            >>> out = paddle.atan2(x, y)
++            >>> out
++            Tensor(shape=[4], dtype=float32, place=Place(cpu), stop_gradient=True,
++            [-2.35619450,  2.35619450,  0.78539819, -0.78539819])
++
++""",
++    """
++def atan2(
++    x: Tensor,
++    y: Tensor,
++    name: str | None = None,
++    *,
++    out: Tensor | None = None,
++) -> Tensor
++""",
++)
++
+ add_doc_and_signature(
+     "log2",
+     r"""
+diff --git a/python/paddle/tensor/math.py b/python/paddle/tensor/math.py
+index 0744cc97bf4dfc..f6a9864bd31e34 100644
+--- a/python/paddle/tensor/math.py
++++ b/python/paddle/tensor/math.py
+@@ -31,6 +31,7 @@
+     amin,
+     angle,
+     any,
++    atan2,
+     baddbmm,
+     baddbmm_,
+     bitwise_left_shift,
+@@ -4425,84 +4426,6 @@ def negative(x: Tensor, name: str | None = None) -> Tensor:
+     return -x
+ 
+ 
+-def atan2(x: Tensor, y: Tensor, name: str | None = None) -> Tensor:
+-    r"""
+-    Element-wise arctangent of x/y with consideration of the quadrant.
+-
+-    Equation:
+-        .. math::
+-
+-            atan2(x,y)=\left\{\begin{matrix}
+-            & tan^{-1}(\frac{x}{y}) & y > 0 \\
+-            & tan^{-1}(\frac{x}{y}) + \pi & x>=0, y < 0 \\
+-            & tan^{-1}(\frac{x}{y}) - \pi & x<0, y < 0 \\
+-            & +\frac{\pi}{2} & x>0, y = 0 \\
+-            & -\frac{\pi}{2} & x<0, y = 0 \\
+-            &\text{undefined} & x=0, y = 0
+-            \end{matrix}\right.
+-
+-    Args:
+-        x (Tensor): An N-D Tensor, the data type is int32, int64, float16, float32, float64.
+-        y (Tensor): An N-D Tensor, must have the same type as `x`.
+-        name (str|None, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
+-
+-    Returns:
+-        out (Tensor): An N-D Tensor, the shape and data type is the same with input (The output data type is float64 when the input data type is int).
+-
+-    Examples:
+-        .. code-block:: pycon
+-
+-            >>> import paddle
+-
+-            >>> x = paddle.to_tensor([-1, +1, +1, -1]).astype('float32')
+-            >>> x
+-            Tensor(shape=[4], dtype=float32, place=Place(cpu), stop_gradient=True,
+-            [-1.,  1.,  1., -1.])
+-
+-            >>> y = paddle.to_tensor([-1, -1, +1, +1]).astype('float32')
+-            >>> y
+-            Tensor(shape=[4], dtype=float32, place=Place(cpu), stop_gradient=True,
+-            [-1., -1.,  1.,  1.])
+-
+-            >>> out = paddle.atan2(x, y)
+-            >>> out
+-            Tensor(shape=[4], dtype=float32, place=Place(cpu), stop_gradient=True,
+-            [-2.35619450,  2.35619450,  0.78539819, -0.78539819])
+-
+-    """
+-
+-    x_shape = list(x.shape)
+-    y_shape = list(y.shape)
+-    if in_dynamic_or_pir_mode():
+-        broadcast_x = x
+-        broadcast_y = y
+-        if x_shape != y_shape:
+-            broadcast_shape = paddle.broadcast_shape(x_shape, y_shape)
+-            broadcast_x = paddle.broadcast_to(broadcast_x, broadcast_shape)
+-            broadcast_y = paddle.broadcast_to(broadcast_y, broadcast_shape)
+-
+-        return _C_ops.atan2(broadcast_x, broadcast_y)
+-    else:
+-        check_variable_and_dtype(
+-            x,
+-            'x',
+-            ['int32', 'int64', 'float16', 'float32', 'float64'],
+-            'atan2',
+-        )
+-        check_variable_and_dtype(
+-            y,
+-            'y',
+-            ['int32', 'int64', 'float16', 'float32', 'float64'],
+-            'atan2',
+-        )
+-
+-        helper = LayerHelper('atan2', **locals())
+-        inputs = {'X1': x, 'X2': y}
+-        out = helper.create_variable_for_type_inference(dtype=x.dtype)
+-        helper.append_op(type='atan2', inputs=inputs, outputs={'Out': out})
+-        return out
+-
+-
+ def logit(
+     x: Tensor, eps: float | None = None, name: str | None = None
+ ) -> Tensor:

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-76736/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-76736/tests/test.patch
@@ -1,0 +1,138 @@
+diff --git a/test/legacy_test/test_api_compatibility.py b/test/legacy_test/test_api_compatibility.py
+index b6ab0ea..0cff240 100644
+--- a/test/legacy_test/test_api_compatibility.py
++++ b/test/legacy_test/test_api_compatibility.py
+@@ -239,6 +239,89 @@ class TestAtanAPI(unittest.TestCase):
+                 np.testing.assert_allclose(out, ref_out, rtol=1e-6)
+ 
+ 
++class TestAtan2API_Compatibility(unittest.TestCase):
++    def setUp(self):
++        np.random.seed(123)
++        paddle.enable_static()
++        self.shape = [5, 6]
++        self.dtype = 'float32'
++        self.init_data()
++
++    def init_data(self):
++        self.np_x = np.random.randn(*self.shape).astype(self.dtype)
++        self.np_y = np.random.randn(*self.shape).astype(self.dtype)
++
++    def test_dygraph_Compatibility(self):
++        paddle.disable_static()
++        x = paddle.to_tensor(self.np_x)
++        y = paddle.to_tensor(self.np_y)
++        paddle_dygraph_out = []
++
++        # Position args
++        out1 = paddle.atan2(x, y)
++        paddle_dygraph_out.append(out1)
++
++        # Paddle keyword args
++        out2 = paddle.atan2(x=x, y=y)
++        paddle_dygraph_out.append(out2)
++
++        # Torch keyword args
++        out3 = paddle.atan2(input=x, other=y)
++        paddle_dygraph_out.append(out3)
++
++        # Test out parameter
++        out4 = paddle.empty([])
++        paddle.atan2(x, y, out=out4)
++        paddle_dygraph_out.append(out4)
++
++        # Numpy reference output
++        ref_out = np.arctan2(self.np_x, self.np_y)
++
++        # Verify all outputs
++        for out in paddle_dygraph_out:
++            np.testing.assert_allclose(ref_out, out.numpy(), rtol=1e-6)
++        paddle.enable_static()
++
++    def test_static_Compatibility(self):
++        paddle.enable_static()
++        main = paddle.static.Program()
++        startup = paddle.static.Program()
++        with paddle.base.program_guard(main, startup):
++            x = paddle.static.data(name="x", shape=self.shape, dtype=self.dtype)
++            y = paddle.static.data(name="y", shape=self.shape, dtype=self.dtype)
++
++            # Position args
++            out1 = paddle.atan2(x, y)
++            # Paddle keyword args
++            out2 = paddle.atan2(x=x, y=y)
++            # Torch keyword args
++            out3 = paddle.atan2(input=x, other=y)
++
++            exe = paddle.base.Executor(paddle.CPUPlace())
++            fetches = exe.run(
++                main,
++                feed={"x": self.np_x, "y": self.np_y},
++                fetch_list=[out1, out2, out3],
++            )
++            ref_out = np.arctan2(self.np_x, self.np_y)
++            for out in fetches:
++                np.testing.assert_allclose(out, ref_out, rtol=1e-6)
++
++    def test_tensor_method(self):
++        np_x = np.array([[-1.5, 0.25, 2.0], [3.5, -0.75, 1.25]])
++        np_y = np.array([[0.5, -2.0, 1.5], [-1.0, 4.0, 0.75]])
++        paddle.disable_static()
++        try:
++            x = paddle.to_tensor(np_x)
++            y = paddle.to_tensor(np_y)
++            ref_out = np.arctan2(np_x, np_y)
++
++            np.testing.assert_allclose(x.atan2(y).numpy(), ref_out)
++            np.testing.assert_allclose(x.atan2(other=y).numpy(), ref_out)
++        finally:
++            paddle.enable_static()
++
++
+ # Edit by AI Agent
+ # Test fmax compatibility
+ class TestFmaxAPI(unittest.TestCase):
+diff --git a/test/legacy_test/test_atan2_op.py b/test/legacy_test/test_atan2_op.py
+index 2dcb9b4..78c3cf9 100644
+--- a/test/legacy_test/test_atan2_op.py
++++ b/test/legacy_test/test_atan2_op.py
+@@ -238,6 +238,39 @@ class TestAtan2Broadcasting(unittest.TestCase):
+ 
+         np.testing.assert_allclose(out_ref, result, rtol=1e-05)
+ 
++    def test_dygraph_broadcast_gradient_values(self):
++        np_x = np.array([[-1.5], [2.0]], dtype='float64')
++        np_y = np.array([[0.5, 1.25, -2.0]], dtype='float64')
++        np_dout = np.array(
++            [[1.0, -0.5, 2.0], [0.25, 3.0, -1.5]], dtype='float64'
++        )
++
++        paddle.disable_static()
++        try:
++            x = paddle.to_tensor(np_x, stop_gradient=False)
++            y = paddle.to_tensor(np_y, stop_gradient=False)
++            out = paddle.atan2(x, y)
++            out.backward(paddle.to_tensor(np_dout))
++
++            denominator = np_x**2 + np_y**2
++            expected_x_grad = np.sum(
++                np_dout * np_y / denominator, axis=1, keepdims=True
++            )
++            expected_y_grad = np.sum(
++                -np_dout * np_x / denominator, axis=0, keepdims=True
++            )
++
++            self.assertEqual(tuple(x.grad.shape), np_x.shape)
++            self.assertEqual(tuple(y.grad.shape), np_y.shape)
++            np.testing.assert_allclose(
++                x.grad.numpy(), expected_x_grad, rtol=1e-12, atol=1e-12
++            )
++            np.testing.assert_allclose(
++                y.grad.numpy(), expected_y_grad, rtol=1e-12, atol=1e-12
++            )
++        finally:
++            paddle.enable_static()
++
+     def test_api_with_dygraph_empty_tensor_input(self):
+         self._test_with_shapes([(100,), (100, 100)])
+         self._test_with_shapes([(), (5, 17, 6)])

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-76736/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-76736/tests/test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PYTHON_BIN="${PYTHON_BIN:-python}"
+export PYTHONPATH="test/legacy_test${PYTHONPATH:+:${PYTHONPATH}}"
+
+"${PYTHON_BIN}" -m pytest test/legacy_test/test_atan2_op.py::TestAtan2API::test_static_api -q
+"${PYTHON_BIN}" -m pytest test/legacy_test/test_atan2_op.py::TestAtan2API::test_dygraph_api -q
+"${PYTHON_BIN}" -m pytest test/legacy_test/test_atan2_op.py::TestAtan2Broadcasting::test_api_with_dygraph_empty_tensor_input -q
+"${PYTHON_BIN}" -m pytest test/legacy_test/test_atan2_op.py::TestAtan2EmptyTensorInput::test_api_with_dygraph_empty_tensor_input -q
+"${PYTHON_BIN}" -m pytest test/legacy_test/test_atan2_op.py::TestAtan2_int32::test_check_output -q
+"${PYTHON_BIN}" -m pytest test/legacy_test/test_atan2_op.py::TestAtan2_int64::test_check_output -q
+"${PYTHON_BIN}" -m pytest test/legacy_test/test_atan2_op.py::TestAtan2Broadcasting::test_dygraph_broadcast_gradient_values -q
+"${PYTHON_BIN}" -m pytest test/legacy_test/test_api_compatibility.py::TestAtan2API_Compatibility::test_dygraph_Compatibility -q
+"${PYTHON_BIN}" -m pytest test/legacy_test/test_api_compatibility.py::TestAtan2API_Compatibility::test_static_Compatibility -q
+"${PYTHON_BIN}" -m pytest test/legacy_test/test_api_compatibility.py::TestAtan2API_Compatibility::test_tensor_method -q


### PR DESCRIPTION
Add the curated atan2 implementation and regression-test package for SWE-Paddle verification.

测试命令
```
python3.10 test/legacy_test/test_api_compatibility.py
```

base commit + 原来的测试 patch，出现预期失败：
<img width="1376" height="596" alt="Screenshot 2026-07-19 at 17 00 00" src="https://github.com/user-attachments/assets/c9b79bf7-2c71-41c2-91ef-29d40c535634" />


应用 code patch 并重新编译安装之后，测试全部通过：
<img width="1375" height="189" alt="Screenshot 2026-07-19 at 17 23 49" src="https://github.com/user-attachments/assets/332c9494-8ff3-4d34-8e90-c6b834dd2238" />


