### PR TITLE
[SWE-Paddle] Add task PaddlePaddle__Paddle-56705

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-56705/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-56705/README.md
@@ -1,0 +1,46 @@
+# PaddlePaddle__Paddle-56705
+
+This directory converts Paddle PR #56705 into a SWE-Paddle community task candidate.
+
+## Source
+
+| Field | Value |
+| --- | --- |
+| Repo | `PaddlePaddle/Paddle` |
+| PR | [56705](https://github.com/PaddlePaddle/Paddle/pull/56705) |
+| PR title | [BugFix]Fix memory leak in mplayers |
+| Base commit | `23955fcfab3ecf5bfe4be9d3a4543cb0d9c7c377` |
+| Merged at | `2023-08-29` |
+| Task type | `bug_fix` |
+| Resource | CPU |
+
+## Summary
+
+修复 dynamic graph model-parallel identity 和 all-reduce 操作重复调用时产生的 Python-side runtime type 累积与长期内存增长问题。
+
+## Why This Is The Starter Example
+
+This sample is suitable as a SWE-Paddle starter example because:
+
+- It covers a real memory-lifecycle bug in distributed model-parallel helpers.
+- It requires preserving the existing forward/backward communication behavior while fixing repeated runtime type creation.
+- It has a clear single-file production scope and deterministic P2P/F2P behavior.
+- It can be verified on CPU with an AST overlay and controlled doubles, without GPU or multi-process timing dependencies.
+
+## Files
+
+- `proposal.md`: candidate proposal for maintainer triage.
+- `instruction.md`: self-contained problem statement for the coding agent.
+- `solution/code.patch`: gold patch from the merged PR.
+- `tests/test.patch`: test patch exposing the target behavior.
+- `tests/test.sh`: minimal target test command.
+- `environment/README.md`: environment notes for reproduction.
+- `README.md`: task overview and verification entrypoint.
+
+## Verification
+
+```bash
+bash tests/test.sh
+```
+
+Expected behavior: applying `tests/test.patch` to `base_commit` should fail on the target behavior; applying both `tests/test.patch` and `solution/code.patch` should pass the target tests.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-56705/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-56705/README.md
@@ -16,7 +16,7 @@ This directory converts Paddle PR #56705 into a SWE-Paddle community task candid
 
 ## Summary
 
-修复 dynamic graph model-parallel identity 和 all-reduce 操作重复调用时产生的 Python-side runtime type 累积与长期内存增长问题。
+Fixed the issue of Python-side runtime type accumulation and long-term memory growth caused by repeated calls to dynamic graph model-parallel identity and all-reduce operations.
 
 ## Why This Is The Starter Example
 

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-56705/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-56705/environment/README.md
@@ -1,0 +1,27 @@
+# Environment Notes
+
+This candidate is part of the SWE-Paddle community task set.
+
+## Expected Environment
+
+- Repository: `PaddlePaddle/Paddle`
+- Base commit: `23955fcfab3ecf5bfe4be9d3a4543cb0d9c7c377`
+- Resource: CPU
+- GPU required: no
+- Build path: Paddle source checkout at the base commit. This Python-only task may be verified with an AST overlay and controlled doubles; source build is not required.
+
+## Run Order
+
+1. Check out `PaddlePaddle/Paddle` at the base commit.
+2. Apply `tests/test.patch`.
+3. Run `bash tests/test.sh`; the target behavior should fail before the fix.
+4. Apply `solution/code.patch`.
+5. Run `bash tests/test.sh` again; the target behavior should pass after the gold patch.
+
+## Minimal Test Command
+
+```bash
+bash tests/test.sh
+```
+
+The verifier is responsible for deriving stable F2P and P2P node IDs from repeated runs.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-56705/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-56705/instruction.md
@@ -1,0 +1,23 @@
+# 修复 model-parallel 操作重复调用导致的内存增长
+
+## 详细描述
+
+修复 dynamic graph 模式下 model-parallel identity 和 all-reduce 操作被重复调用时产生的 Python-side runtime type 累积问题，避免长时间训练过程中出现不必要的内存持续增长。
+
+## 验收说明
+
+- 重复调用 model-parallel identity 操作时，不应按调用次数持续创建新的 Python-side autograd runtime type
+- 重复调用 model-parallel all-reduce 操作时，不应按调用次数持续创建新的 Python-side autograd runtime type
+- identity 和 all-reduce 原有的 forward/backward communication behavior 必须保持不变
+
+## 技术要求
+
+- 熟悉 Python
+- 熟悉 Paddle dynamic graph 和 autograd
+- 了解 model-parallel process group、identity 和 all-reduce 的执行语义
+
+## Acceptance Criteria
+
+- The behavior described above should be fixed.
+- Existing valid behavior should remain unchanged.
+- Do not satisfy the task by deleting tests, weakening assertions, or bypassing validation broadly.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-56705/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-56705/instruction.md
@@ -1,17 +1,21 @@
-# 修复 model-parallel 操作重复调用导致的内存增长
+# 修复 model-parallel layers 中的内存泄漏
 
 ## 详细描述
 
-修复 dynamic graph 模式下 model-parallel identity 和 all-reduce 操作被重复调用时产生的 Python-side runtime type 累积问题，避免长时间训练过程中出现不必要的内存持续增长。
+在动态图模式下，模型并行相关操作被反复调用时可能产生额外的内存占用，并随着调用次数增加而不断累积。
+
+该问题会影响长时间运行的模型并行任务。请修复这一内存泄漏，同时保持相关操作原有的功能和执行行为不变。
 
 ## 验收说明
 
-- 重复调用 model-parallel identity 操作时，不应按调用次数持续创建新的 Python-side autograd runtime type
-- 重复调用 model-parallel all-reduce 操作时，不应按调用次数持续创建新的 Python-side autograd runtime type
-- identity 和 all-reduce 原有的 forward/backward communication behavior 必须保持不变
+- 重复调用 model-parallel `identity` 时，不应产生与调用次数持续相关的额外对象累积
+- 重复调用 model-parallel `all-reduce` 时，不应产生与调用次数持续相关的额外对象累积
+- `identity` 和 `all-reduce` 的前向行为不得发生变化
+- `identity` 和 `all-reduce` 的反向传播及通信行为不得发生变化
+- 静态图模式下的现有行为不得退化
 
 ## 技术要求
 
 - 熟悉 Python
 - 熟悉 Paddle dynamic graph 和 autograd
-- 了解 model-parallel process group、identity 和 all-reduce 的执行语义
+- 了解 model-parallel process group、`identity` 和 `all-reduce` 的执行语义

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-56705/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-56705/instruction.md
@@ -15,9 +15,3 @@
 - 熟悉 Python
 - 熟悉 Paddle dynamic graph 和 autograd
 - 了解 model-parallel process group、identity 和 all-reduce 的执行语义
-
-## Acceptance Criteria
-
-- The behavior described above should be fixed.
-- Existing valid behavior should remain unchanged.
-- Do not satisfy the task by deleting tests, weakening assertions, or bypassing validation broadly.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-56705/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-56705/proposal.md
@@ -1,0 +1,54 @@
+# Task Proposal: PaddlePaddle__Paddle-56705
+
+## 1. 来源信息
+
+- Instance ID：`PaddlePaddle__Paddle-56705`
+- PR 链接：https://github.com/PaddlePaddle/Paddle/pull/56705
+- PR 标题：`[BugFix]Fix memory leak in mplayers`
+- `base_commit`：`23955fcfab3ecf5bfe4be9d3a4543cb0d9c7c377`
+- merged 时间：`2023-08-29`
+- 你的身份：熟悉该模块的 contributor
+- 后续联系人：TBD
+
+## 2. 问题一句话
+
+修复 dynamic graph model-parallel identity 和 all-reduce 操作重复调用时产生的 Python-side runtime type 累积与长期内存增长问题。
+
+## 3. 为什么适合作为 SWE-Paddle 样本
+
+- **真实性**：该任务来自已合入的 Paddle PR #56705，不是合成任务。
+- **代表性**：它覆盖 distributed model parallel、dynamic graph、autograd lifecycle 和 communication contract。
+- **边界清楚**：production change 集中在 `python/paddle/distributed/fleet/layers/mpu/mp_ops.py`，目标行为可以由独立测试直接暴露。
+- **非平凡性**：正确修复既要消除重复创建 runtime type 的问题，也要保持 identity 和 all-reduce 原有的 forward/backward behavior。
+
+## 4. 任务类型和标签
+
+- 任务类型：`bug_fix`
+- 执行后端：`cpu`
+- 设备范围：`cpu_only`
+- 模块标签：`[distributed, fleet, model_parallel, autograd, dynamic_graph]`
+
+## 5. 验证思路
+
+- 目标测试命令：`bash tests/test.sh`
+- 目标测试文件：`test/swe_paddle/test_pr56705_mp_ops_pylayer_lifecycle.py`
+- 修复前预期：在 `base_commit` 上应用 `tests/test.patch` 后，已有 identity/all-reduce communication contract 测试应 pass，重复调用产生多个 distinct `PyLayer` runtime type 的测试应 fail。
+- 修复后预期：继续应用 `solution/code.patch` 后，已有行为测试和 runtime type reuse 测试均应 pass。
+- P2P 候选：identity 和 all-reduce 原有的 forward/backward communication behavior。
+
+## 6. 环境与资源
+
+- 资源需求：CPU
+- Paddle 来源：`PaddlePaddle/Paddle` source checkout at `base_commit`
+- 是否能提供 Docker：暂无
+- patch 类型：Python-only
+- 环境建议：使用可运行 `pytest` 的 Python 环境，通过 AST overlay 执行 checkout 中的目标控制流，并使用 controlled doubles 提供依赖；无需 Paddle source build 或 distributed launch
+- 最小测试命令：`bash tests/test.sh`
+- 是否有 oracle 日志：由 SWE-Paddle verifier 结果另行维护
+
+## 7. 风险自查
+
+- 泄露风险：正式 `instruction.md` 只描述目标行为和验收标准，不直接给出 production code 的具体修改方式。
+- 环境风险：测试不依赖历史 Paddle 模块的完整 import，通过 AST overlay 隔离版本兼容问题。
+- flaky 风险：测试不测真实 RSS、不启动多进程、不依赖 GC timing，而是验证稳定的 runtime type reuse contract。
+- 拆分风险：identity 和 all-reduce 属于同一 runtime lifecycle 问题，并由同一 production file 中的修改共同修复，适合作为一个样本。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-56705/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-56705/proposal.md
@@ -12,14 +12,14 @@
 
 ## 2. 问题一句话
 
-修复 dynamic graph model-parallel identity 和 all-reduce 操作重复调用时产生的 Python-side runtime type 累积与长期内存增长问题。
+修复动态图模式下 model-parallel `identity` 和 `all-reduce` 被反复调用时产生的运行时类型累积与内存泄漏问题。
 
 ## 3. 为什么适合作为 SWE-Paddle 样本
 
-- **真实性**：该任务来自已合入的 Paddle PR #56705，不是合成任务。
-- **代表性**：它覆盖 distributed model parallel、dynamic graph、autograd lifecycle 和 communication contract。
-- **边界清楚**：production change 集中在 `python/paddle/distributed/fleet/layers/mpu/mp_ops.py`，目标行为可以由独立测试直接暴露。
-- **非平凡性**：正确修复既要消除重复创建 runtime type 的问题，也要保持 identity 和 all-reduce 原有的 forward/backward behavior。
+- **真实性**：该任务来自 Paddle 已合入的 PR #56705，并非人工构造的问题。
+- **代表性**：该任务涉及 distributed model parallel、动态图、自动求导生命周期，以及模型并行操作的前向和反向通信行为。
+- **边界清楚**：production change 集中在 `python/paddle/distributed/fleet/layers/mpu/mp_ops.py`，问题范围明确，相关行为可以通过独立测试稳定验证。
+- **非平凡性**：修复不仅需要消除重复调用造成的运行时类型累积，还必须保持 `identity` 和 `all-reduce` 原有的前向、反向及通信行为不变。
 
 ## 4. 任务类型和标签
 
@@ -32,9 +32,9 @@
 
 - 目标测试命令：`bash tests/test.sh`
 - 目标测试文件：`test/swe_paddle/test_pr56705_mp_ops_pylayer_lifecycle.py`
-- 修复前预期：在 `base_commit` 上应用 `tests/test.patch` 后，已有 identity/all-reduce communication contract 测试应 pass，重复调用产生多个 distinct `PyLayer` runtime type 的测试应 fail。
-- 修复后预期：继续应用 `solution/code.patch` 后，已有行为测试和 runtime type reuse 测试均应 pass。
-- P2P 候选：identity 和 all-reduce 原有的 forward/backward communication behavior。
+- 修复前预期：在 `base_commit` 上应用 `tests/test.patch` 后，`identity` 和 `all-reduce` 原有通信行为的测试应通过；验证重复调用是否持续产生不同 `PyLayer` 运行时类型的测试应失败。
+- 修复后预期：继续应用 `solution/code.patch` 后，原有行为测试和运行时类型复用测试均应通过。
+- P2P 候选：`identity` 和 `all-reduce` 原有的前向、反向及通信行为。
 
 ## 6. 环境与资源
 
@@ -42,13 +42,13 @@
 - Paddle 来源：`PaddlePaddle/Paddle` source checkout at `base_commit`
 - 是否能提供 Docker：暂无
 - patch 类型：Python-only
-- 环境建议：使用可运行 `pytest` 的 Python 环境，通过 AST overlay 执行 checkout 中的目标控制流，并使用 controlled doubles 提供依赖；无需 Paddle source build 或 distributed launch
+- 环境建议：使用能够运行 `pytest` 的 Python 环境，通过 AST overlay 加载 source checkout 中的目标逻辑，并使用可控的测试替身补充运行依赖；无需编译 Paddle 源码，也无需启动真实的分布式任务。
 - 最小测试命令：`bash tests/test.sh`
 - 是否有 oracle 日志：由 SWE-Paddle verifier 结果另行维护
 
 ## 7. 风险自查
 
-- 泄露风险：正式 `instruction.md` 只描述目标行为和验收标准，不直接给出 production code 的具体修改方式。
-- 环境风险：测试不依赖历史 Paddle 模块的完整 import，通过 AST overlay 隔离版本兼容问题。
-- flaky 风险：测试不测真实 RSS、不启动多进程、不依赖 GC timing，而是验证稳定的 runtime type reuse contract。
-- 拆分风险：identity 和 all-reduce 属于同一 runtime lifecycle 问题，并由同一 production file 中的修改共同修复，适合作为一个样本。
+- 泄露风险：正式 `instruction.md` 仅描述模型并行操作重复调用时的内存泄漏现象及预期行为，不直接说明 `PyLayer` 的定义位置、类型复用方式或具体代码修改方案。
+- 环境风险：测试不依赖历史版本 Paddle 模块的完整导入，通过 AST overlay 隔离源码版本和运行环境之间的兼容性问题。
+- flaky 风险：测试不直接测量真实 RSS，不启动多进程，也不依赖垃圾回收时机，而是验证重复调用过程中运行时类型数量是否保持稳定。
+- 拆分风险：`identity` 和 `all-reduce` 的问题具有相同成因，并由同一 production file 中的相关修改共同解决，适合作为一个完整样本。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-56705/solution/code.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-56705/solution/code.patch
@@ -1,0 +1,146 @@
+diff --git a/python/paddle/distributed/fleet/layers/mpu/mp_ops.py b/python/paddle/distributed/fleet/layers/mpu/mp_ops.py
+index c18ef35e189fc361284b32acdea9abba8c69a2e8..26949b12e42f76c3591a548d874ddbe401eb73ab 100644
+--- a/python/paddle/distributed/fleet/layers/mpu/mp_ops.py
++++ b/python/paddle/distributed/fleet/layers/mpu/mp_ops.py
+@@ -14,6 +14,7 @@
+ 
+ import paddle
+ from paddle import _legacy_C_ops
++from paddle.autograd import PyLayer
+ from paddle.distributed import collective
+ from paddle.fluid import core
+ from paddle.fluid.data_feeder import check_dtype, check_variable_and_dtype
+@@ -24,6 +25,59 @@ from paddle.nn.utils import dygraph_utils
+ from ....communication.reduce import ReduceOp, _get_reduce_op
+ 
+ 
++class c_identity_eager(PyLayer):
++    @staticmethod
++    def forward(ctx, tensor, group):
++        ctx.group = group
++        return _legacy_C_ops.c_identity(
++            tensor,
++            'use_calc_stream',
++            True,
++            'ring_id',
++            group.id,
++            'use_model_parallel',
++            True,
++        )
++
++    @staticmethod
++    def backward(ctx, dy):
++        op_type = _get_reduce_op(ReduceOp.SUM, "_c_identity")
++        group = ctx.group
++        group.process_group.all_reduce_on_calc_stream(dy, op_type)
++        return dy
++
++
++class mp_allreduce_eager(PyLayer):
++    @staticmethod
++    def forward(ctx, tensor, group, use_calc_stream, use_model_parallel):
++        ctx.ring_id = group.id
++
++        if use_calc_stream:
++            op_type = _get_reduce_op(ReduceOp.SUM, "_mp_allreduce")
++            group.process_group.all_reduce_on_calc_stream(tensor, op_type)
++            return tensor
++        else:
++            return _legacy_C_ops.c_allreduce_sum_(
++                tensor,
++                'use_calc_stream',
++                use_calc_stream,
++                'ring_id',
++                ctx.ring_id,
++            )
++
++    @staticmethod
++    def backward(ctx, dy):
++        return _legacy_C_ops.c_identity(
++            dy,
++            'use_calc_stream',
++            True,
++            'ring_id',
++            ctx.ring_id,
++            'use_model_parallel',
++            True,
++        )
++
++
+ def _c_identity(tensor, group=None):
+     """
+     Return a copy of the tensor, mainly used with model parallel.
+@@ -41,28 +95,7 @@ def _c_identity(tensor, group=None):
+     ring_id = 0 if group is None else group.id
+ 
+     if in_dygraph_mode():
+-        from paddle.autograd import PyLayer
+-
+-        class c_identity_eager(PyLayer):
+-            @staticmethod
+-            def forward(ctx, tensor):
+-                return _legacy_C_ops.c_identity(
+-                    tensor,
+-                    'use_calc_stream',
+-                    True,
+-                    'ring_id',
+-                    group.id,
+-                    'use_model_parallel',
+-                    True,
+-                )
+-
+-            @staticmethod
+-            def backward(ctx, dy):
+-                op_type = _get_reduce_op(ReduceOp.SUM, "_c_identity")
+-                group.process_group.all_reduce_on_calc_stream(dy, op_type)
+-                return dy
+-
+-        return c_identity_eager.apply(tensor)
++        return c_identity_eager.apply(tensor, group)
+     else:
+         op_type = 'c_identity'
+         helper = LayerHelper(op_type, **locals())
+@@ -230,43 +263,6 @@ def _mp_allreduce(
+     if in_dygraph_mode():
+         group = collective._get_default_group() if group is None else group
+         assert op == ReduceOp.SUM, f"Unknown parameter: {op}."
+-
+-        from paddle.autograd import PyLayer
+-
+-        class mp_allreduce_eager(PyLayer):
+-            @staticmethod
+-            def forward(
+-                ctx, tensor, group, use_calc_stream, use_model_parallel
+-            ):
+-                ctx.ring_id = group.id
+-
+-                if use_calc_stream:
+-                    op_type = _get_reduce_op(op, "_mp_allreduce")
+-                    group.process_group.all_reduce_on_calc_stream(
+-                        tensor, op_type
+-                    )
+-                    return tensor
+-                else:
+-                    return _legacy_C_ops.c_allreduce_sum_(
+-                        tensor,
+-                        'use_calc_stream',
+-                        use_calc_stream,
+-                        'ring_id',
+-                        ring_id,
+-                    )
+-
+-            @staticmethod
+-            def backward(ctx, dy):
+-                return _legacy_C_ops.c_identity(
+-                    dy,
+-                    'use_calc_stream',
+-                    True,
+-                    'ring_id',
+-                    ctx.ring_id,
+-                    'use_model_parallel',
+-                    True,
+-                )
+-
+         return mp_allreduce_eager.apply(
+             tensor, group, use_calc_stream, use_model_parallel
+         )

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-56705/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-56705/tests/test.patch
@@ -1,0 +1,211 @@
+diff --git a/test/swe_paddle/test_pr56705_mp_ops_pylayer_lifecycle.py b/test/swe_paddle/test_pr56705_mp_ops_pylayer_lifecycle.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..a3e20080a1fbb0b537dc5fb8266749380ae10b6b
+--- /dev/null
++++ b/test/swe_paddle/test_pr56705_mp_ops_pylayer_lifecycle.py
+@@ -0,0 +1,205 @@
++from __future__ import annotations
++
++import ast
++import copy
++import sys
++import types
++from pathlib import Path
++
++import pytest
++
++
++TARGET = Path("python/paddle/distributed/fleet/layers/mpu/mp_ops.py")
++SELECTED_NODES = {
++    "c_identity_eager",
++    "mp_allreduce_eager",
++    "_c_identity",
++    "_mp_allreduce",
++}
++
++
++class FakePyLayer:
++    invocations = []
++
++    @classmethod
++    def apply(cls, *args):
++        ctx = types.SimpleNamespace()
++        FakePyLayer.invocations.append((cls, ctx, args))
++        return cls.forward(ctx, *args)
++
++
++class FakeLegacyOps:
++    def __init__(self):
++        self.calls = []
++
++    def c_identity(self, tensor, *attrs):
++        self.calls.append(("c_identity", tensor, attrs))
++        return ("identity", tensor)
++
++    def c_allreduce_sum_(self, tensor, *attrs):
++        self.calls.append(("c_allreduce_sum_", tensor, attrs))
++        return ("allreduce", tensor)
++
++
++class FakeProcessGroup:
++    def __init__(self):
++        self.calls = []
++
++    def all_reduce_on_calc_stream(self, tensor, op_type):
++        self.calls.append((tensor, op_type))
++
++
++class FakeGroup:
++    def __init__(self, group_id=17):
++        self.id = group_id
++        self.process_group = FakeProcessGroup()
++
++    def is_member(self):
++        return True
++
++
++class ReduceOp:
++    SUM = "sum"
++
++
++def _get_reduce_op(op, name):
++    return (op, name)
++
++
++def _attrs_to_dict(attrs):
++    assert len(attrs) % 2 == 0
++    return dict(zip(attrs[0::2], attrs[1::2]))
++
++
++def _load_checkout_overlay(monkeypatch):
++    source = TARGET.read_text(encoding="utf-8")
++    tree = ast.parse(source, filename=str(TARGET))
++    body = []
++    for node in tree.body:
++        if isinstance(node, (ast.ClassDef, ast.FunctionDef)) and node.name in SELECTED_NODES:
++            body.append(copy.deepcopy(node))
++
++    names = {node.name for node in body}
++    assert "_c_identity" in names
++    assert "_mp_allreduce" in names
++
++    fake_autograd = types.ModuleType("paddle.autograd")
++    fake_autograd.PyLayer = FakePyLayer
++    fake_paddle = types.ModuleType("paddle")
++    fake_paddle.autograd = fake_autograd
++    monkeypatch.setitem(sys.modules, "paddle", fake_paddle)
++    monkeypatch.setitem(sys.modules, "paddle.autograd", fake_autograd)
++
++    legacy = FakeLegacyOps()
++    default_group = FakeGroup(group_id=31)
++    namespace = {
++        "PyLayer": FakePyLayer,
++        "_legacy_C_ops": legacy,
++        "ReduceOp": ReduceOp,
++        "_get_reduce_op": _get_reduce_op,
++        "in_dygraph_mode": lambda: True,
++        "collective": types.SimpleNamespace(_get_default_group=lambda: default_group),
++        "LayerHelper": object,
++        "check_variable_and_dtype": lambda *args, **kwargs: None,
++    }
++    module = ast.Module(body=body, type_ignores=[])
++    ast.fix_missing_locations(module)
++    exec(compile(module, str(TARGET), "exec"), namespace)
++    return namespace, legacy
++
++
++@pytest.fixture(autouse=True)
++def _reset_fake_pylayer():
++    FakePyLayer.invocations.clear()
++
++
++def test_c_identity_forward_backward_contract(monkeypatch):
++    namespace, legacy = _load_checkout_overlay(monkeypatch)
++    group = FakeGroup(group_id=23)
++    tensor = object()
++
++    output = namespace["_c_identity"](tensor, group=group)
++
++    assert output == ("identity", tensor)
++    assert len(FakePyLayer.invocations) == 1
++    cls, ctx, _ = FakePyLayer.invocations[-1]
++    op_name, called_tensor, attrs = legacy.calls[-1]
++    assert op_name == "c_identity"
++    assert called_tensor is tensor
++    assert _attrs_to_dict(attrs) == {
++        "use_calc_stream": True,
++        "ring_id": 23,
++        "use_model_parallel": True,
++    }
++
++    dy = object()
++    assert cls.backward(ctx, dy) is dy
++    assert group.process_group.calls == [(dy, (ReduceOp.SUM, "_c_identity"))]
++
++
++def test_mp_allreduce_forward_backward_contract(monkeypatch):
++    namespace, legacy = _load_checkout_overlay(monkeypatch)
++    group = FakeGroup(group_id=29)
++    tensor = object()
++
++    output = namespace["_mp_allreduce"](
++        tensor,
++        op=ReduceOp.SUM,
++        group=group,
++        use_calc_stream=True,
++        use_model_parallel=True,
++    )
++
++    assert output is tensor
++    assert group.process_group.calls == [
++        (tensor, (ReduceOp.SUM, "_mp_allreduce"))
++    ]
++    cls, ctx, _ = FakePyLayer.invocations[-1]
++
++    dy = object()
++    backward_output = cls.backward(ctx, dy)
++    assert backward_output == ("identity", dy)
++    op_name, called_tensor, attrs = legacy.calls[-1]
++    assert op_name == "c_identity"
++    assert called_tensor is dy
++    assert _attrs_to_dict(attrs) == {
++        "use_calc_stream": True,
++        "ring_id": 29,
++        "use_model_parallel": True,
++    }
++
++
++def test_c_identity_reuses_pylayer_class_across_calls(monkeypatch):
++    namespace, _ = _load_checkout_overlay(monkeypatch)
++    group = FakeGroup(group_id=37)
++
++    for _ in range(4):
++        namespace["_c_identity"](object(), group=group)
++
++    dispatched_classes = [item[0] for item in FakePyLayer.invocations]
++    assert len(set(dispatched_classes)) == 1, (
++        "Repeated _c_identity calls created distinct PyLayer runtime types; "
++        "this deterministic type growth is a proxy for the reported long-run "
++        "Python-side memory accumulation."
++    )
++
++
++def test_mp_allreduce_reuses_pylayer_class_across_calls(monkeypatch):
++    namespace, _ = _load_checkout_overlay(monkeypatch)
++    group = FakeGroup(group_id=41)
++
++    for _ in range(4):
++        namespace["_mp_allreduce"](
++            object(),
++            op=ReduceOp.SUM,
++            group=group,
++            use_calc_stream=True,
++            use_model_parallel=True,
++        )
++
++    dispatched_classes = [item[0] for item in FakePyLayer.invocations]
++    assert len(set(dispatched_classes)) == 1, (
++        "Repeated _mp_allreduce calls created distinct PyLayer runtime types; "
++        "this deterministic type growth is a proxy for the reported long-run "
++        "Python-side memory accumulation."
++    )

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-56705/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-56705/tests/test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python -m pytest test/swe_paddle/test_pr56705_mp_ops_pylayer_lifecycle.py -q


### PR DESCRIPTION
## 关联

- SWE-Paddle 共建 issue: https://github.com/PaddlePaddle/Paddle/issues/79447
- 来源 PR: https://github.com/PaddlePaddle/Paddle/pull/56705

## 说明

- 新增 SWE-Paddle 任务 `PaddlePaddle__Paddle-56705`

@sunzhongkai588

## 验证结果

| 状态 | Communication contracts P2P | `_c_identity` PyLayer reuse F2P | `_mp_allreduce` PyLayer reuse F2P |
| --- | --- | --- | --- |
| Base + `tests/test.patch` | PASS | FAIL，符合预期 | FAIL，符合预期 |
| Base + test patch + `solution/code.patch` | PASS | PASS | PASS |

#### Base P2P：Existing communication contracts

```text
test_c_identity_forward_backward_contract:
.                                                                        [100%]
1 passed in 0.03s
Base c_identity communication-contract P2P exit code: 0

test_mp_allreduce_forward_backward_contract:
.                                                                        [100%]
1 passed in 0.02s
Base mp_allreduce communication-contract P2P exit code: 0
```

#### Base F2P：`_c_identity` PyLayer class reuse

```text
F                                                                        [100%]
================================== FAILURES ===================================
______________ test_c_identity_reuses_pylayer_class_across_calls ______________

    def test_c_identity_reuses_pylayer_class_across_calls(monkeypatch):
        namespace, _ = _load_checkout_overlay(monkeypatch)
        group = FakeGroup(group_id=37)

        for _ in range(4):
            namespace["_c_identity"](object(), group=group)

        dispatched_classes = [item[0] for item in FakePyLayer.invocations]
>       assert len(set(dispatched_classes)) == 1, (
            "Repeated _c_identity calls created distinct PyLayer runtime types; "
            "this deterministic type growth is a proxy for the reported long-run "
            "Python-side memory accumulation."
        )
E       AssertionError: Repeated _c_identity calls created distinct PyLayer runtime types; this deterministic type growth is a proxy for the reported long-run Python-side memory accumulation.
E       assert 4 == 1
E        +  where 4 = len({<class 'c_identity_eager'>, <class 'c_identity_eager'>, <class 'c_identity_eager'>, <class 'c_identity_eager'>})

FAILED test/swe_paddle/test_pr56705_mp_ops_pylayer_lifecycle.py::test_c_identity_reuses_pylayer_class_across_calls
1 failed in 0.16s
Base c_identity PyLayer-reuse F2P exit code: 1
```

#### Base F2P：`_mp_allreduce` PyLayer class reuse

```text
F                                                                        [100%]
================================== FAILURES ===================================
_____________ test_mp_allreduce_reuses_pylayer_class_across_calls _____________

    def test_mp_allreduce_reuses_pylayer_class_across_calls(monkeypatch):
        namespace, _ = _load_checkout_overlay(monkeypatch)
        group = FakeGroup(group_id=41)

        for _ in range(4):
            namespace["_mp_allreduce"](
                object(),
                op=ReduceOp.SUM,
                group=group,
                use_calc_stream=True,
                use_model_parallel=True,
            )

        dispatched_classes = [item[0] for item in FakePyLayer.invocations]
>       assert len(set(dispatched_classes)) == 1, (
            "Repeated _mp_allreduce calls created distinct PyLayer runtime types; "
            "this deterministic type growth is a proxy for the reported long-run "
            "Python-side memory accumulation."
        )
E       AssertionError: Repeated _mp_allreduce calls created distinct PyLayer runtime types; this deterministic type growth is a proxy for the reported long-run Python-side memory accumulation.
E       assert 4 == 1
E        +  where 4 = len({<class 'mp_allreduce_eager'>, <class 'mp_allreduce_eager'>, <class 'mp_allreduce_eager'>, <class 'mp_allreduce_eager'>})

FAILED test/swe_paddle/test_pr56705_mp_ops_pylayer_lifecycle.py::test_mp_allreduce_reuses_pylayer_class_across_calls
1 failed in 0.19s
Base mp_allreduce PyLayer-reuse F2P exit code: 1
```

#### Solution 测试

```text
Solution c_identity communication-contract P2P:
1 passed in 0.02s

Solution mp_allreduce communication-contract P2P:
1 passed in 0.02s

Solution c_identity PyLayer-reuse F2P:
1 passed in 0.02s

Solution mp_allreduce PyLayer-reuse F2P:
1 passed in 0.02s
```

#### `tests/test.sh`

```text
....                                                                     [100%]
4 passed in 0.04s
Solution tests/test.sh exit code: 0
```