### PR TITLE
[SWE-Paddle] Add task PaddlePaddle__Paddle-56470

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-56470/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-56470/README.md
@@ -1,0 +1,45 @@
+# PaddlePaddle__Paddle-56470
+
+This directory converts Paddle PR #56470 into a SWE-Paddle community task candidate.
+
+## Source
+
+| Field | Value |
+| --- | --- |
+| Repo | `PaddlePaddle/Paddle` |
+| Issue | [55883](https://github.com/PaddlePaddle/Paddle/issues/55883) |
+| PR | [56470](https://github.com/PaddlePaddle/Paddle/pull/56470) |
+| PR title | ``[API Enhancement] No.6 support single `int` input in UpsamplingNearest2D and UpsamplingBilinear2D`` |
+| Base commit | `3568a99c5f6ff0e5fd528d43bd283fde34fe078b` |
+| Merged at | `2023-08-28` |
+| Task type | `feature_enhancement` |
+| Resource | CPU |
+
+## Summary
+
+Added support for a single integer `size` input to `UpsamplingNearest2D` and `UpsamplingBilinear2D`.
+
+## Why This Is A Good SWE-Paddle Candidate
+
+- It adds a user-visible API capability rather than fixing an internal-only failure.
+- The production change is Python-only and limited to two closely related layer constructors.
+- Independent behavior tests can distinguish Base and Solution without GPU, source build, or external data.
+- Existing list, tuple, and `scale_factor` inputs provide clear P2P regression coverage.
+
+## Files
+
+- `proposal.md`: candidate proposal for maintainer triage.
+- `instruction.md`: self-contained problem statement for the coding agent.
+- `solution/code.patch`: gold patch from the merged PR.
+- `tests/test.patch`: test patch exposing the target behavior.
+- `tests/test.sh`: minimal target test command.
+- `environment/README.md`: environment notes for reproduction.
+- `README.md`: task overview and verification entrypoint.
+
+## Verification
+
+```bash
+bash tests/test.sh
+```
+
+Expected behavior: applying `tests/test.patch` to `base_commit` should fail on the target behavior; applying both `tests/test.patch` and `solution/code.patch` should pass the target tests.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-56470/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-56470/environment/README.md
@@ -1,0 +1,27 @@
+# Environment Notes
+
+This candidate is part of the SWE-Paddle community task set.
+
+## Expected Environment
+
+- Repository: `PaddlePaddle/Paddle`
+- Base commit: `3568a99c5f6ff0e5fd528d43bd283fde34fe078b`
+- Resource: CPU
+- GPU required: no
+- Build path: Python-only checkout source with an AST overlay for the target layer classes; no Paddle source build is required.
+
+## Run Order
+
+1. Check out `PaddlePaddle/Paddle` at the base commit.
+2. Apply `tests/test.patch`.
+3. Run `bash tests/test.sh`; the target behavior should fail before the fix.
+4. Apply `solution/code.patch`.
+5. Run `bash tests/test.sh` again; the target behavior should pass after the gold patch.
+
+## Minimal Test Command
+
+```bash
+bash tests/test.sh
+```
+
+The verifier is responsible for deriving stable F2P and P2P node IDs from repeated runs.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-56470/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-56470/instruction.md
@@ -1,0 +1,17 @@
+# 为 2D Upsampling layers 支持单个整数 size
+
+## 详细描述
+
+`UpsamplingNearest2D` 和 `UpsamplingBilinear2D` 的输出尺寸参数目前要求使用二元素 list 或 tuple。对于正方形输出，用户仍需重复填写相同的高度和宽度，降低了 API 易用性。两个 2D Upsampling layers 应支持直接传入单个整数，并将其解释为相同的输出高度和宽度。
+
+## 验收说明
+
+- `UpsamplingNearest2D` 接收单个整数 `size` 时，应在高度和宽度两个维度使用该值。
+- `UpsamplingBilinear2D` 接收单个整数 `size` 时，应在高度和宽度两个维度使用该值。
+- 现有 list、tuple 和 `scale_factor` 调用方式应保持兼容。
+
+## 技术要求
+
+- 熟悉 Python 和 Paddle layer API。
+- 了解 2D image interpolation 的尺寸参数约定。
+- 能够编写稳定的 API behavior tests。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-56470/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-56470/instruction.md
@@ -1,17 +1,24 @@
-# 为 2D Upsampling layers 支持单个整数 size
+# 支持 2D Upsampling 层使用单个整数指定输出尺寸
 
 ## 详细描述
 
-`UpsamplingNearest2D` 和 `UpsamplingBilinear2D` 的输出尺寸参数目前要求使用二元素 list 或 tuple。对于正方形输出，用户仍需重复填写相同的高度和宽度，降低了 API 易用性。两个 2D Upsampling layers 应支持直接传入单个整数，并将其解释为相同的输出高度和宽度。
+`UpsamplingNearest2D` 和 `UpsamplingBilinear2D` 当前要求通过包含两个元素的 list 或 tuple 指定输出尺寸。对于高度和宽度相同的输出，调用方仍需重复传入相同的数值。
+
+请支持使用单个整数设置这两个层的 `size` 参数。当 `size` 为整数时，该值应同时作为输出的高度和宽度。
+
+现有的 list、tuple 以及 `scale_factor` 参数用法不得受到影响。
 
 ## 验收说明
 
-- `UpsamplingNearest2D` 接收单个整数 `size` 时，应在高度和宽度两个维度使用该值。
-- `UpsamplingBilinear2D` 接收单个整数 `size` 时，应在高度和宽度两个维度使用该值。
-- 现有 list、tuple 和 `scale_factor` 调用方式应保持兼容。
+* `UpsamplingNearest2D` 应支持使用单个整数设置 `size`
+* `UpsamplingBilinear2D` 应支持使用单个整数设置 `size`
+* 当 `size` 为整数时，输出的高度和宽度均应使用该值
+* 现有 list 和 tuple 形式的 `size` 参数应保持原有行为
+* 现有 `scale_factor` 调用方式应保持原有行为
+* 两个层现有的插值结果、参数校验和其他合法调用方式不得发生变化
 
 ## 技术要求
 
-- 熟悉 Python 和 Paddle layer API。
-- 了解 2D image interpolation 的尺寸参数约定。
-- 能够编写稳定的 API behavior tests。
+* 熟悉 Python 和 Paddle Layer API
+* 了解二维图像插值及输出尺寸参数的语义
+* 理解 `size` 和 `scale_factor` 的使用方式

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-56470/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-56470/proposal.md
@@ -1,0 +1,56 @@
+# Task Proposal: PaddlePaddle__Paddle-56470
+
+## 1. 来源信息
+
+- Instance ID：`PaddlePaddle__Paddle-56470`
+- Issue 链接：https://github.com/PaddlePaddle/Paddle/issues/55883
+- PR 链接：https://github.com/PaddlePaddle/Paddle/pull/56470
+- PR 标题：``[API Enhancement] No.6 support single `int` input in UpsamplingNearest2D and UpsamplingBilinear2D``
+- `base_commit`：`3568a99c5f6ff0e5fd528d43bd283fde34fe078b`
+- merged 时间：`2023-08-28`
+- 你的身份：原 PR 作者 / reviewer / 熟悉该模块的 contributor
+- 后续联系人：TBD
+
+## 2. 问题一句话
+
+为 `UpsamplingNearest2D` 和 `UpsamplingBilinear2D` 增加单个整数 `size` 输入支持，并将其解释为正方形输出尺寸。
+
+## 3. 为什么适合作为 SWE-Paddle 样本
+
+- **真实性**：该任务来自已合入的 Paddle API 易用性增强 PR，不是合成任务。
+- **代表性**：它覆盖公共 layer API 的参数规范化和既有输入形式兼容性。
+- **边界清楚**：production 行为集中在两个 2D Upsampling layer 对 `size` 的处理。
+- **非平凡性**：修复需要同时覆盖 nearest 与 bilinear 两个 API，并保持 list、tuple 和 `scale_factor` 语义不变。
+- **环境友好性**：目标逻辑为 Python-only，可通过 checkout source AST overlay 在 CPU 环境稳定验证，无需 source build。
+
+## 4. 任务类型和标签
+
+- 任务类型：`feature_enhancement`
+- 执行后端：`cpu`
+- 设备范围：`cpu_only`
+- 模块标签：`[nn, layer_api, upsampling, interpolation, python_only, api_usability]`
+
+## 5. 验证思路
+
+- 目标测试命令：`bash tests/test.sh`
+- 目标测试文件：`test/swe_paddle/test_pr56470_upsampling_single_int.py`
+- 修复前预期：list、tuple 和 `scale_factor` 的既有行为通过；两个 layer 的单整数 `size` 测试失败。
+- 修复后预期：继续应用 `solution/code.patch` 后，全部目标测试通过。
+- P2P 候选：两个 layer 对 list/tuple `size` 及 `scale_factor` 的既有参数传递行为。
+
+## 6. 环境与资源
+
+- 资源需求：CPU
+- Paddle 来源：`PaddlePaddle/Paddle` source checkout at `base_commit`
+- 是否能提供 Docker：暂无
+- patch 类型：Python-only
+- 环境建议：从 checkout source 提取两个 layer 的真实 class control flow，并以 controlled functional double 观察 `interpolate` 参数，无需导入完整历史 Paddle 模块。
+- 最小测试命令：`bash tests/test.sh`
+- 是否有 oracle 日志：由 SWE-Paddle verifier 结果另行维护
+
+## 7. 风险自查
+
+- 泄露风险：`instruction.md` 仅描述公共 API 行为，不指出 Gold patch 的具体代码位置。
+- 环境风险：AST overlay 避免历史 source 与当前 Paddle wheel 的整体 import 兼容问题。
+- flaky 风险：测试仅验证确定性的参数规范化和调用 contract，不依赖随机数、GPU 或网络。
+- 拆分风险：两个 layer 共享同一 API enhancement，适合作为一个样本。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-56470/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-56470/proposal.md
@@ -2,55 +2,54 @@
 
 ## 1. 来源信息
 
-- Instance ID：`PaddlePaddle__Paddle-56470`
-- Issue 链接：https://github.com/PaddlePaddle/Paddle/issues/55883
-- PR 链接：https://github.com/PaddlePaddle/Paddle/pull/56470
-- PR 标题：``[API Enhancement] No.6 support single `int` input in UpsamplingNearest2D and UpsamplingBilinear2D``
-- `base_commit`：`3568a99c5f6ff0e5fd528d43bd283fde34fe078b`
-- merged 时间：`2023-08-28`
-- 你的身份：原 PR 作者 / reviewer / 熟悉该模块的 contributor
-- 后续联系人：TBD
+* Instance ID：`PaddlePaddle__Paddle-56470`
+* Issue 链接：https://github.com/PaddlePaddle/Paddle/issues/55883
+* PR 链接：https://github.com/PaddlePaddle/Paddle/pull/56470
+* PR 标题：`[API Enhancement] No.6 support single int input in UpsamplingNearest2D and UpsamplingBilinear2D`
+* `base_commit`：`3568a99c5f6ff0e5fd528d43bd283fde34fe078b`
+* merged 时间：`2023-08-28`
+* 你的身份：原 PR 作者 / reviewer / 熟悉该模块的 contributor
+* 后续联系人：TBD
 
 ## 2. 问题一句话
 
-为 `UpsamplingNearest2D` 和 `UpsamplingBilinear2D` 增加单个整数 `size` 输入支持，并将其解释为正方形输出尺寸。
+为 `UpsamplingNearest2D` 和 `UpsamplingBilinear2D` 的 `size` 参数增加单个整数输入支持，并将该值同时作为输出的高度和宽度。
 
 ## 3. 为什么适合作为 SWE-Paddle 样本
 
-- **真实性**：该任务来自已合入的 Paddle API 易用性增强 PR，不是合成任务。
-- **代表性**：它覆盖公共 layer API 的参数规范化和既有输入形式兼容性。
-- **边界清楚**：production 行为集中在两个 2D Upsampling layer 对 `size` 的处理。
-- **非平凡性**：修复需要同时覆盖 nearest 与 bilinear 两个 API，并保持 list、tuple 和 `scale_factor` 语义不变。
-- **环境友好性**：目标逻辑为 Python-only，可通过 checkout source AST overlay 在 CPU 环境稳定验证，无需 source build。
+* **真实性**：该任务来自已合入的 Paddle API 易用性增强 PR，不是人工构造的需求。
+* **代表性**：该任务涉及公共 Layer API 的参数扩展、输入形式处理以及现有调用方式的向后兼容。
+* **边界清楚**：production change 集中在 `UpsamplingNearest2D` 和 `UpsamplingBilinear2D` 对 `size` 参数的处理，功能范围明确。
+* **非平凡性**：虽然代码改动较小，但需要同时覆盖 nearest 和 bilinear 两个层，并保证整数、list、tuple 和 `scale_factor` 等参数形式能够保持一致且兼容的行为。
+* **环境友好性**：相关逻辑位于 Python 层，可以在 CPU 环境中直接验证，无需编译 Paddle 源码或运行真实的插值算子。
 
 ## 4. 任务类型和标签
 
-- 任务类型：`feature_enhancement`
-- 执行后端：`cpu`
-- 设备范围：`cpu_only`
-- 模块标签：`[nn, layer_api, upsampling, interpolation, python_only, api_usability]`
+* 任务类型：`feature_enhancement`
+* 执行后端：`cpu`
+* 设备范围：`cpu_only`
+* 模块标签：`[nn, layer_api, upsampling, interpolation, python_only, api_usability]`
 
 ## 5. 验证思路
 
-- 目标测试命令：`bash tests/test.sh`
-- 目标测试文件：`test/swe_paddle/test_pr56470_upsampling_single_int.py`
-- 修复前预期：list、tuple 和 `scale_factor` 的既有行为通过；两个 layer 的单整数 `size` 测试失败。
-- 修复后预期：继续应用 `solution/code.patch` 后，全部目标测试通过。
-- P2P 候选：两个 layer 对 list/tuple `size` 及 `scale_factor` 的既有参数传递行为。
+* 目标测试命令：`bash tests/test.sh`
+* 目标测试文件：`test/swe_paddle/test_pr56470_upsampling_single_int.py`
+* 修复前预期：list、tuple 和 `scale_factor` 等现有参数形式的测试应通过；两个层使用单个整数 `size` 的测试应失败。
+* 修复后预期：继续应用 `solution/code.patch` 后，P2P 与全部 F2P 均应通过；单个整数应被两个层正确解释为相同的输出高度和宽度。
+* P2P 候选：两个层使用 list 或 tuple 形式的 `size` 时，尺寸参数保持不变；使用 `scale_factor` 时，现有参数处理和调用行为保持不变。
 
 ## 6. 环境与资源
 
-- 资源需求：CPU
-- Paddle 来源：`PaddlePaddle/Paddle` source checkout at `base_commit`
-- 是否能提供 Docker：暂无
-- patch 类型：Python-only
-- 环境建议：从 checkout source 提取两个 layer 的真实 class control flow，并以 controlled functional double 观察 `interpolate` 参数，无需导入完整历史 Paddle 模块。
-- 最小测试命令：`bash tests/test.sh`
-- 是否有 oracle 日志：由 SWE-Paddle verifier 结果另行维护
+* 资源需求：CPU
+* Paddle 来源：`PaddlePaddle/Paddle` source checkout at `base_commit`
+* 是否能提供 Docker：暂无
+* patch 类型：Python-only
+* 最小测试命令：`bash tests/test.sh`
+* 是否有 oracle 日志：由 SWE-Paddle verifier 结果另行维护
 
 ## 7. 风险自查
 
-- 泄露风险：`instruction.md` 仅描述公共 API 行为，不指出 Gold patch 的具体代码位置。
-- 环境风险：AST overlay 避免历史 source 与当前 Paddle wheel 的整体 import 兼容问题。
-- flaky 风险：测试仅验证确定性的参数规范化和调用 contract，不依赖随机数、GPU 或网络。
-- 拆分风险：两个 layer 共享同一 API enhancement，适合作为一个样本。
+* 泄露风险：`instruction.md` 只描述单个整数 `size` 的公开行为和兼容性要求，不透露参数在内部如何转换或具体修改位置。
+* 环境风险：通过 AST overlay 隔离 source checkout 与当前运行环境之间的版本差异，避免依赖历史 Paddle package 的完整导入和 native extension。
+* flaky 风险：测试只验证确定性的尺寸参数处理和调用结果，不依赖随机数、GPU、网络或异步执行。
+* 拆分风险：`UpsamplingNearest2D` 和 `UpsamplingBilinear2D` 具有相同的参数增强目标，且修改集中在同一 production 文件中，适合作为一个完整样本。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-56470/solution/code.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-56470/solution/code.patch
@@ -1,0 +1,22 @@
+diff --git a/python/paddle/nn/layer/common.py b/python/paddle/nn/layer/common.py
+index c6bca2efa78a7674f68c6a7becd962e554a63e63..77fcb44437986b09489a419739f03e45e92826f7 100644
+--- a/python/paddle/nn/layer/common.py
++++ b/python/paddle/nn/layer/common.py
+@@ -489,6 +489,8 @@ class UpsamplingNearest2D(Layer):
+         self, size=None, scale_factor=None, data_format='NCHW', name=None
+     ):
+         super().__init__()
++        if isinstance(size, int):
++            size = [size, size]
+         self.size = size
+         self.scale_factor = scale_factor
+         self.data_format = data_format
+@@ -575,6 +577,8 @@ class UpsamplingBilinear2D(Layer):
+         self, size=None, scale_factor=None, data_format='NCHW', name=None
+     ):
+         super().__init__()
++        if isinstance(size, int):
++            size = [size, size]
+         self.size = size
+         self.scale_factor = scale_factor
+         self.data_format = data_format

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-56470/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-56470/tests/test.patch
@@ -1,0 +1,93 @@
+diff --git a/test/swe_paddle/test_pr56470_upsampling_single_int.py b/test/swe_paddle/test_pr56470_upsampling_single_int.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..bfc0452a9297f8ef60614069ab1bd3aa4c09a85f
+--- /dev/null
++++ b/test/swe_paddle/test_pr56470_upsampling_single_int.py
+@@ -0,0 +1,87 @@
++from __future__ import annotations
++
++import ast
++import copy
++import types
++from pathlib import Path
++
++
++TARGET = Path("python/paddle/nn/layer/common.py")
++CLASS_NAMES = ("UpsamplingNearest2D", "UpsamplingBilinear2D")
++
++
++class _Layer:
++    def __init__(self):
++        pass
++
++
++class _Functional:
++    @staticmethod
++    def interpolate(x, **kwargs):
++        return {"x": x, **kwargs}
++
++
++def _load_checkout_classes():
++    tree = ast.parse(TARGET.read_text(encoding="utf-8"), filename=str(TARGET))
++    classes = []
++    for node in tree.body:
++        if isinstance(node, ast.ClassDef) and node.name in CLASS_NAMES:
++            classes.append(copy.deepcopy(node))
++
++    found = {node.name for node in classes}
++    assert found == set(CLASS_NAMES), f"Missing target classes: {set(CLASS_NAMES) - found}"
++
++    module = ast.Module(body=classes, type_ignores=[])
++    ast.fix_missing_locations(module)
++    namespace = {
++        "Layer": _Layer,
++        "F": _Functional,
++    }
++    exec(compile(module, str(TARGET), "exec"), namespace)
++    return tuple(namespace[name] for name in CLASS_NAMES)
++
++
++def test_existing_sequence_and_scale_factor_behavior_remains_valid():
++    nearest_cls, bilinear_cls = _load_checkout_classes()
++
++    nearest = nearest_cls(size=[3, 5], data_format="NHWC", name="nearest")
++    nearest_call = nearest.forward(object())
++    assert nearest.size == [3, 5]
++    assert nearest_call["size"] == [3, 5]
++    assert nearest_call["mode"] == "nearest"
++    assert nearest_call["data_format"] == "NHWC"
++    assert nearest_call["name"] == "nearest"
++
++    bilinear = bilinear_cls(size=(4, 6), data_format="NCHW")
++    bilinear_call = bilinear.forward(object())
++    assert bilinear.size == (4, 6)
++    assert bilinear_call["size"] == (4, 6)
++    assert bilinear_call["mode"] == "bilinear"
++    assert bilinear_call["align_corners"] is True
++
++    scaled = nearest_cls(scale_factor=2)
++    scaled_call = scaled.forward(object())
++    assert scaled.size is None
++    assert scaled.scale_factor == 2
++    assert scaled_call["scale_factor"] == 2
++
++
++def test_nearest_2d_accepts_single_integer_size():
++    nearest_cls, _ = _load_checkout_classes()
++    layer = nearest_cls(size=7)
++    call = layer.forward(object())
++
++    assert layer.size == [7, 7]
++    assert call["size"] == [7, 7]
++    assert call["mode"] == "nearest"
++
++
++def test_bilinear_2d_accepts_single_integer_size():
++    _, bilinear_cls = _load_checkout_classes()
++    layer = bilinear_cls(size=9)
++    call = layer.forward(object())
++
++    assert layer.size == [9, 9]
++    assert call["size"] == [9, 9]
++    assert call["mode"] == "bilinear"
++    assert call["align_corners"] is True

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-56470/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-56470/tests/test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python -m pytest test/swe_paddle/test_pr56470_upsampling_single_int.py -q


