### PR TITLE
[SWE-Paddle] Add task PaddlePaddle__Paddle-78104

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78104/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78104/README.md
@@ -1,0 +1,44 @@
+# PaddlePaddle__Paddle-78104
+
+This directory converts Paddle PR #78104 into a SWE-Paddle community task candidate.
+
+## Source
+
+| Field | Value |
+| --- | --- |
+| Repo | `PaddlePaddle/Paddle` |
+| PR | [78104](https://github.com/PaddlePaddle/Paddle/pull/78104) |
+| PR title | `[Bugfix] paddle.cuda.device(tensor.place)` |
+| Base commit | `d85ad0fca9513ff7d1f0a552649f9136e94cf2a5` |
+| Merged at | `2026-03-03` |
+| Task type | `bug_fix` |
+| Resource | CPU |
+
+## Summary
+
+修复 device context 接收 Tensor 返回的 generic `Place` 时，无法按其真实 device type 和 device id 转换为对应 concrete Place 的问题。
+
+## Why This Is A Good SWE-Paddle Candidate
+
+- It covers a user-visible device-context regression with a small production change.
+- It distinguishes a generic `core.Place` wrapper from concrete CPU, CUDA, XPU, and custom Place objects.
+- It preserves existing string-device and concrete-Place behavior.
+- The upstream unit-test change is excluded from `solution/code.patch`; this task uses an independent CPU-only verifier.
+
+## Files
+
+- `proposal.md`: candidate proposal for maintainer triage.
+- `instruction.md`: self-contained problem statement for the coding agent.
+- `solution/code.patch`: production-only gold patch from the merged PR.
+- `tests/test.patch`: independent test patch exposing the target behavior.
+- `tests/test.sh`: minimal target test command.
+- `environment/README.md`: environment notes for reproduction.
+- `README.md`: task overview and verification entrypoint.
+
+## Verification
+
+```bash
+bash tests/test.sh
+```
+
+Expected behavior: applying `tests/test.patch` to `base_commit` should preserve string and concrete-Place behavior while failing generic Place conversion; applying both `tests/test.patch` and `solution/code.patch` should pass all target tests.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78104/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78104/README.md
@@ -16,7 +16,7 @@ This directory converts Paddle PR #78104 into a SWE-Paddle community task candid
 
 ## Summary
 
-修复 device context 接收 Tensor 返回的 generic `Place` 时，无法按其真实 device type 和 device id 转换为对应 concrete Place 的问题。
+Fixed an issue where a generic `Place` returned by a Tensor could not be converted into the corresponding concrete `Place` based on its actual device type and device ID when received by the device context.
 
 ## Why This Is A Good SWE-Paddle Candidate
 

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78104/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78104/environment/README.md
@@ -1,0 +1,29 @@
+# Environment Notes
+
+This candidate is part of the SWE-Paddle community task set.
+
+## Expected Environment
+
+- Repository: `PaddlePaddle/Paddle`
+- Base commit: `d85ad0fca9513ff7d1f0a552649f9136e94cf2a5`
+- Resource: CPU
+- GPU required: no
+- Build path: Paddle source checkout at the base commit. No Paddle rebuild or wheel installation is required; the verifier executes the checked-out Python function through AST.
+
+The verifier supplies controlled `core.Place`, `CPUPlace`, `CUDAPlace`, `XPUPlace`, and `CustomPlace` doubles. It validates device type and device-id preservation without requiring accelerator hardware.
+
+## Run Order
+
+1. Check out `PaddlePaddle/Paddle` at the base commit.
+2. Apply `tests/test.patch`.
+3. Run `bash tests/test.sh`; the target behavior should fail before the fix.
+4. Apply `solution/code.patch`.
+5. Run `bash tests/test.sh` again; the target behavior should pass after the gold patch.
+
+## Minimal Test Command
+
+```bash
+bash tests/test.sh
+```
+
+The verifier is responsible for deriving stable F2P and P2P node IDs from repeated runs.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78104/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78104/instruction.md
@@ -1,0 +1,23 @@
+# 修复 device context 对 generic Place 的解析
+
+## 详细描述
+
+Tensor 的 `place` 可能表现为 generic `Place` 对象，而不是直接暴露具体的 CPU、CUDA、XPU 或 custom Place 子类。将该对象传给 device context 时，系统可能无法保留其真实 device type 和 device id，从而选择错误设备。
+
+## 验收说明
+
+- generic Place 应根据其实际 device type 转换为对应 concrete Place
+- CUDA、XPU 和 custom device 的 device id 应保持不变
+- 已有 string device 和 concrete Place 输入行为不得退化
+
+## 技术要求
+
+- 熟悉 Python
+- 了解 Paddle Place 与 device context
+- 了解 CPU、CUDA、XPU 和 custom device 表示
+
+## Acceptance Criteria
+
+- The behavior described above should be fixed.
+- Existing valid behavior should remain unchanged.
+- Do not satisfy the task by deleting tests, weakening assertions, or bypassing validation broadly.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78104/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78104/instruction.md
@@ -1,17 +1,25 @@
-# 修复 device context 对 generic Place 的解析
+# 修复 device context 对 Tensor place 的解析
 
 ## 详细描述
 
-Tensor 的 `place` 可能表现为 generic `Place` 对象，而不是直接暴露具体的 CPU、CUDA、XPU 或 custom Place 子类。将该对象传给 device context 时，系统可能无法保留其真实 device type 和 device id，从而选择错误设备。
+在动态图模式下，Tensor 的 `place` 属性可以直接传入 `paddle.device.device` 或 `paddle.cuda.device`，用于在 Tensor 所在设备上创建上下文。
+
+在部分场景中，`tensor.place` 返回的是 `Place` 基类对象，而不是具体的设备类型对象。现有设备解析逻辑可能无法正确处理这类输入，导致设备上下文使用错误的设备。该问题在 Tensor 位于非默认 CUDA 设备时尤为明显，设备编号可能无法得到正确保留。
+
+需要修复设备上下文对 `tensor.place` 的处理，确保上下文使用 Tensor 实际所在的设备。
 
 ## 验收说明
 
-- generic Place 应根据其实际 device type 转换为对应 concrete Place
-- CUDA、XPU 和 custom device 的 device id 应保持不变
-- 已有 string device 和 concrete Place 输入行为不得退化
+* CPU Tensor 的 `place` 可以正确用于设备上下文
+* CUDA Tensor 的 `place` 可以正确用于设备上下文
+* Tensor 位于非默认 CUDA 设备时，其设备编号应保持不变
+* 退出设备上下文后，应恢复进入上下文前的设备
+* 现有字符串设备参数的行为不得退化
+* 现有具体 `Place` 对象的行为不得退化
 
 ## 技术要求
 
-- 熟悉 Python
-- 了解 Paddle Place 与 device context
-- 了解 CPU、CUDA、XPU 和 custom device 表示
+* 熟悉 Python
+* 了解 Paddle 的 Tensor 与 `Place`
+* 了解 Paddle 的设备上下文机制
+* 了解 CPU 和 CUDA 设备的表示方式

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78104/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78104/instruction.md
@@ -15,9 +15,3 @@ Tensor 的 `place` 可能表现为 generic `Place` 对象，而不是直接暴�
 - 熟悉 Python
 - 了解 Paddle Place 与 device context
 - 了解 CPU、CUDA、XPU 和 custom device 表示
-
-## Acceptance Criteria
-
-- The behavior described above should be fixed.
-- Existing valid behavior should remain unchanged.
-- Do not satisfy the task by deleting tests, weakening assertions, or bypassing validation broadly.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78104/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78104/proposal.md
@@ -1,0 +1,55 @@
+# Task Proposal: PaddlePaddle__Paddle-78104
+
+## 1. 来源信息
+
+- Instance ID：`PaddlePaddle__Paddle-78104`
+- PR 链接：https://github.com/PaddlePaddle/Paddle/pull/78104
+- PR 标题：`[Bugfix] paddle.cuda.device(tensor.place)`
+- `base_commit`：`d85ad0fca9513ff7d1f0a552649f9136e94cf2a5`
+- merged 时间：`2026-03-03`
+- 你的身份：熟悉该模块的 contributor
+- 后续联系人：TBD
+
+## 2. 问题一句话
+
+修复 device context 接收 Tensor 返回的 generic `Place` 时丢失真实 device type 或 device id 的问题。
+
+## 3. 为什么适合作为 SWE-Paddle 样本
+
+- **真实性**：任务来自已合入的 Paddle user-experience BugFix PR。
+- **代表性**：覆盖 Tensor place、device context、generic wrapper 与 concrete Place conversion。
+- **边界清楚**：上游只修改一个 production file 和一个 unit-test file，solution 仅保留 production change。
+- **非平凡性**：修复不仅要识别 generic Place，还要分别保留 CPU、CUDA、XPU 和 custom device 的类型与 id。
+- **区分度信号**：该任务能够区分仅对某一种设备做特判的局部修复，与完整覆盖 generic Place conversion 且不破坏已有输入行为的修复。
+
+## 4. 任务类型和标签
+
+- 任务类型：`bug_fix`
+- 执行后端：`cpu`
+- 设备范围：`cpu_only`
+- 模块标签：`[device, place, context_manager, cuda, xpu, custom_device, python_api]`
+
+## 5. 验证思路
+
+- 目标测试命令：`bash tests/test.sh`
+- 目标测试文件：`test/legacy_test/test_device_place_conversion_contract.py`
+- 修复前预期：string device 与 concrete Place P2P 应 pass；generic Place conversion F2P 应 fail。
+- 修复后预期：应用 production-only Gold patch 后，P2P 与 F2P 均应 pass。
+- P2P 候选：`"cpu"` string conversion，以及 concrete CUDAPlace passthrough。
+
+## 6. 环境与资源
+
+- 资源需求：CPU
+- Paddle 来源：`PaddlePaddle/Paddle` source checkout at `base_commit`
+- 是否能提供 Docker：暂无
+- patch 类型：Python-only production change
+- 环境建议：通过 AST 加载 checkout 中的 `_convert_to_place`，使用 controlled core Place doubles 验证 device type 与 id，不依赖实际 GPU/XPU/custom hardware
+- 最小测试命令：`bash tests/test.sh`
+- 是否有 oracle 日志：由 SWE-Paddle verifier 结果另行维护
+
+## 7. 风险自查
+
+- 泄露风险：instruction 只描述 observable conversion contract，不指出具体条件表达式。
+- 环境风险：不依赖 Paddle wheel、GPU、XPU、custom device runtime 或 source build。
+- flaky 风险：所有 Place doubles 和 device ids 固定，测试无随机性与外部依赖。
+- 拆分风险：所有场景都属于 `_convert_to_place` 的同一 conversion contract。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78104/solution/code.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78104/solution/code.patch
@@ -1,0 +1,24 @@
+diff --git a/python/paddle/device/__init__.py b/python/paddle/device/__init__.py
+index d8f62a0e9628a78e17490907b15908c109973a7e..1f1e6bbc3f87f42050830e950d8bb1c97f9262c6 100644
+--- a/python/paddle/device/__init__.py
++++ b/python/paddle/device/__init__.py
+@@ -396,7 +396,18 @@ def device_to_place(device: Place | int | str | None = None) -> Place:
+ 
+ def _convert_to_place(device: PlaceLike) -> Place:
+     if not isinstance(device, str):
+-        return device  # return directly if not a string
++        if type(device) is core.Place:
++            if device.is_gpu_place():
++                return core.CUDAPlace(device.gpu_device_id())
++            elif device.is_cpu_place():
++                return core.CPUPlace()
++            elif device.is_xpu_place():
++                return core.XPUPlace(device.xpu_device_id())
++            elif device.is_custom_place():
++                return core.CustomPlace(
++                    device.custom_device_type(), device.custom_device_id()
++                )
++        return device
+ 
+     lower_device = device.lower()
+     if lower_device.startswith("cuda"):

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78104/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78104/tests/test.patch
@@ -1,0 +1,159 @@
+diff --git a/test/legacy_test/test_device_place_conversion_contract.py b/test/legacy_test/test_device_place_conversion_contract.py
+new file mode 100644
+index 00000000000000..f34738e7193981
+--- /dev/null
++++ b/test/legacy_test/test_device_place_conversion_contract.py
+@@ -0,0 +1,153 @@
++# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++
++import ast
++import copy
++import os
++import re
++import types
++from pathlib import Path
++
++
++_REPO_ROOT = Path(__file__).resolve().parents[2]
++_SOURCE_PATH = _REPO_ROOT / 'python' / 'paddle' / 'device' / '__init__.py'
++
++
++class _ConcretePlace:
++    def __init__(self, kind, device_id=None, device_type=None):
++        self.kind = kind
++        self.device_id = device_id
++        self.device_type = device_type
++
++
++class _Place:
++    def __init__(self, kind, device_id=None, device_type=None):
++        self.kind = kind
++        self.device_id = device_id
++        self.device_type = device_type
++
++    def is_gpu_place(self):
++        return self.kind == 'gpu'
++
++    def gpu_device_id(self):
++        return self.device_id
++
++    def is_cpu_place(self):
++        return self.kind == 'cpu'
++
++    def is_xpu_place(self):
++        return self.kind == 'xpu'
++
++    def xpu_device_id(self):
++        return self.device_id
++
++    def is_custom_place(self):
++        return self.kind == 'custom'
++
++    def custom_device_type(self):
++        return self.device_type
++
++    def custom_device_id(self):
++        return self.device_id
++
++
++class _CPUPlace(_ConcretePlace):
++    def __init__(self):
++        super().__init__('cpu')
++
++
++class _CUDAPlace(_ConcretePlace):
++    def __init__(self, device_id):
++        super().__init__('gpu', device_id=device_id)
++
++
++class _XPUPlace(_ConcretePlace):
++    def __init__(self, device_id):
++        super().__init__('xpu', device_id=device_id)
++
++
++class _CustomPlace(_ConcretePlace):
++    def __init__(self, device_type, device_id):
++        super().__init__('custom', device_id=device_id, device_type=device_type)
++
++
++def _strip_annotations(function):
++    function.returns = None
++    for argument in (
++        list(function.args.posonlyargs)
++        + list(function.args.args)
++        + list(function.args.kwonlyargs)
++    ):
++        argument.annotation = None
++
++
++def _load_checkout_function():
++    tree = ast.parse(
++        _SOURCE_PATH.read_text(encoding='utf-8'),
++        filename=str(_SOURCE_PATH),
++    )
++    target = None
++    for node in tree.body:
++        if isinstance(node, ast.FunctionDef) and node.name == '_convert_to_place':
++            target = copy.deepcopy(node)
++            target.decorator_list = []
++            _strip_annotations(target)
++            break
++    assert target is not None
++
++    core = types.SimpleNamespace(
++        Place=_Place,
++        CPUPlace=_CPUPlace,
++        CUDAPlace=_CUDAPlace,
++        XPUPlace=_XPUPlace,
++        CustomPlace=_CustomPlace,
++        get_all_custom_device_type=lambda: [],
++        is_compiled_with_cuda=lambda: True,
++        is_compiled_with_xpu=lambda: True,
++        is_compiled_with_ipu=lambda: True,
++        IPUPlace=lambda: _ConcretePlace('ipu'),
++    )
++    paddle = types.SimpleNamespace(
++        distributed=types.SimpleNamespace(
++            ParallelEnv=lambda: types.SimpleNamespace(dev_id=0)
++        )
++    )
++    namespace = {'core': core, 'paddle': paddle, 'os': os, 're': re}
++    module = ast.Module(body=[target], type_ignores=[])
++    ast.fix_missing_locations(module)
++    exec(compile(module, str(_SOURCE_PATH), 'exec'), namespace, namespace)
++    return namespace['_convert_to_place']
++
++
++def test_existing_string_and_concrete_place_behavior_remains_valid():
++    function = _load_checkout_function()
++    cpu = function('cpu')
++    concrete_gpu = _CUDAPlace(6)
++
++    assert isinstance(cpu, _CPUPlace)
++    assert function(concrete_gpu) is concrete_gpu
++
++
++def test_generic_place_preserves_device_type_and_id():
++    function = _load_checkout_function()
++
++    cpu = function(_Place('cpu'))
++    gpu = function(_Place('gpu', device_id=3))
++    xpu = function(_Place('xpu', device_id=4))
++    custom = function(
++        _Place('custom', device_id=5, device_type='custom_accel')
++    )
++
++    assert isinstance(cpu, _CPUPlace)
++    assert isinstance(gpu, _CUDAPlace)
++    assert gpu.device_id == 3
++    assert isinstance(xpu, _XPUPlace)
++    assert xpu.device_id == 4
++    assert isinstance(custom, _CustomPlace)
++    assert custom.device_type == 'custom_accel'
++    assert custom.device_id == 5

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78104/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78104/tests/test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+python -m pytest test/legacy_test/test_device_place_conversion_contract.py -q


### PR DESCRIPTION
## 关联

- SWE-Paddle 共建 issue: https://github.com/PaddlePaddle/Paddle/issues/79447
- 来源 PR: https://github.com/PaddlePaddle/Paddle/pull/78104

## 说明

- 新增 SWE-Paddle 任务 `PaddlePaddle__Paddle-78104`

## 验证结果

| 状态 | Existing behavior P2P | Generic `core.Place` F2P |
| --- | --- | --- |
| Base + `tests/test.patch` | PASS | FAIL，符合预期 |
| Base + test patch + `solution/code.patch` | PASS | PASS |

#### Base P2P：Existing Place conversion behavior

```text
.                                                                        [100%]
1 passed in 0.28s
Base existing P2P exit code: 0
````

#### Base F2P：Generic `core.Place` conversion

```text
F                                                                        [100%]
================================== FAILURES ===================================
_______________ test_generic_place_preserves_device_type_and_id _______________

    def test_generic_place_preserves_device_type_and_id():
        function = _load_checkout_function()

        cpu = function(_Place('cpu'))
        gpu = function(_Place('gpu', device_id=3))
        xpu = function(_Place('xpu', device_id=4))
        custom = function(
            _Place('custom', device_id=5, device_type='custom_accel')
        )

>       assert isinstance(cpu, _CPUPlace)
E       assert False
E        +  where False = isinstance(<legacy_test.test_device_place_conversion_contract._Place object at 0x000001B5C8D76C50>, _CPUPlace)

test\legacy_test\test_device_place_conversion_contract.py:146: AssertionError
=========================== short test summary info ===========================
FAILED test/legacy_test/test_device_place_conversion_contract.py::test_generic_place_preserves_device_type_and_id
1 failed in 0.30s
Base generic-Place F2P exit code: 1
```


#### Solution 测试

```text
Solution existing behavior P2P:
1 passed in 0.25s

Solution generic core.Place F2P:
1 passed in 0.27s
```

#### `tests/test.sh`

```text
..                                                                       [100%]
2 passed in 0.25s
Solution tests/test.sh exit code: 0
```
@sunzhongkai588