### PR TITLE
[SWE-Paddle] Complete task package for PaddlePaddle__Paddle-78441

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78441/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78441/README.md
@@ -1,0 +1,44 @@
+# PaddlePaddle__Paddle-78441
+
+This directory converts merged Paddle PR #78441 into a SWE-Paddle community task package.
+
+## Source
+
+| Field | Value |
+| --- | --- |
+| Repository | `PaddlePaddle/Paddle` |
+| PR | [78441](https://github.com/PaddlePaddle/Paddle/pull/78441) |
+| PR title | `[API Compatibility] add aminmax op-part` |
+| Base commit | `35b36cca24a780061268d20d6abe512e758837e6` |
+| Gold commit | `156159726b64d8f85747de864fb3ce41ea1f3f2f` |
+| Merged at | `2026-04-27` |
+| Task type | `feature_implementation` |
+| Track | Python API compatibility / new operator |
+| Resource | CPU; source build required |
+
+## Summary
+
+Add `paddle.aminmax` and the corresponding Tensor method so one reduction returns both minimum and maximum values. The task covers the public API, two-output shape inference, CPU execution, gradients, static and dynamic graph behavior, compatibility aliases, output tensors, and symbolic shapes.
+
+## Scope
+
+The gold change includes operator schemas and code generation inputs, infermeta, CPU/GPU kernel registrations, backward support, PIR symbolic-shape inference, Python exports and signatures, plus focused tests. CPU is the benchmark acceptance backend; GPU registration is retained in the gold patch but does not make GPU hardware a verifier requirement.
+
+## Artifacts
+
+- `proposal.md`: approved candidate proposal and source rationale.
+- `instruction.md`: self-contained task requirements for the coding agent.
+- `environment/README.md`: source-build and reproduction instructions.
+- `solution/code.patch`: exact non-test diff from base to gold commit.
+- `tests/test.patch`: exact test-only diff from base to gold commit.
+- `tests/test.sh`: strict target-test wrapper.
+
+## Verification
+
+From the root of a correctly rebuilt Paddle checkout, after applying the patches in the documented order:
+
+```bash
+bash tests/test.sh
+```
+
+A pre-existing release or nightly wheel cannot validate this task because the change introduces a compiled operator and updates build-time code-generation inputs.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78441/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78441/environment/README.md
@@ -1,0 +1,74 @@
+# Environment Notes
+
+## Expected environment
+
+- Repository: `PaddlePaddle/Paddle`
+- Base commit: `35b36cca24a780061268d20d6abe512e758837e6`
+- Gold commit: `156159726b64d8f85747de864fb3ce41ea1f3f2f`
+- Primary resource: Linux x86_64 CPU
+- Dependencies: a Python version supported by the base revision, NumPy, pytest, CMake, Ninja or Make, and a compatible C/C++ toolchain
+- Patch type: C++, operator YAML/code generation, infermeta, PIR symbolic shape, and Python API metadata
+- Source build required: yes
+
+## Build requirements
+
+Start with a clean checkout at the exact base commit and initialize its submodules. A release or nightly wheel is insufficient: the implementation adds compiled kernels and changes build-time operator schemas, generated bindings, infermeta, and symbolic-shape registration.
+
+Build Paddle from source after applying `solution/code.patch`. A CPU build is sufficient for benchmark acceptance; GPU hardware is not required. Keep the build configuration capable of running legacy Python operator tests and PIR symbolic-shape tests. The upstream test module also contains a CINN dynamic-shape case, so enable CINN when the target environment supports that test dependency. If CINN is unavailable, report that limitation rather than treating a skipped or uncollectable case as complete verification.
+
+A typical CPU configuration is:
+
+```bash
+cmake .. \
+  -GNinja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DPY_VERSION=3.10 \
+  -DWITH_GPU=OFF \
+  -DWITH_DISTRIBUTE=OFF \
+  -DWITH_CINN=ON \
+  -DWITH_TESTING=OFF
+ninja -j"$(nproc)"
+```
+
+Use options compatible with the actual host and base revision. Install the resulting wheel or otherwise ensure tests import the freshly rebuilt package, not a previously installed Paddle.
+
+## Patch and verification order
+
+From the Paddle repository root, with this task directory available as `$TASK_DIR`:
+
+```bash
+git checkout 35b36cca24a780061268d20d6abe512e758837e6
+git submodule update --init --recursive
+git apply "$TASK_DIR/tests/test.patch"
+```
+
+At this state the new test module is present, but the API and compiled operator do not exist. Running the target tests should fail during import, API lookup, graph construction, or execution. The existing reduction P2P tests should remain usable with the base build.
+
+Then apply the implementation and rebuild:
+
+```bash
+git apply "$TASK_DIR/solution/code.patch"
+# Re-run CMake if needed, then rebuild and reinstall Paddle.
+cmake --build build --parallel
+python -m pip install --no-deps --force-reinstall build/python/dist/*.whl
+bash "$TASK_DIR/tests/test.sh"
+```
+
+If the build system produces a wheel tagged for a different Python ABI, install and run tests with the matching interpreter. Do not rename the wheel to bypass ABI checks.
+
+## Exact target tests
+
+`tests/test.sh` runs:
+
+```bash
+python -m pytest test/legacy_test/test_aminmax_op.py -q
+python -m pytest \
+  test/ir/pir/cinn/symbolic/test_infer_sym_shape_unary_op.py::AminmaxOpInferSymbolicShapeTest \
+  -q
+```
+
+Expected post-fix results are passing forward, gradient, API compatibility, static/dynamic, output-tensor, dynamic-shape, and symbolic-shape cases. Stable pre-existing tests for `min`, `max`, `amin`, and `amax` can be added by the verifier as P2P regression guards.
+
+## Limitations
+
+The benchmark's required backend is CPU. The gold patch retains upstream GPU registrations, but GPU execution is not required for acceptance. No external dataset, network service, distributed topology, or multiple devices are needed.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78441/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78441/instruction.md
@@ -1,0 +1,50 @@
+# Add an `aminmax` reduction API
+
+## Problem
+
+Paddle provides separate minimum and maximum reductions but lacks a public operation that computes and returns both results with one API call. Add this capability as `paddle.aminmax` and as an equivalent Tensor method, with consistent behavior in dynamic and static execution.
+
+## Public API
+
+The operation accepts an input Tensor, an optional reduction axis, and an optional `keepdim` flag, and returns a two-element tuple `(minimum, maximum)`.
+
+Required argument behavior:
+
+- The input supports `float32`, `float64`, `int32`, and `int64`.
+- `axis=None` reduces all dimensions.
+- `axis` accepts an integer, list, or tuple, including multiple and negative axes.
+- `keepdim=False` removes reduced dimensions; `keepdim=True` retains them with size one.
+- `input` is accepted as an alias for the input Tensor.
+- `dim` is accepted as an alias for `axis`.
+- The functional API supports `out=(minimum_out, maximum_out)` and writes each result to the corresponding Tensor.
+- The Tensor method and functional API produce equivalent results.
+
+Both outputs must have the input dtype and independently match the results of applying minimum and maximum reductions with the same axis and `keepdim` arguments.
+
+## Shapes and execution modes
+
+Support dynamic graph, static graph, PIR, and symbolic/dynamic input shapes. Infer both output shapes correctly for:
+
+- reduction over all dimensions;
+- one or several axes;
+- negative axes;
+- retained dimensions;
+- scalar inputs;
+- empty tensors where the corresponding reduction is defined.
+
+Both outputs always have identical shapes for the same invocation.
+
+## Gradients
+
+Floating-point inputs must support backward propagation from either or both outputs. The input gradient is the sum of the minimum-output and maximum-output contributions. If a reduced region contains repeated minima or repeated maxima, distribute the corresponding output gradient evenly among all equal extrema. Handle axes and `keepdim` consistently in forward and backward execution, including empty inputs.
+
+## Compatibility and regression requirements
+
+- Preserve existing minimum and maximum reduction behavior.
+- Make the operation available through the normal Paddle API and Tensor method dispatch in rebuilt dynamic and static runtimes.
+- Reject invalid arguments through Paddle's normal validation paths; do not silently alter axis or output semantics.
+- Do not satisfy the task by implementing only a Python-level workaround, deleting tests, weakening assertions, or bypassing gradient and shape validation.
+
+## Verification
+
+The implementation must pass the focused operator/API suite and the `aminmax` symbolic-shape case supplied with this task. Verification must cover numerical outputs, gradients, aliases, `out`, static and dynamic execution, scalar and empty inputs, dynamic shapes, and symbolic shape inference. Because this feature requires compiled operator registration and generated bindings, validate it using a Paddle source build after applying the implementation patch.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78441/solution/code.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78441/solution/code.patch
@@ -1,0 +1,460 @@
+diff --git a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
+index f14a61b025..211294b485 100644
+--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
++++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.cc
+@@ -307,6 +307,24 @@ bool AminOpInferSymbolicShape(pir::Operation *op,
+                                  axis.size() == 0 /*reduce_all*/);
+ }
+ 
++bool AminmaxOpInferSymbolicShape(
++    pir::Operation *op, pir::InferSymbolicShapeContext *infer_context) {
++  const auto &axis = details::GetVectorAttr(op, "axis");
++  bool keepdim = GetBoolAttr(op, "keepdim");
++  bool reduce_all = axis.size() == 0;
++
++  // ReduceInferDim only sets result(0). We need the same shape for both
++  // outputs, so call it for result(0) then copy to result(1).
++  bool ret =
++      details::ReduceInferDim(op, infer_context, axis, keepdim, reduce_all);
++  if (ret) {
++    const auto &out_shape =
++        infer_context->GetShapeOrDataForValue(op->result(0));
++    infer_context->SetShapeOrDataForValue(op->result(1), out_shape);
++  }
++  return ret;
++}
++
+ bool AnyOpInferSymbolicShape(pir::Operation *op,
+                              pir::InferSymbolicShapeContext *infer_context) {
+   const auto &axis = details::GetVectorAttr(op, "axis");
+diff --git a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.h b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.h
+index 18a21a6746..99409f402c 100644
+--- a/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.h
++++ b/paddle/fluid/pir/dialect/operator/interface/infer_symbolic_shape/unary_infer_sym.h
+@@ -21,6 +21,7 @@ OP_DECLARE_INFER_SYMBOLIC_SHAPE(AffineGrid)
+ OP_DECLARE_INFER_SYMBOLIC_SHAPE(All)
+ OP_DECLARE_INFER_SYMBOLIC_SHAPE(Amax)
+ OP_DECLARE_INFER_SYMBOLIC_SHAPE(Amin)
++OP_DECLARE_INFER_SYMBOLIC_SHAPE(Aminmax)
+ OP_DECLARE_INFER_SYMBOLIC_SHAPE(Any)
+ OP_DECLARE_INFER_SYMBOLIC_SHAPE(Argmax)
+ OP_DECLARE_INFER_SYMBOLIC_SHAPE(Argmin)
+diff --git a/paddle/phi/infermeta/unary.cc b/paddle/phi/infermeta/unary.cc
+index ccc37c6418..4843140b25 100644
+--- a/paddle/phi/infermeta/unary.cc
++++ b/paddle/phi/infermeta/unary.cc
+@@ -4291,6 +4291,24 @@ void ReduceInferMeta(const MetaTensor& x,
+   ReduceInferMetaBase(x, axis, keep_dim, reduce_all, out);
+ }
+ 
++void AMinMaxInferMeta(const MetaTensor& x,
++                      const std::vector<int64_t>& axis,
++                      bool keep_dim,
++                      MetaTensor* min,
++                      MetaTensor* max) {
++  bool reduce_all = false;
++  if (axis.empty()) {
++    reduce_all = true;
++  }
++  DDim out_dim = ReduceInferDim(x, axis, keep_dim, reduce_all);
++  min->set_dims(out_dim);
++  min->set_dtype(x.dtype());
++  min->set_layout(x.layout());
++  max->set_dims(out_dim);
++  max->set_dtype(x.dtype());
++  max->set_layout(x.layout());
++}
++
+ DDim ReduceInferDimForIntArrayAxis(const MetaTensor& x,
+                                    const IntArray& axis,
+                                    bool keep_dim,
+diff --git a/paddle/phi/infermeta/unary.h b/paddle/phi/infermeta/unary.h
+index 7032fef96d..991d2dfea7 100644
+--- a/paddle/phi/infermeta/unary.h
++++ b/paddle/phi/infermeta/unary.h
+@@ -69,6 +69,12 @@ PADDLE_API void ArgMinMaxInferMeta(const MetaTensor& x,
+                                    MetaTensor* out,
+                                    MetaConfig config = MetaConfig());
+ 
++PADDLE_API void AMinMaxInferMeta(const MetaTensor& x,
++                                 const std::vector<int64_t>& axis,
++                                 bool keep_dim,
++                                 MetaTensor* min,
++                                 MetaTensor* max);
++
+ PADDLE_API void MinMaxWithIndexInferMeta(const MetaTensor& x,
+                                          const Scalar& axis,
+                                          bool keepdims,
+diff --git a/paddle/phi/kernels/aminmax_grad_kernel.cc b/paddle/phi/kernels/aminmax_grad_kernel.cc
+new file mode 100644
+index 0000000000..c656e8746d
+--- /dev/null
++++ b/paddle/phi/kernels/aminmax_grad_kernel.cc
+@@ -0,0 +1,77 @@
++// Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
++//
++// Licensed under the Apache License, Version 2.0 (the "License");
++// you may not use this file except in compliance with the License.
++// You may obtain a copy of the License at
++//
++//     http://www.apache.org/licenses/LICENSE-2.0
++//
++// Unless required by applicable law or agreed to in writing, software
++// distributed under the License is distributed on an "AS IS" BASIS,
++// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++// See the License for the specific language governing permissions and
++// limitations under the License.
++
++#include "paddle/phi/kernels/aminmax_grad_kernel.h"
++
++#include "paddle/phi/backends/all_context.h"
++#include "paddle/phi/core/kernel_registry.h"
++#include "paddle/phi/kernels/elementwise_add_kernel.h"
++#include "paddle/phi/kernels/reduce_amax_grad_kernel.h"
++#include "paddle/phi/kernels/reduce_amin_grad_kernel.h"
++
++namespace phi {
++
++template <typename T, typename Context>
++void AMinMaxGradKernel(const Context& dev_ctx,
++                       const DenseTensor& x,
++                       const DenseTensor& min,
++                       const DenseTensor& max,
++                       const DenseTensor& min_grad,
++                       const DenseTensor& max_grad,
++                       const std::vector<int64_t>& dims,
++                       bool keep_dim,
++                       bool reduce_all,
++                       DenseTensor* x_grad) {
++  if (x_grad && x_grad->numel() == 0) {
++    dev_ctx.template Alloc<T>(x_grad);
++    return;
++  }
++  reduce_all = recompute_reduce_all(x, dims, reduce_all);
++
++  // Compute amax grad contribution into x_grad
++  ReduceAMaxGradKernel<T, Context>(
++      dev_ctx, x, max, max_grad, dims, keep_dim, reduce_all, x_grad);
++
++  // Compute amin grad contribution into a temporary tensor
++  DenseTensor amin_x_grad;
++  amin_x_grad.Resize(x_grad->dims());
++  dev_ctx.template Alloc<T>(&amin_x_grad);
++  ReduceAMinGradKernel<T, Context>(
++      dev_ctx, x, min, min_grad, dims, keep_dim, reduce_all, &amin_x_grad);
++
++  // x_grad = amax_grad_result + amin_grad_result
++  Add<T, Context>(dev_ctx, *x_grad, amin_x_grad, x_grad);
++}
++
++}  // namespace phi
++
++PD_REGISTER_KERNEL(aminmax_grad,
++                   CPU,
++                   ALL_LAYOUT,
++                   phi::AMinMaxGradKernel,
++                   float,
++                   double,
++                   int,
++                   int64_t) {}
++
++#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
++PD_REGISTER_KERNEL(aminmax_grad,
++                   GPU,
++                   ALL_LAYOUT,
++                   phi::AMinMaxGradKernel,
++                   float,
++                   double,
++                   int,
++                   int64_t) {}
++#endif
+diff --git a/paddle/phi/kernels/aminmax_grad_kernel.h b/paddle/phi/kernels/aminmax_grad_kernel.h
+new file mode 100644
+index 0000000000..8ad0c4810f
+--- /dev/null
++++ b/paddle/phi/kernels/aminmax_grad_kernel.h
+@@ -0,0 +1,31 @@
++// Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
++//
++// Licensed under the Apache License, Version 2.0 (the "License");
++// you may not use this file except in compliance with the License.
++// You may obtain a copy of the License at
++//
++//     http://www.apache.org/licenses/LICENSE-2.0
++//
++// Unless required by applicable law or agreed to in writing, software
++// distributed under the License is distributed on an "AS IS" BASIS,
++// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++// See the License for the specific language governing permissions and
++// limitations under the License.
++
++#pragma once
++
++#include "paddle/phi/core/dense_tensor.h"
++
++namespace phi {
++template <typename T, typename Context>
++void AMinMaxGradKernel(const Context& dev_ctx,
++                       const DenseTensor& x,
++                       const DenseTensor& min,
++                       const DenseTensor& max,
++                       const DenseTensor& min_grad,
++                       const DenseTensor& max_grad,
++                       const std::vector<int64_t>& axis,
++                       bool keep_dim,
++                       bool reduce_all,
++                       DenseTensor* x_grad);
++}  // namespace phi
+diff --git a/paddle/phi/kernels/aminmax_kernel.cc b/paddle/phi/kernels/aminmax_kernel.cc
+new file mode 100644
+index 0000000000..7e89df957a
+--- /dev/null
++++ b/paddle/phi/kernels/aminmax_kernel.cc
+@@ -0,0 +1,50 @@
++// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
++//
++// Licensed under the Apache License, Version 2.0 (the "License");
++// you may not use this file except in compliance with the License.
++// You may obtain a copy of the License at
++//
++//     http://www.apache.org/licenses/LICENSE-2.0
++//
++// Unless required by applicable law or agreed to in writing, software
++// distributed under the License is distributed on an "AS IS" BASIS,
++// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++// See the License for the specific language governing permissions and
++// limitations under the License.
++
++#include "paddle/phi/kernels/aminmax_kernel.h"
++
++#include "paddle/phi/backends/all_context.h"
++#include "paddle/phi/core/kernel_registry.h"
++#include "paddle/phi/kernels/reduce_amax_kernel.h"
++#include "paddle/phi/kernels/reduce_amin_kernel.h"
++
++namespace phi {
++
++template <typename T, typename Context>
++void AMinMaxKernel(const Context& dev_ctx,
++                   const DenseTensor& x,
++                   const std::vector<int64_t>& dims,
++                   bool keep_dim,
++                   DenseTensor* min,
++                   DenseTensor* max) {
++  bool reduce_all = recompute_reduce_all(x, dims);
++  AMinRawKernel<T>(dev_ctx, x, dims, keep_dim, reduce_all, min);
++  AMaxRawKernel<T>(dev_ctx, x, dims, keep_dim, reduce_all, max);
++}
++
++}  // namespace phi
++
++PD_REGISTER_KERNEL(
++    aminmax, CPU, ALL_LAYOUT, phi::AMinMaxKernel, float, double, int, int64_t) {
++}
++
++#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
++PD_REGISTER_KERNEL(
++    aminmax, GPU, ALL_LAYOUT, phi::AMinMaxKernel, float, double, int, int64_t) {
++}
++#endif
++
++#if defined(PADDLE_WITH_XPU_KP)
++PD_REGISTER_KERNEL(aminmax, KPS, ALL_LAYOUT, phi::AMinMaxKernel, float) {}
++#endif
+diff --git a/paddle/phi/kernels/aminmax_kernel.h b/paddle/phi/kernels/aminmax_kernel.h
+new file mode 100644
+index 0000000000..ab4ebcacb7
+--- /dev/null
++++ b/paddle/phi/kernels/aminmax_kernel.h
+@@ -0,0 +1,29 @@
++// Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
++//
++// Licensed under the Apache License, Version 2.0 (the "License");
++// you may not use this file except in compliance with the License.
++// You may obtain a copy of the License at
++//
++//     http://www.apache.org/licenses/LICENSE-2.0
++//
++// Unless required by applicable law or agreed to in writing, software
++// distributed under the License is distributed on an "AS IS" BASIS,
++// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++// See the License for the specific language governing permissions and
++// limitations under the License.
++
++#pragma once
++
++#include "paddle/phi/core/dense_tensor.h"
++
++namespace phi {
++
++template <typename T, typename Context>
++void AMinMaxKernel(const Context& dev_ctx,
++                   const DenseTensor& x,
++                   const std::vector<int64_t>& dims,
++                   bool keep_dim,
++                   DenseTensor* min,
++                   DenseTensor* max);
++
++}  // namespace phi
+diff --git a/paddle/phi/ops/yaml/backward.yaml b/paddle/phi/ops/yaml/backward.yaml
+index 355611abe6..4d3b2fb19c 100644
+--- a/paddle/phi/ops/yaml/backward.yaml
++++ b/paddle/phi/ops/yaml/backward.yaml
+@@ -141,6 +141,16 @@
+   kernel :
+     func : amin_grad
+ 
++- backward_op : aminmax_grad
++  forward : aminmax (Tensor x, int64_t[] axis={}, bool keepdim=false) -> Tensor(min), Tensor(max)
++  args : (Tensor x, Tensor min, Tensor max, Tensor min_grad, Tensor max_grad, int64_t[] axis={}, bool keepdim=false, bool reduce_all=false)
++  output : Tensor(x_grad)
++  infer_meta :
++    func : UnchangedInferMeta
++    param : [x]
++  kernel :
++    func : aminmax_grad
++
+ - backward_op : angle_grad
+   forward : angle (Tensor x) -> Tensor(out)
+   args : (Tensor x, Tensor out_grad)
+diff --git a/paddle/phi/ops/yaml/op_compat.yaml b/paddle/phi/ops/yaml/op_compat.yaml
+index 97ba24befe..0583723c22 100755
+--- a/paddle/phi/ops/yaml/op_compat.yaml
++++ b/paddle/phi/ops/yaml/op_compat.yaml
+@@ -206,6 +206,14 @@
+     amin_grad : GetReduceGradExpectedKernelType
+   manual_signature : [amin]
+ 
++- op : aminmax
++  backward : aminmax_grad
++  inputs :
++    x : X
++  outputs :
++    {min : Min, max : Max}
++  manual_signature : [aminmax]
++
+ - op : anchor_generator
+   inputs:
+     input : Input
+diff --git a/paddle/phi/ops/yaml/ops.yaml b/paddle/phi/ops/yaml/ops.yaml
+index 6723d6d55b..e95a65b5b3 100644
+--- a/paddle/phi/ops/yaml/ops.yaml
++++ b/paddle/phi/ops/yaml/ops.yaml
+@@ -258,6 +258,16 @@
+   backward : amin_grad
+   interfaces : paddle::dialect::InferSymbolicShapeInterface, paddle::dialect::LayoutTransformationInterface
+ 
++- op : aminmax
++  args : (Tensor x, int64_t[] axis={}, bool keepdim=false)
++  output : Tensor(min), Tensor(max)
++  infer_meta :
++    func : AMinMaxInferMeta
++  kernel :
++    func : aminmax
++  backward : aminmax_grad
++  interfaces : paddle::dialect::InferSymbolicShapeInterface
++
+ - op : angle
+   args : (Tensor x)
+   output : Tensor
+diff --git a/paddle/phi/ops/yaml/python_api_info.yaml b/paddle/phi/ops/yaml/python_api_info.yaml
+index 3e5aa5018b..fa79d453f5 100644
+--- a/paddle/phi/ops/yaml/python_api_info.yaml
++++ b/paddle/phi/ops/yaml/python_api_info.yaml
+@@ -55,6 +55,11 @@
+   args_alias :
+     use_default_mapping : True
+ 
++- op : aminmax
++  name : [paddle.aminmax, paddle.Tensor.aminmax]
++  args_alias :
++    use_default_mapping : True
++
+ - op : angle
+   name : [paddle.angle, paddle.Tensor.angle]
+   args_alias :
+diff --git a/python/paddle/__init__.py b/python/paddle/__init__.py
+index 7ac6009986..23c779c177 100644
+--- a/python/paddle/__init__.py
++++ b/python/paddle/__init__.py
+@@ -1143,6 +1143,7 @@ __all__ = [
+     'min',
+     'narrow',
+     'amin',
++    'aminmax',
+     'any',
+     'slice',
+     'slice_scatter',
+diff --git a/python/paddle/_paddle_docs.py b/python/paddle/_paddle_docs.py
+index 5bd3301bd6..ade0d82674 100644
+--- a/python/paddle/_paddle_docs.py
++++ b/python/paddle/_paddle_docs.py
+@@ -329,6 +329,56 @@ def amin(
+ """,
+ )
+ 
++add_doc_and_signature(
++    "aminmax",
++    r"""
++    Computes both the minimum and maximum of tensor elements over the given axis.
++
++    Note:
++        Like amin and amax, if there are multiple minimum/maximum elements,
++        aminmax evenly distributes gradient between these equal values.
++
++    Args:
++        x (Tensor): A tensor, the data type is float32, float64, int32, int64.
++            Alias: ``input``.
++        axis (int|list|tuple|None, optional): The axis along which the minimum and maximum
++            are computed. If :attr:`None`, compute over all elements of
++            `x` and return Tensors with a single element,
++            otherwise must be in the range :math:`[-x.ndim, x.ndim)`.
++            If :math:`axis[i] < 0`, the axis to reduce is :math:`x.ndim + axis[i]`.
++            Alias: ``dim``.
++        keepdim (bool, optional): Whether to reserve the reduced dimension in the
++            output Tensors. The result tensors will have one fewer dimension
++            than the `x` unless :attr:`keepdim` is true, default
++            value is False.
++
++    Keyword args:
++        out(tuple(Tensor, Tensor), optional): The output tensors.
++
++    Returns:
++        tuple(Tensor, Tensor), the minimum and maximum results on the specified axis
++        of input tensor, the data type is the same as `x`.
++
++    Examples:
++        .. code-block:: pycon
++
++            >>> import paddle
++            >>> x = paddle.to_tensor([[0.1, 0.9, 0.9, 0.9],
++            ...                       [0.9, 0.9, 0.6, 0.7]],
++            ...                       dtype='float64', stop_gradient=False)
++            >>> # min_val, max_val = paddle.aminmax(x)  # doctest to be enabled after API is merged
++""",
++    """
++def aminmax(
++    x: Tensor,
++    axis: int | Sequence[int] | None = None,
++    keepdim: bool = False,
++    *,
++    out: tuple[Tensor, Tensor] | None = None,
++) -> tuple[Tensor, Tensor]
++""",
++)
++
+ add_doc_and_signature(
+     "amax",
+     r"""
+diff --git a/python/paddle/tensor/__init__.py b/python/paddle/tensor/__init__.py
+index 7907c9ee0d..ee05261e70 100644
+--- a/python/paddle/tensor/__init__.py
++++ b/python/paddle/tensor/__init__.py
+@@ -625,6 +625,7 @@ tensor_method_func = [
+     'positive',
+     'min',
+     'amin',
++    'aminmax',
+     'minimum',
+     'fmax',
+     'fmin',

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78441/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78441/tests/test.patch
@@ -1,0 +1,514 @@
+diff --git a/test/ir/pir/cinn/symbolic/test_infer_sym_shape_unary_op.py b/test/ir/pir/cinn/symbolic/test_infer_sym_shape_unary_op.py
+index 4c476831f1..075b8a08a5 100644
+--- a/test/ir/pir/cinn/symbolic/test_infer_sym_shape_unary_op.py
++++ b/test/ir/pir/cinn/symbolic/test_infer_sym_shape_unary_op.py
+@@ -447,6 +447,64 @@ class MaxMinOpInferSymbolicShapeTest(TestBase):
+         return True
+ 
+ 
++class AminmaxNet(paddle.nn.Layer):
++    def __init__(self):
++        super().__init__()
++
++    def forward(self, x):
++        min_out, max_out = paddle.aminmax(x)
++        min_out, max_out = paddle.aminmax(x, axis=0)
++        min_out, max_out = paddle.aminmax(x, axis=1)
++        min_out, max_out = paddle.aminmax(x, axis=-1)
++        min_out, max_out = paddle.aminmax(x, axis=-2)
++        # keepdim=True
++        min_out, max_out = paddle.aminmax(x, keepdim=True)
++        min_out, max_out = paddle.aminmax(x, axis=0, keepdim=True)
++        min_out, max_out = paddle.aminmax(x, axis=1, keepdim=True)
++        min_out, max_out = paddle.aminmax(x, axis=-1, keepdim=True)
++        min_out, max_out = paddle.aminmax(x, axis=-2, keepdim=True)
++
++        min_out, max_out = paddle.aminmax(x, axis=[1, 2])
++        min_out, max_out = paddle.aminmax(x, axis=[1, 2], keepdim=True)
++        return min_out, max_out
++
++
++class AminmaxOpInferSymbolicShapeTest(TestBase):
++    def prepare_data(self):
++        self.cases = [np.random.rand(2, 4, 3)]
++
++        self.expected = [
++            'shape[], data[NULL]',
++            'shape[S1, S2], data[NULL]',
++            'shape[S0, S2], data[NULL]',
++            'shape[S0, S1], data[NULL]',
++            'shape[S0, S2], data[NULL]',
++            # keepdim=True
++            'shape[1, 1, 1], data[NULL]',
++            'shape[1, S1, S2], data[NULL]',
++            'shape[S0, 1, S2], data[NULL]',
++            'shape[S0, S1, 1], data[NULL]',
++            'shape[S0, 1, S2], data[NULL]',
++            'shape[S0], data[NULL]',
++            'shape[S0, 1, 1], data[NULL]',
++        ]
++
++    def test_eval_symbolic(self):
++        net = AminmaxNet()
++
++        for i in range(len(self.cases)):
++            x = self.cases[i]
++            x_spec = InputSpec(
++                shape=[None for index in range(len(x.shape))], dtype='float32'
++            )
++            input_spec = [x_spec]
++            net = apply_to_static(net, False, input_spec)
++            net.eval()
++            check_infer_results(net, input_spec, 'pd_op.aminmax', self.expected)
++
++        return True
++
++
+ class NonzeroNet(paddle.nn.Layer):
+     def __init__(self):
+         super().__init__()
+diff --git a/test/legacy_test/test_aminmax_op.py b/test/legacy_test/test_aminmax_op.py
+new file mode 100644
+index 0000000000..39e56aad43
+--- /dev/null
++++ b/test/legacy_test/test_aminmax_op.py
+@@ -0,0 +1,439 @@
++# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++
++import unittest
++
++import numpy as np
++from op_test import OpTest
++from utils import dygraph_guard, static_guard
++
++import paddle
++from paddle import base
++from paddle.static import InputSpec
++
++
++def ref_aminmax(x, axis=None, keepdim=False):
++    min_val = np.amin(x, axis=axis, keepdims=keepdim)
++    max_val = np.amax(x, axis=axis, keepdims=keepdim)
++    return min_val, max_val
++
++
++def ref_aminmax_grad(x, axis=None, keepdim=False):
++    """Compute expected gradient: amin_grad + amax_grad (evenly distributed)."""
++    min_val = np.amin(x, axis=axis, keepdims=True)
++    max_val = np.amax(x, axis=axis, keepdims=True)
++    min_mask = (x == min_val).astype(x.dtype)
++    max_mask = (x == max_val).astype(x.dtype)
++    min_count = np.sum(min_mask, axis=axis, keepdims=True)
++    max_count = np.sum(max_mask, axis=axis, keepdims=True)
++    grad = min_mask / min_count + max_mask / max_count
++    return grad
++
++
++class TestAminmaxOp(OpTest):
++    def setUp(self):
++        self.op_type = "aminmax"
++        self.python_api = paddle.aminmax
++        self.public_python_api = paddle.aminmax
++        self.init_dtype()
++        self.init_shape()
++        self.init_args()
++        np.random.seed(2025)
++        self.input_data = np.random.random(self.shape).astype(self.dtype)
++        self.inputs = {'X': self.input_data}
++        self.attrs = {'axis': self.axis, 'keepdim': self.keepdim}
++        min_val, max_val = ref_aminmax(
++            self.input_data, axis=self.axis_for_np, keepdim=self.keepdim
++        )
++        self.outputs = {'Min': min_val, 'Max': max_val}
++
++    def init_dtype(self):
++        self.dtype = np.float64
++
++    def init_shape(self):
++        self.shape = [4, 5, 6]
++
++    def init_args(self):
++        self.axis = []
++        self.axis_for_np = None
++        self.keepdim = False
++
++    def test_check_output(self):
++        self.check_output(check_pir=True)
++
++    def test_check_grad(self):
++        self.check_grad(
++            ['X'],
++            ['Min', 'Max'],
++            check_pir=True,
++        )
++
++
++class TestAminmaxOpAxis0(TestAminmaxOp):
++    def init_args(self):
++        self.axis = [0]
++        self.axis_for_np = 0
++        self.keepdim = False
++
++
++class TestAminmaxOpAxis1(TestAminmaxOp):
++    def init_args(self):
++        self.axis = [1]
++        self.axis_for_np = 1
++        self.keepdim = False
++
++
++class TestAminmaxOpAxisNeg(TestAminmaxOp):
++    def init_args(self):
++        self.axis = [-1]
++        self.axis_for_np = -1
++        self.keepdim = False
++
++
++class TestAminmaxOpKeepdim(TestAminmaxOp):
++    def init_args(self):
++        self.axis = [1]
++        self.axis_for_np = 1
++        self.keepdim = True
++
++
++class TestAminmaxOpFloat32(TestAminmaxOp):
++    def init_dtype(self):
++        self.dtype = np.float32
++
++    def init_shape(self):
++        self.shape = [10, 10]
++
++    def test_check_grad(self):
++        # float32 numerical gradient is unreliable for aminmax:
++        # small perturbations can flip which element is min/max,
++        # causing the numerical and analytic gradients to diverge.
++        pass
++
++
++class TestAminmaxOpZeroDim(TestAminmaxOp):
++    def init_shape(self):
++        self.shape = []
++
++
++class TestAminmaxOpEmptyTensor(unittest.TestCase):
++    """Test aminmax with empty tensor to cover the numel==0 early return in grad kernel."""
++
++    def test_empty_tensor_grad(self):
++        paddle.disable_static()
++        x = paddle.zeros([0, 3], dtype='float64')
++        x.stop_gradient = False
++        min_val, max_val = paddle.aminmax(x, axis=0)
++        loss = min_val.sum() + max_val.sum()
++        loss.backward()
++        self.assertEqual(list(x.grad.shape), [0, 3])
++        paddle.enable_static()
++
++
++class TestAminmaxAPI(unittest.TestCase):
++    def setUp(self):
++        np.random.seed(2025)
++        self.x_np = np.array(
++            [[0.2, 0.3, 0.5, 0.9], [0.1, 0.2, 0.6, 0.7]], dtype='float64'
++        )
++
++    def test_dygraph(self):
++        paddle.disable_static()
++        x = paddle.to_tensor(self.x_np, stop_gradient=False)
++        min_val, max_val = paddle.aminmax(x, axis=1, keepdim=True)
++
++        expected_min, expected_max = ref_aminmax(
++            self.x_np, axis=1, keepdim=True
++        )
++        np.testing.assert_allclose(min_val.numpy(), expected_min, rtol=1e-05)
++        np.testing.assert_allclose(max_val.numpy(), expected_max, rtol=1e-05)
++        paddle.enable_static()
++
++    def test_dygraph_gradient(self):
++        paddle.disable_static()
++        x = paddle.to_tensor(self.x_np, stop_gradient=False)
++        min_val, max_val = paddle.aminmax(x)
++        loss = min_val.sum() + max_val.sum()
++        loss.backward()
++
++        expected_grad = ref_aminmax_grad(self.x_np)
++        np.testing.assert_allclose(x.grad.numpy(), expected_grad, rtol=1e-05)
++        paddle.enable_static()
++
++    def test_dygraph_gradient_with_axis(self):
++        paddle.disable_static()
++        x = paddle.to_tensor(self.x_np, stop_gradient=False)
++        min_val, max_val = paddle.aminmax(x, axis=1)
++        loss = min_val.sum() + max_val.sum()
++        loss.backward()
++
++        expected_grad = ref_aminmax_grad(self.x_np, axis=1)
++        np.testing.assert_allclose(x.grad.numpy(), expected_grad, rtol=1e-05)
++        paddle.enable_static()
++
++    def test_dygraph_gradient_duplicate_values(self):
++        paddle.disable_static()
++        x_np = np.array(
++            [[0.9, 0.1, 0.1, 0.9], [0.1, 0.9, 0.5, 0.1]], dtype='float64'
++        )
++        x = paddle.to_tensor(x_np, stop_gradient=False)
++        min_val, max_val = paddle.aminmax(x)
++        loss = min_val.sum() + max_val.sum()
++        loss.backward()
++
++        expected_grad = ref_aminmax_grad(x_np)
++        np.testing.assert_allclose(x.grad.numpy(), expected_grad, rtol=1e-05)
++        paddle.enable_static()
++
++    def test_dygraph_out(self):
++        paddle.disable_static()
++        x = paddle.to_tensor(self.x_np)
++        min_out = paddle.empty([])
++        max_out = paddle.empty([])
++        min_val, max_val = paddle.aminmax(x, out=(min_out, max_out))
++
++        expected_min, expected_max = ref_aminmax(self.x_np)
++        np.testing.assert_allclose(min_val.numpy(), expected_min, rtol=1e-05)
++        np.testing.assert_allclose(max_val.numpy(), expected_max, rtol=1e-05)
++        np.testing.assert_allclose(min_out.numpy(), expected_min, rtol=1e-05)
++        np.testing.assert_allclose(max_out.numpy(), expected_max, rtol=1e-05)
++        paddle.enable_static()
++
++    def test_dygraph_out_with_axis(self):
++        paddle.disable_static()
++        x = paddle.to_tensor(self.x_np)
++        min_out = paddle.empty([2])
++        max_out = paddle.empty([2])
++        min_val, max_val = paddle.aminmax(x, axis=1, out=(min_out, max_out))
++
++        expected_min, expected_max = ref_aminmax(self.x_np, axis=1)
++        np.testing.assert_allclose(min_val.numpy(), expected_min, rtol=1e-05)
++        np.testing.assert_allclose(max_val.numpy(), expected_max, rtol=1e-05)
++        np.testing.assert_allclose(min_out.numpy(), expected_min, rtol=1e-05)
++        np.testing.assert_allclose(max_out.numpy(), expected_max, rtol=1e-05)
++        paddle.enable_static()
++
++    def test_static(self):
++        paddle.enable_static()
++        main = paddle.static.Program()
++        startup = paddle.static.Program()
++        with paddle.static.program_guard(main, startup):
++            x = paddle.static.data(name='x', dtype='float64', shape=[2, 4])
++            min_val, max_val = paddle.aminmax(x, axis=1, keepdim=True)
++
++            exe = paddle.static.Executor()
++            fetches = exe.run(
++                main,
++                feed={'x': self.x_np},
++                fetch_list=[min_val, max_val],
++            )
++
++            expected_min, expected_max = ref_aminmax(
++                self.x_np, axis=1, keepdim=True
++            )
++            np.testing.assert_allclose(fetches[0], expected_min, rtol=1e-05)
++            np.testing.assert_allclose(fetches[1], expected_max, rtol=1e-05)
++
++
++class TestAminmaxAPI_Compatibility(unittest.TestCase):
++    def setUp(self):
++        np.random.seed(2025)
++        paddle.enable_static()
++        self.shape = [5, 6]
++        self.dtype = 'float64'
++        self.init_data()
++
++    def init_data(self):
++        self.np_input = np.random.random(self.shape).astype(self.dtype)
++
++    def test_dygraph_Compatibility(self):
++        paddle.disable_static()
++        x = paddle.to_tensor(self.np_input)
++        paddle_dygraph_min = []
++        paddle_dygraph_max = []
++        # 1. Paddle Positional arguments
++        min1, max1 = paddle.aminmax(x, 1, True)
++        paddle_dygraph_min.append(min1)
++        paddle_dygraph_max.append(max1)
++        # 2. Paddle keyword arguments
++        min2, max2 = paddle.aminmax(x=x, axis=1, keepdim=True)
++        paddle_dygraph_min.append(min2)
++        paddle_dygraph_max.append(max2)
++        # 4. PyTorch keyword arguments (alias)
++        min3, max3 = paddle.aminmax(input=x, dim=1, keepdim=True)
++        paddle_dygraph_min.append(min3)
++        paddle_dygraph_max.append(max3)
++        # 5. Mixed arguments
++        min4, max4 = paddle.aminmax(x, dim=1, keepdim=True)
++        paddle_dygraph_min.append(min4)
++        paddle_dygraph_max.append(max4)
++        # 6. out parameter test
++        min_out = paddle.empty([])
++        max_out = paddle.empty([])
++        paddle.aminmax(x, 1, True, out=(min_out, max_out))
++        paddle_dygraph_min.append(min_out)
++        paddle_dygraph_max.append(max_out)
++        # 7. Tensor method - args
++        min5, max5 = x.aminmax(1, True)
++        paddle_dygraph_min.append(min5)
++        paddle_dygraph_max.append(max5)
++        # 8. Tensor method - kwargs
++        min6, max6 = x.aminmax(dim=1, keepdim=True)
++        paddle_dygraph_min.append(min6)
++        paddle_dygraph_max.append(max6)
++        # Test default value
++        min8, max8 = x.aminmax(1)
++        # Numpy reference out
++        ref_min = np.amin(self.np_input, 1, keepdims=True)
++        ref_max = np.amax(self.np_input, 1, keepdims=True)
++        # Check
++        for out in paddle_dygraph_min:
++            np.testing.assert_allclose(ref_min, out.numpy())
++        for out in paddle_dygraph_max:
++            np.testing.assert_allclose(ref_max, out.numpy())
++        ref_min = np.amin(self.np_input, 1, keepdims=False)
++        ref_max = np.amax(self.np_input, 1, keepdims=False)
++        np.testing.assert_allclose(ref_min, min8.numpy())
++        np.testing.assert_allclose(ref_max, max8.numpy())
++        paddle.enable_static()
++
++    def test_static_Compatibility(self):
++        main = paddle.static.Program()
++        startup = paddle.static.Program()
++        with base.program_guard(main, startup):
++            x = paddle.static.data(name="x", shape=self.shape, dtype=self.dtype)
++            # 1. Paddle Positional arguments
++            min1, max1 = paddle.aminmax(x, 1, True)
++            # 2. Paddle keyword arguments
++            min2, max2 = paddle.aminmax(x=x, axis=1, keepdim=True)
++            # 4. PyTorch keyword arguments (alias)
++            min3, max3 = paddle.aminmax(input=x, dim=1, keepdim=True)
++            # 5. Mixed arguments
++            min4, max4 = paddle.aminmax(x, dim=1, keepdim=True)
++            # 6. Do not support out in static
++            # 7. Tensor method - args
++            min5, max5 = x.aminmax(1, True)
++            # 8. Tensor method - kwargs
++            min6, max6 = x.aminmax(dim=1, keepdim=True)
++            # Test default value
++            min8, max8 = x.aminmax()
++            exe = base.Executor()
++            fetches = exe.run(
++                main,
++                feed={"x": self.np_input},
++                fetch_list=[
++                    min1,
++                    max1,
++                    min2,
++                    max2,
++                    min3,
++                    max3,
++                    min4,
++                    max4,
++                    min5,
++                    max5,
++                    min6,
++                    max6,
++                    min8,
++                    max8,
++                ],
++            )
++            ref_min = np.amin(self.np_input, 1, keepdims=True)
++            ref_max = np.amax(self.np_input, 1, keepdims=True)
++            for i in range(0, len(fetches) - 2, 2):
++                np.testing.assert_allclose(fetches[i], ref_min)
++                np.testing.assert_allclose(fetches[i + 1], ref_max)
++            ref_min = np.amin(self.np_input)
++            ref_max = np.amax(self.np_input)
++            np.testing.assert_allclose(fetches[-2], ref_min)
++            np.testing.assert_allclose(fetches[-1], ref_max)
++
++
++def aminmax_net(x):
++    return paddle.aminmax(x, axis=1)
++
++
++class TestAminmaxDynamicShape(unittest.TestCase):
++    def setUp(self):
++        np.random.seed(2025)
++        self.shape = [4, 5, 6]
++        self.dtype = "float32"
++        self.init_shape = [None, None, 6]
++        self.x = np.random.random(self.shape).astype(self.dtype)
++        self.net = aminmax_net
++        self.enable_cinn = True
++        self.tol = 1e-6
++
++    def base_net(self, flag=None):
++        x = paddle.to_tensor(self.x)
++        if flag == "static":
++            fn = paddle.jit.to_static(
++                self.net,
++                input_spec=[
++                    InputSpec(shape=self.init_shape, dtype=self.dtype),
++                ],
++                backend="CINN" if self.enable_cinn else None,
++                full_graph=True,
++            )
++            fn.eval()
++            res = fn(x)
++        elif flag == "dygraph":
++            fn = self.net
++            res = fn(x)
++        return res
++
++    def test_all_dynamic(self):
++        with dygraph_guard():
++            res_ref = self.base_net("dygraph")
++            res = self.base_net("static")
++            for ref, actual in zip(res_ref, res):
++                np.testing.assert_allclose(ref, actual, rtol=self.tol)
++
++
++class TestAminmaxInferSymbolicShapePass(unittest.TestCase):
++    def setUp(self):
++        np.random.seed(2025)
++        self.x_np = np.random.random((2, 4, 6)).astype("float32")
++
++    def test_infer_symbolic_shape_pass(self):
++        with static_guard(), paddle.pir_utils.IrGuard():
++            main = paddle.static.Program()
++            startup = paddle.static.Program()
++            with paddle.static.program_guard(main, startup):
++                x = paddle.static.data(
++                    name='x', shape=[None, 4, 6], dtype='float32'
++                )
++                min_val, max_val = paddle.aminmax(x, axis=1, keepdim=False)
++
++                op_names = [op.name() for op in main.global_block().ops]
++                self.assertIn("pd_op.aminmax", op_names)
++
++                pm = paddle.base.libpaddle.pir.PassManager()
++                paddle.base.libpaddle.pir.infer_symbolic_shape_pass(pm, main)
++                pm.run(main)
++
++                exe = paddle.static.Executor()
++                fetches = exe.run(
++                    main,
++                    feed={'x': self.x_np},
++                    fetch_list=[min_val, max_val],
++                )
++
++                ref_min, ref_max = ref_aminmax(self.x_np, axis=1, keepdim=False)
++                np.testing.assert_allclose(fetches[0], ref_min, rtol=1e-05)
++                np.testing.assert_allclose(fetches[1], ref_max, rtol=1e-05)
++
++
++if __name__ == '__main__':
++    unittest.main()

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78441/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78441/tests/test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python -m pytest test/legacy_test/test_aminmax_op.py -q
+python -m pytest \
+  test/ir/pir/cinn/symbolic/test_infer_sym_shape_unary_op.py::AminmaxOpInferSymbolicShapeTest \
+  -q


### PR DESCRIPTION
Related issue/PR:
- https://github.com/PaddlePaddle/community/pull/1431
- https://github.com/paddlePaddle/Paddle/issues/79447

F2P:
```bash
λ /workspace/Paddle python3.10 test/legacy_test/test_aminmax_op.py
grep: warning: GREP_OPTIONS is deprecated; please use an alias or script
EEEEW0723 03:19:40.765118 14414 gpu_resources.cc:116] Please NOTE: device: 0, GPU Compute Capability: 7.0, Driver API Version: 12.6, Runtime API Version: 11.8
EEEEEEEEEEEEEEEEEEEEEEEEEEEEE
======================================================================
ERROR: test_dygraph (__main__.TestAminmaxAPI)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/Paddle/test/legacy_test/test_aminmax_op.py", line 154, in test_dygraph
    min_val, max_val = paddle.aminmax(x, axis=1, keepdim=True)
AttributeError: module 'paddle' has no attribute 'aminmax'

======================================================================

----------------------------------------------------------------------
Ran 26 tests in 0.170s

FAILED (errors=33)
```

P2P:
```bash
λ /workspace/Paddle python3.10 test/legacy_test/test_aminmax_op.py
grep: warning: GREP_OPTIONS is deprecated; please use an alias or script
W0723 03:37:11.949118 19676 gpu_resources.cc:116] Please NOTE: device: 0, GPU Compute Capability: 7.0, Driver API Version: 12.6, Runtime API Version: 11.8
......I0723 03:37:12.096786 19676 pir_interpreter.cc:1528] New Executor is Running ...
I0723 03:37:12.097424 19676 pir_interpreter.cc:1551] pir interpreter is running by multi-thread mode ...
...I0723 03:37:12.205730 19676 pir_interpreter.cc:1605] New Executor is Running ...
I0723 03:37:12.205878 19676 pir_interpreter.cc:1626] pir interpreter is running by trace mode ...
..I0723 03:37:12.275465 19676 program_interpreter.cc:255] New Executor is Running.
I0723 03:37:12.280503 19676 interpreter_util.cc:624] Standalone Executor is Used.
W0723 03:37:12.287034 19676 eager_utils.cc:3618] Paddle static graph(PIR) not support input out tensor for now!!!!!
/usr/local/lib/python3.10/dist-packages/paddle/pir/math_op_patch.py:261: UserWarning: Tensor do not have 'place' interface for pir graph mode, try not to use it. None will be returned.
  warnings.warn(
...............
----------------------------------------------------------------------
Ran 26 tests in 1.365s

OK
```

@sunzhongkai588  Thx