### PR DESCRIPTION
## 关联

- SWE-Paddle 共建 issue: https://github.com/PaddlePaddle/Paddle/issues/79447
- 来源 PR: https://github.com/PaddlePaddle/Paddle/pull/56470

## 说明

- 新增 SWE-Paddle 任务 `PaddlePaddle__Paddle-56470`
- swe-bench类型：`api_enhanced`

@sunzhongkai588

## 验证结果

| 状态 | Existing sequence/scale-factor P2P | Nearest2D single-int F2P | Bilinear2D single-int F2P |
| --- | --- | --- | --- |
| Base + `tests/test.patch` | PASS | FAIL，符合预期 | FAIL，符合预期 |
| Base + test patch + `solution/code.patch` | PASS | PASS | PASS |

#### Base P2P：Existing sequence and scale-factor behavior

```text
.                                                                        [100%]
1 passed in 0.03s
Base existing behavior P2P exit code: 0
```

#### Base F2P：`UpsamplingNearest2D` accepts a single integer size

```text
F                                                                        [100%]
================================== FAILURES ===================================
_________________ test_nearest_2d_accepts_single_integer_size _________________

    def test_nearest_2d_accepts_single_integer_size():
        nearest_cls, _ = _load_checkout_classes()
        layer = nearest_cls(size=7)
        call = layer.forward(object())

>       assert layer.size == [7, 7]
E       assert 7 == [7, 7]
E        +  where 7 = <UpsamplingNearest2D object at 0x00000282721FA250>.size

test\swe_paddle\test_pr56470_upsampling_single_int.py:74: AssertionError
=========================== short test summary info ===========================
FAILED test/swe_paddle/test_pr56470_upsampling_single_int.py::test_nearest_2d_accepts_single_integer_size
1 failed in 0.25s
Base Nearest2D single-int F2P exit code: 1
```

