### PR TITLE
[SWE-Paddle] Add task PaddlePaddle__Paddle-79167

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79167/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79167/README.md
@@ -1,0 +1,44 @@
+# PaddlePaddle__Paddle-79167
+
+This directory converts Paddle PR #79167 into a SWE-Paddle community task candidate.
+
+## Source
+
+| Field | Value |
+| --- | --- |
+| Repo | `PaddlePaddle/Paddle` |
+| PR | [79167](https://github.com/PaddlePaddle/Paddle/pull/79167) |
+| PR title | `[API Compatibility] Add alias for paddle.random.initial_seed` |
+| Base commit | `c34031973911346f8cd98717583577f61adcf0b1` |
+| Merged at | `2026-05-29` |
+| Task type | `api_addition` |
+| Resource | CPU |
+
+## Summary
+
+Add a top-level public alias, `paddle.initial_seed`, for the existing `paddle.random.initial_seed`, and include this name in Paddle's set of public exports.
+
+## Why This Is A Good SWE-Paddle Candidate
+
+- It adds a user-visible public API instead of repairing an internal-only bug.
+- The production change is Python-only and limited to Paddle's top-level export surface.
+- Independent tests can distinguish Base and Solution without importing a historical Paddle wheel or building native extensions.
+- Existing `seed` and `manual_seed` exports provide clear P2P coverage, while alias identity and `__all__` membership provide direct F2P signals.
+
+## Files
+
+- `proposal.md`: candidate proposal for maintainer triage.
+- `instruction.md`: self-contained problem statement for the coding agent.
+- `solution/code.patch`: gold patch from the merged PR.
+- `tests/test.patch`: test patch exposing the target behavior.
+- `tests/test.sh`: minimal target test command.
+- `environment/README.md`: environment notes for reproduction.
+- `README.md`: task overview and verification entrypoint.
+
+## Verification
+
+```bash
+bash tests/test.sh
+```
+
+Expected behavior: applying `tests/test.patch` to `base_commit` should fail on the new top-level alias behavior; applying both `tests/test.patch` and `solution/code.patch` should pass the target tests.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79167/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79167/environment/README.md
@@ -1,0 +1,27 @@
+# Environment Notes
+
+This candidate is part of the SWE-Paddle community task set.
+
+## Expected Environment
+
+- Repository: `PaddlePaddle/Paddle`
+- Base commit: `c34031973911346f8cd98717583577f61adcf0b1`
+- Resource: CPU
+- GPU required: no
+- Build path: Python-only checkout source with an AST overlay for the relevant top-level import/export statements; no Paddle source build is required.
+
+## Run Order
+
+1. Check out `PaddlePaddle/Paddle` at the base commit.
+2. Apply `tests/test.patch`.
+3. Run `bash tests/test.sh`; the new top-level API behavior should fail before the implementation.
+4. Apply `solution/code.patch`.
+5. Run `bash tests/test.sh` again; the target tests should pass after the gold patch.
+
+## Minimal Test Command
+
+```bash
+bash tests/test.sh
+```
+
+The verifier is responsible for deriving stable F2P and P2P node IDs from repeated runs.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79167/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79167/instruction.md
@@ -1,0 +1,18 @@
+# 为 paddle.random.initial_seed 增加顶层公共别名
+
+## 详细描述
+
+Paddle 已提供 `paddle.random.initial_seed` 用于读取初始随机种子，但该 API 尚未从 `paddle` 顶层命名空间公开。调用方和自动迁移工具通常期望通过 `paddle.initial_seed` 访问同一能力。需要增加该顶层公共 API，同时保持现有随机数 API 的对象关系和导出行为稳定。
+
+## 验收说明
+
+- `paddle.initial_seed` 应可从 Paddle 顶层命名空间访问。
+- `paddle.initial_seed` 应与 `paddle.random.initial_seed` 指向同一个函数对象，而不是行为相似的重复实现。
+- 新名称应纳入 Paddle 的标准公共导出集合。
+- 现有 `paddle.seed` 和 `paddle.manual_seed` 行为应保持不变。
+
+## 技术要求
+
+- 熟悉 Python package 顶层 API 导出机制。
+- 了解 `__all__` 与 API alias 的语义。
+- 能够维护既有公共 API 的向后兼容性。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79167/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79167/instruction.md
@@ -1,18 +1,24 @@
-# 为 paddle.random.initial_seed 增加顶层公共别名
+# 新增 `paddle.initial_seed` 顶层别名
 
 ## 详细描述
 
-Paddle 已提供 `paddle.random.initial_seed` 用于读取初始随机种子，但该 API 尚未从 `paddle` 顶层命名空间公开。调用方和自动迁移工具通常期望通过 `paddle.initial_seed` 访问同一能力。需要增加该顶层公共 API，同时保持现有随机数 API 的对象关系和导出行为稳定。
+Paddle 已经提供 `paddle.random.initial_seed`，用于获取初始随机种子，但目前无法直接通过 Paddle 顶层命名空间访问该接口。
+
+请新增 `paddle.initial_seed`，使其作为现有 `paddle.random.initial_seed` 的顶层别名。两个名称应指向同一个函数对象，并具有完全一致的调用行为。
+
+新增别名后，现有随机数相关接口及其行为不得受到影响。
 
 ## 验收说明
 
-- `paddle.initial_seed` 应可从 Paddle 顶层命名空间访问。
-- `paddle.initial_seed` 应与 `paddle.random.initial_seed` 指向同一个函数对象，而不是行为相似的重复实现。
-- 新名称应纳入 Paddle 的标准公共导出集合。
-- 现有 `paddle.seed` 和 `paddle.manual_seed` 行为应保持不变。
+* `paddle.initial_seed` 应能够从 Paddle 顶层命名空间访问
+* `paddle.initial_seed` 与 `paddle.random.initial_seed` 应指向同一个函数对象
+* `paddle.initial_seed` 应能够在 Paddle 顶层公开 API 中被正常发现
+* 通过两个名称调用时，应获得一致的结果
+* 现有 `paddle.seed`、`paddle.manual_seed` 和 `paddle.random.initial_seed` 的行为不得发生变化
 
 ## 技术要求
 
-- 熟悉 Python package 顶层 API 导出机制。
-- 了解 `__all__` 与 API alias 的语义。
-- 能够维护既有公共 API 的向后兼容性。
+* 熟悉 Python package 的顶层 API 导出方式
+* 了解 API 别名和 Python 对象身份的语义
+* 了解顶层公共 API 的可访问性与可发现性
+* 能够保证新增别名不影响已有随机数接口

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79167/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79167/proposal.md
@@ -1,0 +1,55 @@
+# Task Proposal: PaddlePaddle__Paddle-79167
+
+## 1. 来源信息
+
+- Instance ID：`PaddlePaddle__Paddle-79167`
+- PR 链接：https://github.com/PaddlePaddle/Paddle/pull/79167
+- PR 标题：`[API Compatibility] Add alias for paddle.random.initial_seed`
+- `base_commit`：`c34031973911346f8cd98717583577f61adcf0b1`
+- merged 时间：`2026-05-29`
+- 你的身份：熟悉该模块的 contributor
+- 后续联系人：TBD
+
+## 2. 问题一句话
+
+为 `paddle.random.initial_seed` 增加等价的顶层公共 API `paddle.initial_seed`，并确保该名称参与标准公共导出。
+
+## 3. 为什么适合作为 SWE-Paddle 样本
+
+- **真实性**：任务来自已合入的 Paddle API Compatibility PR，不是合成需求。
+- **类型多样性**：这是公共 API addition/alias 任务，而不是 bug fix。
+- **边界清楚**：production 行为仅涉及 Paddle 顶层命名空间和公共导出集合。
+- **可观察性强**：可以直接验证新名称是否与原 API 指向同一对象，以及是否出现在 `__all__` 中。
+- **环境友好性**：Python-only、CPU-only；通过执行 checkout 中真实 import/export AST 节点即可稳定验证，无需 native source build。
+
+## 4. 任务类型和标签
+
+- 任务类型：`api_addition`
+- 执行后端：`cpu`
+- 设备范围：`cpu_only`
+- 模块标签：`[public_api, api_alias, initial_seed, module_export, python_only]`
+
+## 5. 验证思路
+
+- 目标测试命令：`bash tests/test.sh`
+- 目标测试文件：`test/swe_paddle/test_pr79167_initial_seed_alias.py`
+- 修复前预期：现有 `seed` / `manual_seed` 导出测试通过；顶层 `initial_seed` alias 和公共导出测试失败。
+- 修复后预期：继续应用 `solution/code.patch` 后，全部目标测试通过。
+- P2P 候选：`seed` 仍指向原 framework random API，`manual_seed` 仍为 `seed` 的别名，且两者继续位于公共导出集合。
+
+## 6. 环境与资源
+
+- 资源需求：CPU
+- Paddle 来源：`PaddlePaddle/Paddle` source checkout at `base_commit`
+- 是否能提供 Docker：暂无
+- patch 类型：Python-only
+- 环境建议：从 checkout 的 `python/paddle/__init__.py` 提取并执行相关 import、alias assignment 和 `__all__` AST 节点，以 controlled module doubles 验证真实 Python 导出语义。
+- 最小测试命令：`bash tests/test.sh`
+- 是否有 oracle 日志：由 SWE-Paddle verifier 结果另行维护
+
+## 7. 风险自查
+
+- 泄露风险：`instruction.md` 只描述公共 API contract，不指出具体修改行。
+- 环境风险：AST overlay 避免导入历史 checkout 中完整 Paddle package 所需的 native extension。
+- flaky 风险：测试仅验证确定性的对象 identity 和公共导出元数据。
+- 拆分风险：顶层 alias 与 `__all__` 注册共同构成一个完整的公共 API 暴露目标。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79167/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79167/proposal.md
@@ -2,54 +2,53 @@
 
 ## 1. 来源信息
 
-- Instance ID：`PaddlePaddle__Paddle-79167`
-- PR 链接：https://github.com/PaddlePaddle/Paddle/pull/79167
-- PR 标题：`[API Compatibility] Add alias for paddle.random.initial_seed`
-- `base_commit`：`c34031973911346f8cd98717583577f61adcf0b1`
-- merged 时间：`2026-05-29`
-- 你的身份：熟悉该模块的 contributor
-- 后续联系人：TBD
+* Instance ID：`PaddlePaddle__Paddle-79167`
+* PR 链接：https://github.com/PaddlePaddle/Paddle/pull/79167
+* PR 标题：`[API Compatibility] Add alias for paddle.random.initial_seed`
+* `base_commit`：`c34031973911346f8cd98717583577f61adcf0b1`
+* merged 时间：`2026-05-29`
+* 你的身份：熟悉该模块的 contributor
+* 后续联系人：TBD
 
 ## 2. 问题一句话
 
-为 `paddle.random.initial_seed` 增加等价的顶层公共 API `paddle.initial_seed`，并确保该名称参与标准公共导出。
+为 `paddle.random.initial_seed` 增加等价的顶层公共入口 `paddle.initial_seed`，并确保该名称能够通过 Paddle 顶层命名空间访问和发现。
 
 ## 3. 为什么适合作为 SWE-Paddle 样本
 
-- **真实性**：任务来自已合入的 Paddle API Compatibility PR，不是合成需求。
-- **类型多样性**：这是公共 API addition/alias 任务，而不是 bug fix。
-- **边界清楚**：production 行为仅涉及 Paddle 顶层命名空间和公共导出集合。
-- **可观察性强**：可以直接验证新名称是否与原 API 指向同一对象，以及是否出现在 `__all__` 中。
-- **环境友好性**：Python-only、CPU-only；通过执行 checkout 中真实 import/export AST 节点即可稳定验证，无需 native source build。
+* **真实性**：任务来自已合入的 Paddle API Compatibility PR，不是人工构造的需求。
+* **类型多样性**：该任务属于公共 API alias 新增，可补充 SWE-Paddle 中以 bug fix 为主的任务类型。
+* **边界清楚**：production change 仅涉及 Paddle 顶层命名空间中的 API 引入和公开名称发现，改动范围集中。
+* **可观察性强**：可以直接验证 `paddle.initial_seed` 是否可访问、是否与 `paddle.random.initial_seed` 指向同一个函数对象，以及是否能通过顶层 API 枚举发现。
+* **环境友好性**：任务仅涉及 Python 层的导入和模块属性行为，可以在 CPU 环境中直接验证，无需编译 Paddle 源码或加载完整的 native runtime。
 
 ## 4. 任务类型和标签
 
-- 任务类型：`api_addition`
-- 执行后端：`cpu`
-- 设备范围：`cpu_only`
-- 模块标签：`[public_api, api_alias, initial_seed, module_export, python_only]`
+* 任务类型：`api_addition`
+* 执行后端：`cpu`
+* 设备范围：`cpu_only`
+* 模块标签：`[public_api, api_alias, initial_seed, module_export, python_only]`
 
 ## 5. 验证思路
 
-- 目标测试命令：`bash tests/test.sh`
-- 目标测试文件：`test/swe_paddle/test_pr79167_initial_seed_alias.py`
-- 修复前预期：现有 `seed` / `manual_seed` 导出测试通过；顶层 `initial_seed` alias 和公共导出测试失败。
-- 修复后预期：继续应用 `solution/code.patch` 后，全部目标测试通过。
-- P2P 候选：`seed` 仍指向原 framework random API，`manual_seed` 仍为 `seed` 的别名，且两者继续位于公共导出集合。
+* 目标测试命令：`bash tests/test.sh`
+* 目标测试文件：`test/swe_paddle/test_pr79167_initial_seed_alias.py`
+* 修复前预期：现有 `seed`、`manual_seed` 和 `paddle.random.initial_seed` 的相关测试应通过；顶层 `paddle.initial_seed` 的可访问性、对象身份和公开发现测试应失败。
+* 修复后预期：继续应用 `solution/code.patch` 后，全部目标测试均应通过；`paddle.initial_seed` 应能够从顶层命名空间访问，并与 `paddle.random.initial_seed` 指向同一个函数对象。
+* P2P 候选：`paddle.seed`、`paddle.manual_seed` 和 `paddle.random.initial_seed` 的对象关系及现有调用行为保持不变。
 
 ## 6. 环境与资源
 
-- 资源需求：CPU
-- Paddle 来源：`PaddlePaddle/Paddle` source checkout at `base_commit`
-- 是否能提供 Docker：暂无
-- patch 类型：Python-only
-- 环境建议：从 checkout 的 `python/paddle/__init__.py` 提取并执行相关 import、alias assignment 和 `__all__` AST 节点，以 controlled module doubles 验证真实 Python 导出语义。
-- 最小测试命令：`bash tests/test.sh`
-- 是否有 oracle 日志：由 SWE-Paddle verifier 结果另行维护
+* 资源需求：CPU
+* Paddle 来源：`PaddlePaddle/Paddle` source checkout at `base_commit`
+* 是否能提供 Docker：暂无
+* patch 类型：Python-only
+* 最小测试命令：`bash tests/test.sh`
+* 是否有 oracle 日志：由 SWE-Paddle verifier 结果另行维护
 
 ## 7. 风险自查
 
-- 泄露风险：`instruction.md` 只描述公共 API contract，不指出具体修改行。
-- 环境风险：AST overlay 避免导入历史 checkout 中完整 Paddle package 所需的 native extension。
-- flaky 风险：测试仅验证确定性的对象 identity 和公共导出元数据。
-- 拆分风险：顶层 alias 与 `__all__` 注册共同构成一个完整的公共 API 暴露目标。
+* 泄露风险：`instruction.md` 只描述顶层 API 的可访问性、对象身份和公开发现行为，不指出具体修改行或导入语句。
+* 环境风险：AST overlay 避免导入历史 checkout 中完整 Paddle package 所需的 native extension。
+* flaky 风险：测试仅验证确定性的模块属性、对象 identity 和 `dir()` 结果，不涉及随机数结果、并发或异步时序。
+* 拆分风险：顶层 alias 和公开名称发现共同构成 `paddle.initial_seed` 的完整公共 API 暴露目标，适合作为一个任务。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79167/solution/code.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79167/solution/code.patch
@@ -1,0 +1,20 @@
+diff --git a/python/paddle/__init__.py b/python/paddle/__init__.py
+index 6abf27963cb4089b3d49b16adc49354de9fdc26a..387e50b2e85dfc8152e0e62aa8cf6b0dee891d57 100644
+--- a/python/paddle/__init__.py
++++ b/python/paddle/__init__.py
+@@ -366,6 +366,7 @@ from .nn.functional.distance import (
+     pdist,
+ )
+ from .nn.initializer.lazy_init import LazyGuard
++from .random import initial_seed
+ from .tensor.attribute import (
+     imag,
+     is_complex,
+@@ -1577,6 +1578,7 @@ __all__ = [
+     'enable_compat',
+     'disable_compat',
+     'use_compat_guard',
++    'initial_seed',
+ ]
+ import os
+ 

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79167/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79167/tests/test.patch
@@ -1,0 +1,99 @@
+diff --git a/test/swe_paddle/test_pr79167_initial_seed_alias.py b/test/swe_paddle/test_pr79167_initial_seed_alias.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..9e48192ece74b820f57d42bb281eb89b322f753a
+--- /dev/null
++++ b/test/swe_paddle/test_pr79167_initial_seed_alias.py
+@@ -0,0 +1,93 @@
++import ast
++import copy
++import sys
++from pathlib import Path
++from types import ModuleType
++
++
++TARGET = Path("python/paddle/__init__.py")
++
++
++def _callable(name, result):
++    def function(*args, **kwargs):
++        return result
++
++    function.__name__ = name
++    return function
++
++
++def _load_checkout_public_namespace():
++    tree = ast.parse(TARGET.read_text(encoding="utf-8"), filename=str(TARGET))
++    selected = []
++    for node in tree.body:
++        if (
++            isinstance(node, ast.ImportFrom)
++            and node.level == 1
++            and node.module in {"framework.random", "random"}
++        ):
++            selected.append(copy.deepcopy(node))
++            continue
++        if isinstance(node, ast.Assign):
++            target_names = {
++                target.id
++                for target in node.targets
++                if isinstance(target, ast.Name)
++            }
++            if target_names & {"manual_seed", "__all__"}:
++                selected.append(copy.deepcopy(node))
++
++    package_name = "_swe_paddle_pr79167"
++    package = ModuleType(package_name)
++    package.__path__ = []
++    framework_package = ModuleType(f"{package_name}.framework")
++    framework_package.__path__ = []
++    framework_random = ModuleType(f"{package_name}.framework.random")
++    random_module = ModuleType(f"{package_name}.random")
++
++    framework_random.Generator = object()
++    framework_random.get_cuda_rng_state = _callable("get_cuda_rng_state", [])
++    framework_random.get_rng_state = _callable("get_rng_state", [])
++    framework_random.seed = _callable("seed", "seed-result")
++    framework_random.set_cuda_rng_state = _callable("set_cuda_rng_state", None)
++    framework_random.set_rng_state = _callable("set_rng_state", None)
++    random_module.initial_seed = _callable("initial_seed", 2026)
++
++    module_names = {
++        package_name: package,
++        f"{package_name}.framework": framework_package,
++        f"{package_name}.framework.random": framework_random,
++        f"{package_name}.random": random_module,
++    }
++    previous = {name: sys.modules.get(name) for name in module_names}
++    sys.modules.update(module_names)
++    namespace = {"__name__": package_name, "__package__": package_name}
++    try:
++        module = ast.Module(body=selected, type_ignores=[])
++        ast.fix_missing_locations(module)
++        exec(compile(module, str(TARGET), "exec"), namespace)
++    finally:
++        for name, old_value in previous.items():
++            if old_value is None:
++                sys.modules.pop(name, None)
++            else:
++                sys.modules[name] = old_value
++    return namespace, framework_random, random_module
++
++
++def test_existing_seed_exports_remain_unchanged():
++    namespace, framework_random, _ = _load_checkout_public_namespace()
++    assert namespace["seed"] is framework_random.seed
++    assert namespace["manual_seed"] is framework_random.seed
++    assert namespace["seed"](123) == "seed-result"
++    assert {"seed", "manual_seed"}.issubset(namespace["__all__"])
++
++
++def test_initial_seed_is_exported_at_top_level():
++    namespace, _, random_module = _load_checkout_public_namespace()
++    assert namespace["initial_seed"] is random_module.initial_seed
++    assert namespace["initial_seed"]() == 2026
++
++
++def test_initial_seed_is_in_public_all():
++    namespace, _, _ = _load_checkout_public_namespace()
++    assert "initial_seed" in namespace["__all__"]

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79167/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79167/tests/test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python -m pytest test/swe_paddle/test_pr79167_initial_seed_alias.py -q


### PR DESCRIPTION
## 关联

- SWE-Paddle 共建 issue: https://github.com/PaddlePaddle/Paddle/issues/79447
- 来源 PR: https://github.com/PaddlePaddle/Paddle/pull/79167

## 说明

- 新增 SWE-Paddle 任务 `PaddlePaddle__Paddle-79167`

@sunzhongkai588

## 验证结果

| 状态 | Existing seed exports P2P | Top-level alias F2P | Public `__all__` F2P |
| --- | --- | --- | --- |
| Base + `tests/test.patch` | PASS | FAIL，符合预期 | FAIL，符合预期 |
| Base + test patch + `solution/code.patch` | PASS | PASS | PASS |

#### Base P2P：Existing seed exports remain unchanged

```text
.                                                                        [100%]
1 passed in 0.04s
Base existing-seed-exports P2P exit code: 0
```

#### Base F2P：Export `initial_seed` at the top level

```text
F                                                                        [100%]
================================== FAILURES ===================================
_________________ test_initial_seed_is_exported_at_top_level __________________

    def test_initial_seed_is_exported_at_top_level():
        namespace, _, random_module = _load_checkout_public_namespace()
>       assert namespace["initial_seed"] is random_module.initial_seed
               ^^^^^^^^^^^^^^^^^^^^^^^^^
E       KeyError: 'initial_seed'

test\swe_paddle\test_pr79167_initial_seed_alias.py:87: KeyError
=========================== short test summary info ===========================
FAILED test/swe_paddle/test_pr79167_initial_seed_alias.py::test_initial_seed_is_exported_at_top_level
1 failed in 0.51s
Base top-level-alias F2P exit code: 1
```

#### Base F2P：Include `initial_seed` in public `__all__`

```text
F                                                                        [100%]
================================== FAILURES ===================================
_____________________ test_initial_seed_is_in_public_all ______________________

    def test_initial_seed_is_in_public_all():
        namespace, _, _ = _load_checkout_public_namespace()
>       assert "initial_seed" in namespace["__all__"]
E       AssertionError: assert 'initial_seed' in ['block_diag', 'gt', 'eq', 'iinfo', 'finfo', 'dtype', ...]

test\swe_paddle\test_pr79167_initial_seed_alias.py:93: AssertionError
=========================== short test summary info ===========================
FAILED test/swe_paddle/test_pr79167_initial_seed_alias.py::test_initial_seed_is_in_public_all
1 failed in 0.56s
Base public-all F2P exit code: 1
```

#### Solution 测试

```text
Solution existing-seed-exports P2P:
1 passed in 0.03s

Solution top-level-alias F2P:
1 passed in 0.03s

Solution public-all F2P:
1 passed in 0.03s
```

#### `tests/test.sh`

```text
...                                                                      [100%]
3 passed in 0.05s
Solution tests/test.sh exit code: 0
```