### PR TITLE
[SWE-Paddle] Add task PaddlePaddle__Paddle-54625

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-54625/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-54625/README.md
@@ -1,0 +1,46 @@
+# PaddlePaddle__Paddle-54625
+
+This directory converts Paddle PR #54625 into a SWE-Paddle community task candidate.
+
+## Source
+
+| Field | Value |
+| --- | --- |
+| Repo | `PaddlePaddle/Paddle` |
+| PR | [54625](https://github.com/PaddlePaddle/Paddle/pull/54625) |
+| PR title | [BugFix] fix bug of release output in pp |
+| Base commit | `974676bc6ec41e222083729af55f34e4b2f20f2e` |
+| Merged at | `2023-06-16` |
+| Task type | `bug_fix` |
+| Resource | CPU |
+
+## Summary
+
+修复 pipeline parallel 在释放中间输出时错误清理未初始化或已发生 in-place 修改的 Tensor 数据的问题。
+
+## Why This Is The Starter Example
+
+This sample is suitable as a SWE-Paddle starter example because:
+
+- It covers a real Tensor-lifecycle bug in pipeline parallel output release.
+- It requires preserving normal output cleanup while protecting unsafe Tensor states.
+- It has a clear single-file production scope and deterministic P2P/F2P behavior.
+- It can be verified on CPU with an AST overlay and controlled doubles, without GPU or distributed communication dependencies.
+
+## Files
+
+- `proposal.md`: candidate proposal for maintainer triage.
+- `instruction.md`: self-contained problem statement for the coding agent.
+- `solution/code.patch`: gold patch from the merged PR.
+- `tests/test.patch`: test patch exposing the target behavior.
+- `tests/test.sh`: minimal target test command.
+- `environment/README.md`: environment notes for reproduction.
+- `README.md`: task overview and verification entrypoint.
+
+## Verification
+
+```bash
+bash tests/test.sh
+```
+
+Expected behavior: applying `tests/test.patch` to `base_commit` should fail on the target behavior; applying both `tests/test.patch` and `solution/code.patch` should pass the target tests.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-54625/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-54625/README.md
@@ -16,7 +16,7 @@ This directory converts Paddle PR #54625 into a SWE-Paddle community task candid
 
 ## Summary
 
-修复 pipeline parallel 在释放中间输出时错误清理未初始化或已发生 in-place 修改的 Tensor 数据的问题。
+Fixed an issue in pipeline parallelism where tensor data that was uninitialized or had undergone in-place modification was incorrectly cleaned up when releasing intermediate outputs.
 
 ## Why This Is The Starter Example
 

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-54625/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-54625/environment/README.md
@@ -1,0 +1,27 @@
+# Environment Notes
+
+This candidate is part of the SWE-Paddle community task set.
+
+## Expected Environment
+
+- Repository: `PaddlePaddle/Paddle`
+- Base commit: `974676bc6ec41e222083729af55f34e4b2f20f2e`
+- Resource: CPU
+- GPU required: no
+- Build path: Paddle source checkout at the base commit. This Python-only task may be verified with an AST overlay and controlled doubles; source build is not required.
+
+## Run Order
+
+1. Check out `PaddlePaddle/Paddle` at the base commit.
+2. Apply `tests/test.patch`.
+3. Run `bash tests/test.sh`; the target behavior should fail before the fix.
+4. Apply `solution/code.patch`.
+5. Run `bash tests/test.sh` again; the target behavior should pass after the gold patch.
+
+## Minimal Test Command
+
+```bash
+bash tests/test.sh
+```
+
+The verifier is responsible for deriving stable F2P and P2P node IDs from repeated runs.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-54625/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-54625/instruction.md
@@ -1,0 +1,23 @@
+# 修复 pipeline parallel 中间输出的不安全释放
+
+## 详细描述
+
+修复 pipeline parallel 在发送中间输出后回收 Tensor 底层数据时的不安全释放问题。未初始化的 Tensor 或已经发生 in-place 修改的 Tensor 不应被清理，否则可能破坏后续访问或 autograd 生命周期；满足安全条件的正常中间输出仍应按原有行为释放。
+
+## 验收说明
+
+- 未初始化的 pipeline 中间输出 Tensor 不应被释放
+- 已发生 in-place 修改的 pipeline 中间输出 Tensor 不应被释放
+- 已初始化且未发生 in-place 修改的 Tensor，以及 tuple/list 输出的既有释放行为必须保持不变
+
+## 技术要求
+
+- 熟悉 Python
+- 熟悉 Paddle dynamic graph 和 Tensor lifecycle
+- 了解 pipeline parallel 中间输出的发送、缓存与释放流程
+
+## Acceptance Criteria
+
+- The behavior described above should be fixed.
+- Existing valid behavior should remain unchanged.
+- Do not satisfy the task by deleting tests, weakening assertions, or bypassing validation broadly.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-54625/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-54625/instruction.md
@@ -1,17 +1,21 @@
-# 修复 pipeline parallel 中间输出的不安全释放
+# 修复 pipeline parallel 输出释放异常
 
 ## 详细描述
 
-修复 pipeline parallel 在发送中间输出后回收 Tensor 底层数据时的不安全释放问题。未初始化的 Tensor 或已经发生 in-place 修改的 Tensor 不应被清理，否则可能破坏后续访问或 autograd 生命周期；满足安全条件的正常中间输出仍应按原有行为释放。
+在 pipeline parallel 训练过程中，中间输出发送完成后，系统会回收不再需要的 Tensor 数据，以减少内存占用。当前输出释放逻辑未充分考虑 Tensor 的状态，可能会清理尚未初始化或已经发生原地修改的 Tensor，从而影响后续执行。请修复该问题，确保仅回收可以安全释放的中间输出，同时保持正常输出原有的释放行为。
 
 ## 验收说明
 
-- 未初始化的 pipeline 中间输出 Tensor 不应被释放
-- 已发生 in-place 修改的 pipeline 中间输出 Tensor 不应被释放
-- 已初始化且未发生 in-place 修改的 Tensor，以及 tuple/list 输出的既有释放行为必须保持不变
+- 尚未初始化的 pipeline 中间输出 Tensor 不应被释放
+- 已经发生原地修改的 pipeline 中间输出 Tensor 不应被释放
+- 已初始化且未发生原地修改的 Tensor 应保持原有释放行为
+- 单个 Tensor 以及 tuple/list 中的 Tensor 均应得到正确处理
+- tuple/list 中的非 Tensor 元素不得受到影响
+- 修复不得影响 pipeline parallel 原有的前向、反向和通信行为
 
 ## 技术要求
 
 - 熟悉 Python
-- 熟悉 Paddle dynamic graph 和 Tensor lifecycle
-- 了解 pipeline parallel 中间输出的发送、缓存与释放流程
+- 熟悉 Paddle dynamic graph 和 Tensor 生命周期
+- 了解 pipeline parallel 中间输出的发送、保存和释放流程
+- 了解 Tensor 初始化状态及原地修改语义

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-54625/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-54625/instruction.md
@@ -1,25 +1,23 @@
-# 修复 pipeline parallel 输出释放异常
+# 修复 Pipeline Parallel 错误释放输出 Tensor 的问题
 
 ## 详细描述
 
-在 pipeline parallel 训练过程中，中间输出发送完成后，系统会清理不再需要的 Tensor 数据，以减少内存占用。
+Pipeline Parallel 会在中间输出发送完成后清理不再需要的 Tensor 数据，以减少显存占用。 
 
-当前输出释放逻辑没有充分考虑 Tensor 的状态，可能会清理尚未初始化或已经执行过 inplace 操作的 Tensor。这里的 inplace 操作是指直接修改 Tensor 本身，并使其 inplace version 发生变化的操作。
+但是目前尚未初始化的 Tensor，或者已经执行过 `inplace` 操作的 Tensor，也会被清理。 
 
-请修复该问题，确保仅清理满足释放条件的中间输出，同时保持其他输出原有的释放行为。
+需要避免清理这两类 Tensor，同时保持普通输出原有的释放行为。
 
 ## 验收说明
 
-* 尚未初始化的 pipeline 中间输出 Tensor 不应被释放
-* 已经执行过 inplace 操作的 pipeline 中间输出 Tensor 不应被释放
-* 已初始化且未执行过 inplace 操作的 Tensor 应保持原有释放行为
-* 单个 Tensor 以及 tuple/list 中的 Tensor 均应得到正确处理
-* tuple/list 中的非 Tensor 元素不得受到影响
-* 修复不得影响 pipeline parallel 原有的前向、反向和通信行为
+- 尚未初始化的输出 Tensor 不应被清理
+- 执行过 `inplace` 操作的输出 Tensor 不应被清理
+- 已初始化且未执行过 `inplace` 操作的输出 Tensor 应正常清理
+- 单个 Tensor 以及 `list`、`tuple` 中的 Tensor 都应正确处理
+- `None` 和非 Tensor 元素不应受到影响
 
 ## 技术要求
 
-* 熟悉 Python
-* 熟悉 Paddle dynamic graph 和 Tensor 生命周期
-* 了解 pipeline parallel 中间输出的发送、保存和释放流程
-* 了解 Tensor 初始化状态、inplace 操作和 inplace version
+- 熟悉 Python
+- 了解 Paddle Pipeline Parallel
+- 了解 Tensor 的初始化状态、`inplace` 操作和数据释放

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-54625/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-54625/instruction.md
@@ -2,20 +2,24 @@
 
 ## 详细描述
 
-在 pipeline parallel 训练过程中，中间输出发送完成后，系统会回收不再需要的 Tensor 数据，以减少内存占用。当前输出释放逻辑未充分考虑 Tensor 的状态，可能会清理尚未初始化或已经发生原地修改的 Tensor，从而影响后续执行。请修复该问题，确保仅回收可以安全释放的中间输出，同时保持正常输出原有的释放行为。
+在 pipeline parallel 训练过程中，中间输出发送完成后，系统会清理不再需要的 Tensor 数据，以减少内存占用。
+
+当前输出释放逻辑没有充分考虑 Tensor 的状态，可能会清理尚未初始化或已经执行过 inplace 操作的 Tensor。这里的 inplace 操作是指直接修改 Tensor 本身，并使其 inplace version 发生变化的操作。
+
+请修复该问题，确保仅清理满足释放条件的中间输出，同时保持其他输出原有的释放行为。
 
 ## 验收说明
 
-- 尚未初始化的 pipeline 中间输出 Tensor 不应被释放
-- 已经发生原地修改的 pipeline 中间输出 Tensor 不应被释放
-- 已初始化且未发生原地修改的 Tensor 应保持原有释放行为
-- 单个 Tensor 以及 tuple/list 中的 Tensor 均应得到正确处理
-- tuple/list 中的非 Tensor 元素不得受到影响
-- 修复不得影响 pipeline parallel 原有的前向、反向和通信行为
+* 尚未初始化的 pipeline 中间输出 Tensor 不应被释放
+* 已经执行过 inplace 操作的 pipeline 中间输出 Tensor 不应被释放
+* 已初始化且未执行过 inplace 操作的 Tensor 应保持原有释放行为
+* 单个 Tensor 以及 tuple/list 中的 Tensor 均应得到正确处理
+* tuple/list 中的非 Tensor 元素不得受到影响
+* 修复不得影响 pipeline parallel 原有的前向、反向和通信行为
 
 ## 技术要求
 
-- 熟悉 Python
-- 熟悉 Paddle dynamic graph 和 Tensor 生命周期
-- 了解 pipeline parallel 中间输出的发送、保存和释放流程
-- 了解 Tensor 初始化状态及原地修改语义
+* 熟悉 Python
+* 熟悉 Paddle dynamic graph 和 Tensor 生命周期
+* 了解 pipeline parallel 中间输出的发送、保存和释放流程
+* 了解 Tensor 初始化状态、inplace 操作和 inplace version

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-54625/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-54625/instruction.md
@@ -15,9 +15,3 @@
 - 熟悉 Python
 - 熟悉 Paddle dynamic graph 和 Tensor lifecycle
 - 了解 pipeline parallel 中间输出的发送、缓存与释放流程
-
-## Acceptance Criteria
-
-- The behavior described above should be fixed.
-- Existing valid behavior should remain unchanged.
-- Do not satisfy the task by deleting tests, weakening assertions, or bypassing validation broadly.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-54625/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-54625/proposal.md
@@ -1,0 +1,54 @@
+# Task Proposal: PaddlePaddle__Paddle-54625
+
+## 1. 来源信息
+
+- Instance ID：`PaddlePaddle__Paddle-54625`
+- PR 链接：https://github.com/PaddlePaddle/Paddle/pull/54625
+- PR 标题：`[BugFix] fix bug of release output in pp`
+- `base_commit`：`974676bc6ec41e222083729af55f34e4b2f20f2e`
+- merged 时间：`2023-06-16`
+- 你的身份：熟悉该模块的 contributor
+- 后续联系人：TBD
+
+## 2. 问题一句话
+
+修复 pipeline parallel 在释放中间输出时错误清理未初始化或已发生 in-place 修改的 Tensor 数据的问题。
+
+## 3. 为什么适合作为 SWE-Paddle 样本
+
+- **真实性**：该任务来自已合入的 Paddle PR #54625，不是合成任务。
+- **代表性**：它覆盖 pipeline parallel、Tensor lifecycle、in-place version tracking 和中间输出资源释放。
+- **边界清楚**：production change 集中在 `python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py`，目标行为可以由独立测试直接暴露。
+- **非平凡性**：正确修复既要跳过不安全释放的 Tensor，也要维持普通 Tensor 与 tuple/list 输出原有的数据释放行为。
+
+## 4. 任务类型和标签
+
+- 任务类型：`bug_fix`
+- 执行后端：`cpu`
+- 设备范围：`cpu_only`
+- 模块标签：`[distributed, fleet, pipeline_parallel, tensor_lifecycle, dynamic_graph]`
+
+## 5. 验证思路
+
+- 目标测试命令：`bash tests/test.sh`
+- 目标测试文件：`test/swe_paddle/test_pr54625_pipeline_output_release.py`
+- 修复前预期：在 `base_commit` 上应用 `tests/test.patch` 后，已初始化且未修改的单个及 tuple/list Tensor 释放行为应 pass；未初始化 Tensor 和已发生 in-place 修改的 Tensor 不应释放的测试应 fail。
+- 修复后预期：继续应用 `solution/code.patch` 后，已有释放行为和两个安全保护测试均应 pass。
+- P2P 候选：已初始化且未发生 in-place 修改的单个 Tensor、tuple 和 list 输出仍按原有行为释放。
+
+## 6. 环境与资源
+
+- 资源需求：CPU
+- Paddle 来源：`PaddlePaddle/Paddle` source checkout at `base_commit`
+- 是否能提供 Docker：暂无
+- patch 类型：Python-only
+- 环境建议：使用可运行 `pytest` 的 Python 环境，通过 AST overlay 执行 checkout 中的 `_release_output` 真实控制流，并使用 controlled Tensor doubles 提供依赖；无需 Paddle source build 或 distributed launch
+- 最小测试命令：`bash tests/test.sh`
+- 是否有 oracle 日志：由 SWE-Paddle verifier 结果另行维护
+
+## 7. 风险自查
+
+- 泄露风险：正式 `instruction.md` 只描述输出生命周期的触发条件和期望行为，不直接给出 production code 的具体修改方式。
+- 环境风险：测试不依赖历史 Paddle 模块的完整 import，通过 AST overlay 隔离版本兼容问题。
+- flaky 风险：测试不启动多进程、不执行真实通信、不测内存时序，只验证确定性的释放 side effect。
+- 拆分风险：未初始化与 in-place 修改属于同一中间输出安全释放问题，并由同一 production method 的修改共同修复，适合作为一个样本。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-54625/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-54625/proposal.md
@@ -2,53 +2,53 @@
 
 ## 1. 来源信息
 
-- Instance ID：`PaddlePaddle__Paddle-54625`
-- PR 链接：https://github.com/PaddlePaddle/Paddle/pull/54625
-- PR 标题：`[BugFix] fix bug of release output in pp`
-- `base_commit`：`974676bc6ec41e222083729af55f34e4b2f20f2e`
-- merged 时间：`2023-06-16`
-- 你的身份：熟悉该模块的 contributor
-- 后续联系人：TBD
+* Instance ID：`PaddlePaddle__Paddle-54625`
+* PR 链接：https://github.com/PaddlePaddle/Paddle/pull/54625
+* PR 标题：`[BugFix] fix bug of release output in pp`
+* `base_commit`：`974676bc6ec41e222083729af55f34e4b2f20f2e`
+* merged 时间：`2023-06-16`
+* 你的身份：熟悉该模块的 contributor
+* 后续联系人：TBD
 
 ## 2. 问题一句话
 
-修复 pipeline parallel 在释放中间输出时错误清理未初始化或已发生 in-place 修改的 Tensor 数据的问题。
+修复 pipeline parallel 在回收中间输出时错误清理未初始化或已经发生 in-place 修改的 Tensor 数据的问题。
 
 ## 3. 为什么适合作为 SWE-Paddle 样本
 
-- **真实性**：该任务来自已合入的 Paddle PR #54625，不是合成任务。
-- **代表性**：它覆盖 pipeline parallel、Tensor lifecycle、in-place version tracking 和中间输出资源释放。
-- **边界清楚**：production change 集中在 `python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py`，目标行为可以由独立测试直接暴露。
-- **非平凡性**：正确修复既要跳过不安全释放的 Tensor，也要维持普通 Tensor 与 tuple/list 输出原有的数据释放行为。
+* **真实性**：该任务来自已合入的 Paddle PR #54625，不是合成任务。
+* **代表性**：它涉及 pipeline parallel、中间输出的数据回收、Tensor 初始化状态以及 in-place 修改状态的处理。
+* **边界清楚**：production change 集中在 `python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py`，问题范围明确，相关行为可以通过独立测试直接验证。
+* **非平凡性**：正确修复既要避免清理不满足释放条件的 Tensor，也要保证普通 Tensor 以及 tuple/list 输出原有的数据回收行为不受影响。
 
 ## 4. 任务类型和标签
 
-- 任务类型：`bug_fix`
-- 执行后端：`cpu`
-- 设备范围：`cpu_only`
-- 模块标签：`[distributed, fleet, pipeline_parallel, tensor_lifecycle, dynamic_graph]`
+* 任务类型：`bug_fix`
+* 执行后端：`cpu`
+* 设备范围：`cpu_only`
+* 模块标签：`[distributed, fleet, pipeline_parallel, tensor_lifecycle, dynamic_graph]`
 
 ## 5. 验证思路
 
-- 目标测试命令：`bash tests/test.sh`
-- 目标测试文件：`test/swe_paddle/test_pr54625_pipeline_output_release.py`
-- 修复前预期：在 `base_commit` 上应用 `tests/test.patch` 后，已初始化且未修改的单个及 tuple/list Tensor 释放行为应 pass；未初始化 Tensor 和已发生 in-place 修改的 Tensor 不应释放的测试应 fail。
-- 修复后预期：继续应用 `solution/code.patch` 后，已有释放行为和两个安全保护测试均应 pass。
-- P2P 候选：已初始化且未发生 in-place 修改的单个 Tensor、tuple 和 list 输出仍按原有行为释放。
+* 目标测试命令：`bash tests/test.sh`
+* 目标测试文件：`test/swe_paddle/test_pr54625_pipeline_output_release.py`
+* 修复前预期：在 `base_commit` 上应用 `tests/test.patch` 后，已初始化且未发生 in-place 修改的单个 Tensor、tuple 和 list 输出的释放测试应通过；未初始化 Tensor 和已经发生 in-place 修改的 Tensor 不应被释放的测试应失败。
+* 修复后预期：继续应用 `solution/code.patch` 后，正常输出释放测试和异常状态保护测试均应通过。
+* P2P 候选：已初始化且未发生 in-place 修改的单个 Tensor、tuple 和 list 输出仍按原有行为释放。
 
 ## 6. 环境与资源
 
-- 资源需求：CPU
-- Paddle 来源：`PaddlePaddle/Paddle` source checkout at `base_commit`
-- 是否能提供 Docker：暂无
-- patch 类型：Python-only
-- 环境建议：使用可运行 `pytest` 的 Python 环境，通过 AST overlay 执行 checkout 中的 `_release_output` 真实控制流，并使用 controlled Tensor doubles 提供依赖；无需 Paddle source build 或 distributed launch
-- 最小测试命令：`bash tests/test.sh`
-- 是否有 oracle 日志：由 SWE-Paddle verifier 结果另行维护
+* 资源需求：CPU
+* Paddle 来源：`PaddlePaddle/Paddle` source checkout at `base_commit`
+* 是否能提供 Docker：暂无
+* patch 类型：Python-only
+* 环境建议：使用能够运行 `pytest` 的 Python 环境，通过 AST overlay 加载 source checkout 中 `_release_output` 的实际控制流程，并使用可控的 Tensor 测试替身提供所需依赖；无需编译 Paddle 源码，也无需启动分布式任务。
+* 最小测试命令：`bash tests/test.sh`
+* 是否有 oracle 日志：由 SWE-Paddle verifier 结果另行维护
 
 ## 7. 风险自查
 
-- 泄露风险：正式 `instruction.md` 只描述输出生命周期的触发条件和期望行为，不直接给出 production code 的具体修改方式。
-- 环境风险：测试不依赖历史 Paddle 模块的完整 import，通过 AST overlay 隔离版本兼容问题。
-- flaky 风险：测试不启动多进程、不执行真实通信、不测内存时序，只验证确定性的释放 side effect。
-- 拆分风险：未初始化与 in-place 修改属于同一中间输出安全释放问题，并由同一 production method 的修改共同修复，适合作为一个样本。
+* 泄露风险：正式 `instruction.md` 只描述不同 Tensor 状态下的预期释放行为，不直接说明内部判断条件、使用的属性或具体代码修改方式。
+* 环境风险：测试不依赖历史 Paddle 模块的完整导入，通过 AST overlay 隔离源码版本与运行环境之间的兼容性问题。
+* flaky 风险：测试不启动多进程、不执行真实通信，也不依赖内存采样时机，只验证 Tensor 数据清理操作是否发生。
+* 拆分风险：未初始化和 in-place 修改均属于 pipeline parallel 中间输出释放条件处理不当的问题，并由同一 production method 中的修改共同修复，适合作为一个样本。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-54625/solution/code.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-54625/solution/code.patch
@@ -1,0 +1,27 @@
+diff --git a/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py b/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
+index a3f840cf770668a1a5f666c0fd4df34d54975901..3bc9fc1ccf2aa33ec0114fc67e714d922bb890f7 100755
+--- a/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
++++ b/python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py
+@@ -673,11 +673,20 @@ class PipelineParallel(MetaParallelBase):
+             self.lr_scheduler.step()
+ 
+     def _release_output(self, output):
++        def can_free(t):
++            return (
++                t is not None
++                and isinstance(t, paddle.Tensor)
++                and t._is_initialized()
++                and t.inplace_version == 0
++            )
++
+         if isinstance(output, (tuple, list)):
+             for t in output:
+-                if t is not None and isinstance(t, paddle.Tensor):
++                if can_free(t):
+                     t._clear_dataptr()
+-        elif output is not None and isinstance(output, paddle.Tensor):
++
++        elif can_free(output):
+             output._clear_dataptr()
+ 
+ 

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-54625/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-54625/tests/test.patch
@@ -1,0 +1,92 @@
+diff --git a/test/swe_paddle/test_pr54625_pipeline_output_release.py b/test/swe_paddle/test_pr54625_pipeline_output_release.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..f55cea71100256656b0a71da82925f4ab01905a0
+--- /dev/null
++++ b/test/swe_paddle/test_pr54625_pipeline_output_release.py
+@@ -0,0 +1,86 @@
++from __future__ import annotations
++
++import ast
++import copy
++import types
++from pathlib import Path
++
++
++TARGET = Path(
++    "python/paddle/distributed/fleet/meta_parallel/pipeline_parallel.py"
++)
++
++
++class _Tensor:
++    def __init__(self, *, initialized=True, inplace_version=0):
++        self._initialized = initialized
++        self.inplace_version = inplace_version
++        self.clear_calls = 0
++
++    def _is_initialized(self):
++        return self._initialized
++
++    def _clear_dataptr(self):
++        self.clear_calls += 1
++
++
++def _load_checkout_function():
++    tree = ast.parse(TARGET.read_text(encoding="utf-8"), filename=str(TARGET))
++    function = None
++    for node in tree.body:
++        if isinstance(node, ast.ClassDef) and node.name == "PipelineParallel":
++            for item in node.body:
++                if (
++                    isinstance(item, ast.FunctionDef)
++                    and item.name == "_release_output"
++                ):
++                    function = copy.deepcopy(item)
++                    break
++
++    assert function is not None, "PipelineParallel._release_output not found"
++    module = ast.Module(body=[function], type_ignores=[])
++    ast.fix_missing_locations(module)
++    namespace = {
++        "paddle": types.SimpleNamespace(Tensor=_Tensor),
++    }
++    exec(compile(module, str(TARGET), "exec"), namespace)
++    return namespace["_release_output"]
++
++
++def test_initialized_pristine_outputs_are_released():
++    function = _load_checkout_function()
++    single = _Tensor()
++    tuple_tensor = _Tensor()
++    list_tensor = _Tensor()
++
++    function(object(), single)
++    function(object(), (tuple_tensor, None, object()))
++    function(object(), [list_tensor, "not-a-tensor"])
++
++    assert single.clear_calls == 1
++    assert tuple_tensor.clear_calls == 1
++    assert list_tensor.clear_calls == 1
++
++
++def test_uninitialized_outputs_are_not_released():
++    function = _load_checkout_function()
++    single = _Tensor(initialized=False)
++    sequence_item = _Tensor(initialized=False)
++
++    function(object(), single)
++    function(object(), [sequence_item])
++
++    assert single.clear_calls == 0
++    assert sequence_item.clear_calls == 0
++
++
++def test_inplace_modified_outputs_are_not_released():
++    function = _load_checkout_function()
++    single = _Tensor(inplace_version=1)
++    sequence_item = _Tensor(inplace_version=3)
++
++    function(object(), single)
++    function(object(), (sequence_item,))
++
++    assert single.clear_calls == 0
++    assert sequence_item.clear_calls == 0

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-54625/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-54625/tests/test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python -m pytest test/swe_paddle/test_pr54625_pipeline_output_release.py -q


### PR DESCRIPTION
## 关联

- SWE-Paddle 共建 issue: https://github.com/PaddlePaddle/Paddle/issues/79447
- 来源 PR: https://github.com/PaddlePaddle/Paddle/pull/54625

## 说明

- 新增 SWE-Paddle 任务 `PaddlePaddle__Paddle-54625`

@sunzhongkai588

## 验证结果

| 状态 | Existing output release P2P | Uninitialized output F2P | In-place modified output F2P |
| --- | --- | --- | --- |
| Base + `tests/test.patch` | PASS | FAIL，符合预期 | FAIL，符合预期 |
| Base + test patch + `solution/code.patch` | PASS | PASS | PASS |

#### Base P2P

```text
.                                                                        [100%]
1 passed in 0.03s
```

#### Base F2P：未初始化输出不应被释放

```text
F                                                                        [100%]
================================== FAILURES ===================================
_________________ test_uninitialized_outputs_are_not_released _________________

    def test_uninitialized_outputs_are_not_released():
        function = _load_checkout_function()
        single = _Tensor(initialized=False)
        sequence_item = _Tensor(initialized=False)

        function(object(), single)
        function(object(), [sequence_item])

>       assert single.clear_calls == 0
E       assert 1 == 0
E        +  where 1 = <test_pr54625_pipeline_output_release._Tensor object at 0x000001F3030C9D10>.clear_calls

FAILED test/swe_paddle/test_pr54625_pipeline_output_release.py::test_uninitialized_outputs_are_not_released
1 failed in 0.08s
```

#### Base F2P：发生 in-place 修改的输出不应被释放

```text
F                                                                        [100%]
================================== FAILURES ===================================
_______________ test_inplace_modified_outputs_are_not_released ________________

    def test_inplace_modified_outputs_are_not_released():
        function = _load_checkout_function()
        single = _Tensor(inplace_version=1)
        sequence_item = _Tensor(inplace_version=3)

        function(object(), single)
        function(object(), (sequence_item,))

>       assert single.clear_calls == 0
E       assert 1 == 0
E        +  where 1 = <test_pr54625_pipeline_output_release._Tensor object at 0x0000026389676C50>.clear_calls

FAILED test/swe_paddle/test_pr54625_pipeline_output_release.py::test_inplace_modified_outputs_are_not_released
1 failed in 0.10s
```

#### Solution 测试

```text
Solution existing output-release P2P:
1 passed in 0.02s

Solution uninitialized-output F2P:
1 passed in 0.02s

Solution in-place-modified-output F2P:
1 passed in 0.02s
```

#### `tests/test.sh`

```text
...                                                                      [100%]
3 passed in 0.03s
Solution tests/test.sh exit code: 0
```