#### Base F2P：`UpsamplingBilinear2D` accepts a single integer size

```text
F                                                                        [100%]
================================== FAILURES ===================================
________________ test_bilinear_2d_accepts_single_integer_size _________________

    def test_bilinear_2d_accepts_single_integer_size():
        _, bilinear_cls = _load_checkout_classes()
        layer = bilinear_cls(size=9)
        call = layer.forward(object())

>       assert layer.size == [9, 9]
E       assert 9 == [9, 9]
E        +  where 9 = <UpsamplingBilinear2D object at 0x000001AEF23BA250>.size

test\swe_paddle\test_pr56470_upsampling_single_int.py:84: AssertionError
=========================== short test summary info ===========================
FAILED test/swe_paddle/test_pr56470_upsampling_single_int.py::test_bilinear_2d_accepts_single_integer_size
1 failed in 0.13s
Base Bilinear2D single-int F2P exit code: 1
```

#### Solution 测试

```text
Solution existing behavior P2P:
1 passed in 0.03s

Solution Nearest2D single-int F2P:
1 passed in 0.03s

Solution Bilinear2D single-int F2P:
1 passed in 0.03s
```

#### `tests/test.sh`

```text
...                                                                      [100%]
3 passed in 0.04s
Solution tests/test.sh exit code: 0
```