### PR TITLE
[SWE-Paddle] Add task PaddlePaddle__Paddle-79310

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79310/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79310/README.md
@@ -1,0 +1,47 @@
+# PaddlePaddle__Paddle-79310
+
+This directory converts Paddle PR #79310 into a SWE-Paddle community task candidate.
+
+## Source
+
+| Field | Value |
+| --- | --- |
+| Repo | `PaddlePaddle/Paddle` |
+| PR | [79310](https://github.com/PaddlePaddle/Paddle/pull/79310) |
+| PR title | `[API Compatibility] Add paddle.nn.init.sparse_()` |
+| Base commit | `14f2f9df49bd9bd7fd94eb9cdef850c581243784` |
+| Merged at | `2026-06-21` |
+| Task type | `api_addition` / `feature_enhancement` |
+| Resource | CPU |
+
+## Summary
+
+Added `paddle.nn.init.sparse_()`, a 2D sparse initialization API, 
+and unified the in-place return semantics of initializer helpers in dynamic graph mode: 
+the input Tensor itself is returned after initialization.
+
+## Why This Is A Good SWE-Paddle Candidate
+
+- It adds a user-visible initializer API rather than fixing an internal-only bug.
+- The sparse initializer has a concrete numerical contract: initialize values, then zero a defined fraction of every column.
+- The API has an explicit dimensionality boundary that can be tested independently.
+- The Gold change also makes existing in-place initializer helpers return the input Tensor in dygraph mode, giving an observable compatibility contract beyond symbol existence.
+- The target behavior can be tested deterministically from the checkout's real Python function bodies without CUDA, native kernels, or a Paddle source build.
+
+## Patch Boundary
+
+`solution/code.patch` contains only the production file changed by the Gold commit:
+
+- `python/paddle/nn/init.py`
+
+The original PR change to `test/legacy_test/test_nn_init_function.py` is intentionally excluded. Independent benchmark tests are supplied only through `tests/test.patch`.
+
+The packaged `solution/code.patch` is a bootstrap representation. During cross validation it is replaced by the exact production-only Gold diff generated from local Git objects.
+
+## Verification
+
+```bash
+bash tests/test.sh
+```
+
+Expected behavior: with only `tests/test.patch`, the existing non-dygraph `normal_` path remains valid while the new dygraph-return, `eye_` return, and `sparse_` behaviors fail. After applying the exact Gold production patch, all target tests should pass.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79310/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79310/environment/README.md
@@ -1,0 +1,45 @@
+# Environment Notes
+
+This candidate is part of the SWE-Paddle community task set.
+
+## Expected Environment
+
+- Repository: `PaddlePaddle/Paddle`
+- Base commit: `14f2f9df49bd9bd7fd94eb9cdef850c581243784`
+- Resource: CPU
+- GPU required: no
+- Build path: Python-only checkout source with AST overlays for the target initializer functions; no Paddle source build is required.
+
+## Why GPU Is Not Required
+
+The benchmark executes the real Python bodies of the target initializer functions in a controlled namespace. Tensor mutation, random index generation, no-grad context behavior, and initializer calls are represented by deterministic doubles. CUDA kernels, GPU allocation, NCCL, and device synchronization are not used.
+
+A GPU-enabled machine is compatible with the task, but the benchmark itself is CPU-only.
+
+## Gold Patch Boundary
+
+`solution/code.patch` must contain only:
+
+- `python/paddle/nn/init.py`
+
+Do not include the original PR modification to:
+
+- `test/legacy_test/test_nn_init_function.py`
+
+The verifier checks the complete Gold changed-file scope separately and generates the final solution patch from Git objects using only the production path.
+
+## Run Order
+
+1. Check out `PaddlePaddle/Paddle` at the base commit.
+2. Apply `tests/test.patch`.
+3. Run `bash tests/test.sh`; the existing P2P should pass and the new initializer behaviors should fail.
+4. Apply `solution/code.patch`.
+5. Run `bash tests/test.sh` again; all target tests should pass after the Gold production patch.
+
+## Minimal Test Command
+
+```bash
+bash tests/test.sh
+```
+
+The verifier is responsible for deriving stable F2P and P2P node IDs from repeated runs.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79310/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79310/instruction.md
@@ -1,19 +1,26 @@
-# 新增二维 Tensor 稀疏初始化 API
+# 新增 `paddle.nn.init.sparse_` 并统一原地初始化返回值
 
 ## 详细描述
 
-Paddle 的函数式 initializer 接口需要支持二维 Tensor 的稀疏初始化能力。调用方应能够通过稀疏比例和标准差控制初始化结果，并保持函数式 initializer 的原地操作语义。
+Paddle 需要为二维 Tensor 提供函数式稀疏初始化接口。调用方应能够通过稀疏比例控制每列中被置零的元素，并通过标准差控制其余元素的随机分布。
 
-同时，动态图模式下现有函数式原地 initializer 的返回语义需要保持一致：完成初始化后应返回被修改的输入 Tensor。非动态图路径的既有行为应继续保持兼容。
+请新增 `paddle.nn.init.sparse_`，使其能够原地修改输入 Tensor，并返回初始化后的同一个 Tensor。对于不满足维度要求的输入，应给出明确的异常。
+
+同时，现有函数式原地初始化接口在动态图模式下应具有一致的返回行为，即完成初始化后返回被修改的输入 Tensor。非动态图模式下的现有行为不得受到影响。
 
 ## 验收说明
 
-- 提供可用于二维 Tensor 的 `paddle.nn.init.sparse_()`，并正确处理稀疏比例、标准差以及非法维度输入。
-- `sparse_` 应原地初始化并返回输入 Tensor；动态图下现有函数式原地 initializer 也应返回输入 Tensor 本身。
-- 非动态图路径以及已有合法 initializer 用法的行为应保持不变。
+* 提供公开的 `paddle.nn.init.sparse_` API
+* `sparse_` 应支持通过 `tensor`、`sparsity` 和 `std` 参数调用
+* 输入为二维 Tensor 时，应按照指定稀疏比例对每列元素进行置零，并使用指定标准差初始化其余元素
+* 输入不是二维 Tensor 时，应抛出 `ValueError`
+* `sparse_` 应原地修改输入，并返回输入 Tensor 本身
+* 动态图模式下，现有函数式原地初始化接口应返回被修改的输入 Tensor 本身
+* 现有初始化接口的数值行为和合法调用方式不得发生变化
+* 非动态图模式下的现有行为不得发生变化
 
 ## 技术要求
 
-- 熟悉 Paddle initializer API 和 Tensor 原地操作语义。
-- 了解 dynamic graph 与非 dynamic graph 执行模式的差异。
-- 能够为随机初始化行为设计稳定、可重复的回归测试。
+* 熟悉 Paddle initializer API 和 Tensor 原地操作语义
+* 了解动态图与非动态图执行模式的差异
+* 理解二维 Tensor 的稀疏初始化语义

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79310/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79310/instruction.md
@@ -1,0 +1,19 @@
+# 新增二维 Tensor 稀疏初始化 API
+
+## 详细描述
+
+Paddle 的函数式 initializer 接口需要支持二维 Tensor 的稀疏初始化能力。调用方应能够通过稀疏比例和标准差控制初始化结果，并保持函数式 initializer 的原地操作语义。
+
+同时，动态图模式下现有函数式原地 initializer 的返回语义需要保持一致：完成初始化后应返回被修改的输入 Tensor。非动态图路径的既有行为应继续保持兼容。
+
+## 验收说明
+
+- 提供可用于二维 Tensor 的 `paddle.nn.init.sparse_()`，并正确处理稀疏比例、标准差以及非法维度输入。
+- `sparse_` 应原地初始化并返回输入 Tensor；动态图下现有函数式原地 initializer 也应返回输入 Tensor 本身。
+- 非动态图路径以及已有合法 initializer 用法的行为应保持不变。
+
+## 技术要求
+
+- 熟悉 Paddle initializer API 和 Tensor 原地操作语义。
+- 了解 dynamic graph 与非 dynamic graph 执行模式的差异。
+- 能够为随机初始化行为设计稳定、可重复的回归测试。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79310/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79310/instruction.md
@@ -1,26 +1,29 @@
-# 新增 `paddle.nn.init.sparse_` 并统一原地初始化返回值
+# 新增 `paddle.nn.init.sparse_` 并补齐动态图下的返回值
 
 ## 详细描述
 
-Paddle 需要为二维 Tensor 提供函数式稀疏初始化接口。调用方应能够通过稀疏比例控制每列中被置零的元素，并通过标准差控制其余元素的随机分布。
+`paddle.nn.init` 目前缺少用于二维 Tensor 的稀疏初始化接口。
 
-请新增 `paddle.nn.init.sparse_`，使其能够原地修改输入 Tensor，并返回初始化后的同一个 Tensor。对于不满足维度要求的输入，应给出明确的异常。
+所以需要新增 `paddle.nn.init.sparse_(tensor, sparsity, std=0.01)`。该接口直接修改输入 Tensor：先按照均值为 0、标准差为 `std` 的正态分布初始化，再将每一列中的部分元素置为 0。每列置零的元素数量为 `ceil(sparsity * 行数)`。
 
-同时，现有函数式原地初始化接口在动态图模式下应具有一致的返回行为，即完成初始化后返回被修改的输入 Tensor。非动态图模式下的现有行为不得受到影响。
+该接口只支持二维 Tensor，其他维度的输入应抛出 `ValueError`，并返回修改后的输入 Tensor。
+
+此外，现有函数式初始化接口在动态图下完成初始化后，也应返回传入的 Tensor，而不是返回 `None`。非动态图模式下的现有行为保持不变。
 
 ## 验收说明
 
-* 提供公开的 `paddle.nn.init.sparse_` API
-* `sparse_` 应支持通过 `tensor`、`sparsity` 和 `std` 参数调用
-* 输入为二维 Tensor 时，应按照指定稀疏比例对每列元素进行置零，并使用指定标准差初始化其余元素
-* 输入不是二维 Tensor 时，应抛出 `ValueError`
-* `sparse_` 应原地修改输入，并返回输入 Tensor 本身
-* 动态图模式下，现有函数式原地初始化接口应返回被修改的输入 Tensor 本身
-* 现有初始化接口的数值行为和合法调用方式不得发生变化
-* 非动态图模式下的现有行为不得发生变化
+- 提供 `paddle.nn.init.sparse_`
+- `sparse_` 支持 `tensor`、`sparsity` 和 `std` 参数，其中 `std` 默认为 `0.01`
+- 输入为二维 Tensor 时，每列应有 `ceil(sparsity * 行数)` 个元素被置为 0
+- 其余元素应按照均值为 0、标准差为 `std` 的正态分布初始化
+- 输入不是二维 Tensor 时应抛出 `ValueError`
+- `sparse_` 应直接修改并返回输入 Tensor
+- 动态图下，现有函数式初始化接口也应返回被修改的输入 Tensor
+- 现有初始化结果、参数用法以及非动态图模式下的行为保持不变
 
 ## 技术要求
 
-* 熟悉 Paddle initializer API 和 Tensor 原地操作语义
-* 了解动态图与非动态图执行模式的差异
-* 理解二维 Tensor 的稀疏初始化语义
+- 熟悉 Python
+- 了解 Paddle 的初始化接口
+- 了解 Tensor 的稀疏初始化
+- 了解 Paddle 动态图和非动态图模式

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79310/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79310/proposal.md
@@ -2,54 +2,52 @@
 
 ## 1. 来源信息
 
-- Instance ID：`PaddlePaddle__Paddle-79310`
-- PR 链接：https://github.com/PaddlePaddle/Paddle/pull/79310
-- PR 标题：`[API Compatibility] Add paddle.nn.init.sparse_()`
-- `base_commit`：`14f2f9df49bd9bd7fd94eb9cdef850c581243784`
-- merged 时间：`2026-06-21`
-- 你的身份：熟悉该模块的 contributor
-- 后续联系人：TBD
+* Instance ID：`PaddlePaddle__Paddle-79310`
+* PR 链接：https://github.com/PaddlePaddle/Paddle/pull/79310
+* PR 标题：`[API Compatibility] Add paddle.nn.init.sparse_()`
+* `base_commit`：`14f2f9df49bd9bd7fd94eb9cdef850c581243784`
+* merged 时间：`2026-06-21`
+* 你的身份：熟悉该模块的 contributor
+* 后续联系人：TBD
 
 ## 2. 问题一句话
 
-新增二维 Tensor 稀疏初始化 API `paddle.nn.init.sparse_()`，并统一动态图模式下函数式原地 initializer 的返回语义。
+新增用于二维 Tensor 的 `paddle.nn.init.sparse_()`，并统一函数式原地 initializer 在动态图模式下的返回行为。
 
 ## 3. 为什么适合作为 SWE-Paddle 样本
 
-- **真实性**：该任务来自已合入的 Paddle PR #79310，不是合成任务。
-- **代表性**：任务属于公共 API 新增和 API compatibility，可补充当前 SWE-Paddle 中以 bug fix 为主的任务类型。
-- **边界清楚**：production change 集中在 `python/paddle/nn/init.py`，目标行为可通过独立测试直接观察。
-- **非平凡性**：任务同时涉及新的稀疏初始化行为、输入约束、原地操作语义以及已有 initializer 的返回兼容性。
-- **环境友好性**：目标逻辑位于 Python 层，可通过 AST overlay 和 controlled doubles 在 CPU 环境稳定验证，无需 GPU 或 Paddle source build。
+* **真实性**：该任务来自已合入的 Paddle PR #79310，不是人工构造的需求。
+* **代表性**：该任务涉及公共初始化 API、新增稀疏初始化能力、原地操作语义以及与同类框架的接口兼容。
+* **边界清楚**：production change 集中在 `python/paddle/nn/init.py`，包括新增 `sparse_` 以及调整现有函数式 initializer 的动态图返回行为，改动范围明确。
+* **非平凡性**：任务既要实现二维 Tensor 的稀疏初始化和非法维度检查，也要保证原地修改后的返回对象符合预期，并且不能影响已有 initializer 的初始化结果和非动态图行为。
 
 ## 4. 任务类型和标签
 
-- 任务类型：`feature_enhancement`
-- 执行后端：`cpu`
-- 设备范围：`cpu_only`
-- 模块标签：`[nn_init, sparse_initializer, api_compatibility, inplace_api]`
+* 任务类型：`feature_enhancement`
+* 执行后端：`cpu`
+* 设备范围：`cpu_only`
+* 模块标签：`[nn_init, sparse_initializer, api_compatibility, inplace_api]`
 
 ## 5. 验证思路
 
-- 目标测试命令：`bash tests/test.sh`
-- 目标测试文件：`test/swe_paddle/test_pr79310_sparse_initializer.py`
-- 修复前预期：在 `base_commit` 上应用 `tests/test.patch` 后，已有非动态图 initializer 行为应 pass；新增稀疏初始化能力和动态图原地返回语义相关测试应 fail。
-- 修复后预期：继续应用 `solution/code.patch` 后，已有行为测试与新增行为测试均应 pass。
-- P2P 候选：非动态图环境下已有函数式 initializer 的返回行为。
+* 目标测试命令：`bash tests/test.sh`
+* 目标测试文件：`test/swe_paddle/test_pr79310_sparse_initializer.py`
+* 修复前预期：在 `base_commit` 上应用 `tests/test.patch` 后，已有 initializer 的初始化行为和非动态图路径测试应通过；`sparse_` API、二维稀疏初始化、非法维度检查以及动态图返回输入 Tensor 的相关测试应失败。
+* 修复后预期：继续应用 `solution/code.patch` 后，已有行为测试与新增行为测试均应通过；`sparse_` 应正确修改并返回输入 Tensor，现有函数式原地 initializer 在动态图模式下也应返回各自接收的 Tensor。
+* P2P 候选：现有 initializer 的数值初始化行为、参数处理方式以及非动态图路径的返回行为保持不变。
 
 ## 6. 环境与资源
 
-- 资源需求：CPU
-- Paddle 来源：`PaddlePaddle/Paddle` source checkout at `base_commit`
-- 是否能提供 Docker：暂无
-- patch 类型：Python-only
-- 环境建议：使用可运行 `pytest` 的 Python 环境，通过 AST overlay 执行 checkout 中的目标函数控制流，并使用 controlled doubles 提供依赖；无需 Paddle source build
-- 最小测试命令：`bash tests/test.sh`
-- 是否有 oracle 日志：由 SWE-Paddle verifier 结果另行维护
+* 资源需求：CPU
+* Paddle 来源：`PaddlePaddle/Paddle` source checkout at `base_commit`
+* 是否能提供 Docker：暂无
+* patch 类型：Python-only
+* 最小测试命令：`bash tests/test.sh`
+* 是否有 oracle 日志：由 SWE-Paddle verifier 结果另行维护
 
 ## 7. 风险自查
 
-- 泄露风险：`instruction.md` 只描述用户可观察行为和兼容性要求，不提供 Gold patch 的具体修改方式。
-- 环境风险：测试不依赖历史 Paddle package 的完整 import，也不要求 native extension 与 checkout 完全匹配。
-- flaky 风险：随机相关行为通过 controlled doubles 稳定验证，不依赖随机命中、GPU 或外部数据。
-- 拆分风险：新增 `sparse_` 与动态图原地 initializer 返回语义属于同一个已合入 API compatibility PR，并集中在同一 production 文件中，适合作为一个任务。
+* 泄露风险：`instruction.md` 只描述稀疏初始化、原地返回和兼容性等用户可观察行为，不透露 Gold patch 中的随机索引生成方式、逐列处理流程或具体分支结构。
+* 环境风险：测试不依赖历史 Paddle package 的完整导入，也不要求 native extension 与 source checkout 完全匹配。
+* flaky 风险：测试通过固定输入和可控的随机操作替身验证稀疏位置及分布参数，不依赖真实随机结果、GPU 或外部数据。
+* 拆分风险：新增 `sparse_` 和统一动态图下函数式原地 initializer 的返回行为属于同一个已合入的 API compatibility PR，且集中在同一 production 文件中，适合作为一个任务。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79310/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79310/proposal.md
@@ -1,0 +1,55 @@
+# Task Proposal: PaddlePaddle__Paddle-79310
+
+## 1. 来源信息
+
+- Instance ID：`PaddlePaddle__Paddle-79310`
+- PR 链接：https://github.com/PaddlePaddle/Paddle/pull/79310
+- PR 标题：`[API Compatibility] Add paddle.nn.init.sparse_()`
+- `base_commit`：`14f2f9df49bd9bd7fd94eb9cdef850c581243784`
+- merged 时间：`2026-06-21`
+- 你的身份：熟悉该模块的 contributor
+- 后续联系人：TBD
+
+## 2. 问题一句话
+
+新增二维 Tensor 稀疏初始化 API `paddle.nn.init.sparse_()`，并统一动态图模式下函数式原地 initializer 的返回语义。
+
+## 3. 为什么适合作为 SWE-Paddle 样本
+
+- **真实性**：该任务来自已合入的 Paddle PR #79310，不是合成任务。
+- **代表性**：任务属于公共 API 新增和 API compatibility，可补充当前 SWE-Paddle 中以 bug fix 为主的任务类型。
+- **边界清楚**：production change 集中在 `python/paddle/nn/init.py`，目标行为可通过独立测试直接观察。
+- **非平凡性**：任务同时涉及新的稀疏初始化行为、输入约束、原地操作语义以及已有 initializer 的返回兼容性。
+- **环境友好性**：目标逻辑位于 Python 层，可通过 AST overlay 和 controlled doubles 在 CPU 环境稳定验证，无需 GPU 或 Paddle source build。
+
+## 4. 任务类型和标签
+
+- 任务类型：`feature_enhancement`
+- 执行后端：`cpu`
+- 设备范围：`cpu_only`
+- 模块标签：`[nn_init, sparse_initializer, api_compatibility, inplace_api]`
+
+## 5. 验证思路
+
+- 目标测试命令：`bash tests/test.sh`
+- 目标测试文件：`test/swe_paddle/test_pr79310_sparse_initializer.py`
+- 修复前预期：在 `base_commit` 上应用 `tests/test.patch` 后，已有非动态图 initializer 行为应 pass；新增稀疏初始化能力和动态图原地返回语义相关测试应 fail。
+- 修复后预期：继续应用 `solution/code.patch` 后，已有行为测试与新增行为测试均应 pass。
+- P2P 候选：非动态图环境下已有函数式 initializer 的返回行为。
+
+## 6. 环境与资源
+
+- 资源需求：CPU
+- Paddle 来源：`PaddlePaddle/Paddle` source checkout at `base_commit`
+- 是否能提供 Docker：暂无
+- patch 类型：Python-only
+- 环境建议：使用可运行 `pytest` 的 Python 环境，通过 AST overlay 执行 checkout 中的目标函数控制流，并使用 controlled doubles 提供依赖；无需 Paddle source build
+- 最小测试命令：`bash tests/test.sh`
+- 是否有 oracle 日志：由 SWE-Paddle verifier 结果另行维护
+
+## 7. 风险自查
+
+- 泄露风险：`instruction.md` 只描述用户可观察行为和兼容性要求，不提供 Gold patch 的具体修改方式。
+- 环境风险：测试不依赖历史 Paddle package 的完整 import，也不要求 native extension 与 checkout 完全匹配。
+- flaky 风险：随机相关行为通过 controlled doubles 稳定验证，不依赖随机命中、GPU 或外部数据。
+- 拆分风险：新增 `sparse_` 与动态图原地 initializer 返回语义属于同一个已合入 API compatibility PR，并集中在同一 production 文件中，适合作为一个任务。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79310/solution/code.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79310/solution/code.patch
@@ -1,0 +1,280 @@
+diff --git a/python/paddle/nn/init.py b/python/paddle/nn/init.py
+index 5dc730c6e43e0df07ba793982aef8d40335d8433..e577e585746ffa0228b344189f837184eaed3bc1 100644
+--- a/python/paddle/nn/init.py
++++ b/python/paddle/nn/init.py
+@@ -14,6 +14,8 @@
+ 
+ from __future__ import annotations
+ 
++import math
++
+ import numpy as np
+ 
+ import paddle
+@@ -69,7 +71,7 @@ def kaiming_uniform_(
+     a: float = 0,
+     mode: str = "fan_in",
+     nonlinearity: str = "leaky_relu",
+-) -> paddle.Tensor | None:
++) -> paddle.Tensor:
+     """Modify tensor inplace using Kaiming uniform method.
+ 
+     Args:
+@@ -89,6 +91,9 @@ def kaiming_uniform_(
+         negative_slope=a, nonlinearity=nonlinearity, mode=mode
+     )
+ 
++    if in_dygraph_mode():
++        init(tensor)
++        return tensor
+     return init(tensor)
+ 
+ 
+@@ -97,7 +102,7 @@ def kaiming_normal_(
+     a: float = 0,
+     mode: str = "fan_in",
+     nonlinearity: str = "leaky_relu",
+-) -> paddle.Tensor | None:
++) -> paddle.Tensor:
+     """Modify tensor inplace using Kaiming normal method.
+ 
+     Args:
+@@ -115,6 +120,9 @@ def kaiming_normal_(
+     """
+     init = KaimingNormal(negative_slope=a, nonlinearity=nonlinearity, mode=mode)
+ 
++    if in_dygraph_mode():
++        init(tensor)
++        return tensor
+     return init(tensor)
+ 
+ 
+@@ -123,7 +131,7 @@ def xavier_uniform_(
+     gain: float = 1.0,
+     fan_in: float | None = None,
+     fan_out: float | None = None,
+-) -> paddle.Tensor | None:
++) -> paddle.Tensor:
+     """Modify tensor inplace using Xavier uniform method.
+ 
+     Args:
+@@ -143,6 +151,9 @@ def xavier_uniform_(
+         fan_out=fan_out,
+     )
+ 
++    if in_dygraph_mode():
++        init(tensor)
++        return tensor
+     return init(tensor)
+ 
+ 
+@@ -151,7 +162,7 @@ def xavier_normal_(
+     gain: float = 1.0,
+     fan_in: float | None = None,
+     fan_out: float | None = None,
+-) -> paddle.Tensor | None:
++) -> paddle.Tensor:
+     """Modify tensor inplace using Xavier normal method.
+ 
+     Args:
+@@ -171,6 +182,9 @@ def xavier_normal_(
+         fan_out=fan_out,
+     )
+ 
++    if in_dygraph_mode():
++        init(tensor)
++        return tensor
+     return init(tensor)
+ 
+ 
+@@ -178,7 +192,7 @@ def uniform_(
+     tensor: paddle.Tensor,
+     a: float = 0.0,
+     b: float = 1.0,
+-) -> paddle.Tensor | None:
++) -> paddle.Tensor:
+     """Modify tensor inplace using uniform method.
+ 
+     Args:
+@@ -191,6 +205,9 @@ def uniform_(
+     """
+     init = Uniform(low=a, high=b)
+ 
++    if in_dygraph_mode():
++        init(tensor)
++        return tensor
+     return init(tensor)
+ 
+ 
+@@ -198,7 +215,7 @@ def normal_(
+     tensor: paddle.Tensor,
+     mean: float = 0.0,
+     std: float = 1.0,
+-) -> paddle.Tensor | None:
++) -> paddle.Tensor:
+     """Modify tensor inplace using normal method.
+ 
+     Args:
+@@ -211,6 +228,9 @@ def normal_(
+     """
+     init = Normal(mean=mean, std=std)
+ 
++    if in_dygraph_mode():
++        init(tensor)
++        return tensor
+     return init(tensor)
+ 
+ 
+@@ -220,7 +240,7 @@ def trunc_normal_(
+     std: float = 1.0,
+     a: float = -2.0,
+     b: float = 2.0,
+-) -> paddle.Tensor | None:
++) -> paddle.Tensor:
+     """Modify tensor inplace using truncated normal method.
+ 
+     Args:
+@@ -235,13 +255,16 @@ def trunc_normal_(
+     """
+     init = TruncatedNormal(mean=mean, std=std, a=a, b=b)
+ 
++    if in_dygraph_mode():
++        init(tensor)
++        return tensor
+     return init(tensor)
+ 
+ 
+ def constant_(
+     tensor: paddle.Tensor,
+     val: float,
+-) -> paddle.Tensor | None:
++) -> paddle.Tensor:
+     """Modify tensor inplace using constant method.
+ 
+     Args:
+@@ -253,12 +276,15 @@ def constant_(
+     """
+     init = Constant(value=val)
+ 
++    if in_dygraph_mode():
++        init(tensor)
++        return tensor
+     return init(tensor)
+ 
+ 
+ def ones_(
+     tensor: paddle.Tensor,
+-) -> paddle.Tensor | None:
++) -> paddle.Tensor:
+     """Fill the input Tensor with the scalar value 1.
+ 
+     Args:
+@@ -269,12 +295,15 @@ def ones_(
+     """
+     init = Constant(value=1.0)
+ 
++    if in_dygraph_mode():
++        init(tensor)
++        return tensor
+     return init(tensor)
+ 
+ 
+ def zeros_(
+     tensor: paddle.Tensor,
+-) -> paddle.Tensor | None:
++) -> paddle.Tensor:
+     """Fill the input Tensor with the scalar value 0.
+ 
+     Args:
+@@ -285,13 +314,16 @@ def zeros_(
+     """
+     init = Constant(value=0.0)
+ 
++    if in_dygraph_mode():
++        init(tensor)
++        return tensor
+     return init(tensor)
+ 
+ 
+ def dirac_(
+     tensor: paddle.Tensor,
+     groups: int = 1,
+-) -> paddle.Tensor | None:
++) -> paddle.Tensor:
+     """Initialize the 3D/4D/5D Tensor with Dirac delta function.
+ 
+     Args:
+@@ -303,12 +335,15 @@ def dirac_(
+     """
+     init = Dirac(groups=groups)
+ 
++    if in_dygraph_mode():
++        init(tensor)
++        return tensor
+     return init(tensor)
+ 
+ 
+ def eye_(
+     tensor: paddle.Tensor,
+-) -> paddle.Tensor | None:
++) -> paddle.Tensor:
+     """Fill the 2-dimensional input Tensor with the identity matrix.
+ 
+     Args:
+@@ -327,7 +362,7 @@ def eye_(
+             tensor.shape[0], tensor.shape[1], dtype=tensor.dtype
+         )
+         new_tensor._share_underline_tensor_to(tensor)
+-        return None
++        return tensor
+     elif in_pir_mode():
+         new_tensor = paddle.eye(
+             tensor.shape[0], tensor.shape[1], dtype=tensor.dtype
+@@ -342,7 +377,7 @@ def eye_(
+ def orthogonal_(
+     tensor: paddle.Tensor,
+     gain: float = 1,
+-) -> paddle.Tensor | None:
++) -> paddle.Tensor:
+     """Fill the input Tensor with a (semi) orthogonal matrix.
+ 
+     Args:
+@@ -352,4 +387,38 @@ def orthogonal_(
+         Tensor: Initialized tensor.
+     """
+     init = Orthogonal(gain=gain)
++    if in_dygraph_mode():
++        init(tensor)
++        return tensor
+     return init(tensor)
++
++
++def sparse_(
++    tensor: paddle.Tensor, sparsity: float, std: float = 0.01
++) -> paddle.Tensor:
++    """Fill the 2D input Tensor as a sparse matrix.
++
++    The non-zero elements will be drawn from the normal distribution.
++
++    Args:
++        tensor (Tensor): Paddle Tensor with 2 dimensions.
++        sparsity (float): The fraction of elements in each column to be set to zero.
++        std (float): the standard deviation of the normal distribution used to generate
++            the non-zero values. Default is 0.01.
++
++    Examples:
++        >>> tensor = paddle.empty(3, 5)
++        >>> result = paddle.nn.init.sparse_(tensor, sparsity=0.1)
++    """
++    if tensor.ndimension() != 2:
++        raise ValueError("Only tensors with 2 dimensions are supported")
++    rows, cols = tensor.shape
++    num_zeros = math.ceil(sparsity * rows)
++
++    with paddle.no_grad():
++        tensor = normal_(tensor, mean=0, std=std)
++        for col_idx in range(cols):
++            row_indices = paddle.randperm(rows)
++            zero_indices = row_indices[:num_zeros]
++            tensor[zero_indices, col_idx] = 0
++    return tensor

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79310/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79310/tests/test.patch
@@ -1,0 +1,240 @@
+diff --git a/test/swe_paddle/test_pr79310_sparse_initializer.py b/test/swe_paddle/test_pr79310_sparse_initializer.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..e6c84f70a42c8fa2114c31cccc5cd9866a010263
+--- /dev/null
++++ b/test/swe_paddle/test_pr79310_sparse_initializer.py
+@@ -0,0 +1,234 @@
++import ast
++import copy
++import math
++import types
++from contextlib import nullcontext
++from pathlib import Path
++
++import pytest
++
++
++TARGET = Path("python/paddle/nn/init.py")
++
++
++def _extract_function(name, namespace):
++    tree = ast.parse(TARGET.read_text(encoding="utf-8"), filename=str(TARGET))
++    node = next(
++        copy.deepcopy(item)
++        for item in tree.body
++        if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef))
++        and item.name == name
++    )
++    future = ast.ImportFrom(
++        module="__future__", names=[ast.alias(name="annotations")], level=0
++    )
++    module = ast.Module(body=[future, node], type_ignores=[])
++    ast.fix_missing_locations(module)
++    exec(compile(module, str(TARGET), "exec"), namespace)
++    return namespace[name]
++
++
++class _Initializer:
++    def __init__(self, calls, result, args, kwargs):
++        self._calls = calls
++        self._result = result
++        self._args = args
++        self._kwargs = kwargs
++
++    def __call__(self, tensor):
++        self._calls.append((tensor, self._args, self._kwargs))
++        return self._result
++
++
++def _initializer_factory(calls, result):
++    def factory(*args, **kwargs):
++        return _Initializer(calls, result, args, kwargs)
++
++    return factory
++
++
++def _initializer_namespace(*, dygraph, initializer_result, calls):
++    factory = _initializer_factory(calls, initializer_result)
++    return {
++        "KaimingUniform": factory,
++        "KaimingNormal": factory,
++        "XavierUniform": factory,
++        "XavierNormal": factory,
++        "Uniform": factory,
++        "Normal": factory,
++        "TruncatedNormal": factory,
++        "Constant": factory,
++        "Dirac": factory,
++        "Orthogonal": factory,
++        "in_dygraph_mode": lambda: dygraph,
++    }
++
++
++class _Tensor:
++    def __init__(self, rows, cols):
++        self.shape = (rows, cols)
++        self.dtype = "float32"
++        self.values = [
++            [float(row * cols + col + 1) for col in range(cols)]
++            for row in range(rows)
++        ]
++
++    def ndimension(self):
++        return len(self.shape)
++
++    def __setitem__(self, key, value):
++        row_indices, col_idx = key
++        for row_idx in row_indices:
++            self.values[int(row_idx)][col_idx] = value
++
++
++class _Non2DTensor:
++    shape = (2, 3, 4)
++
++    def ndimension(self):
++        return 3
++
++
++class _PaddleDouble:
++    def __init__(self):
++        self.randperm_calls = []
++
++    def no_grad(self):
++        return nullcontext()
++
++    def randperm(self, rows):
++        self.randperm_calls.append(rows)
++        # Deterministic indices keep the test non-flaky while the checkout's
++        # real sparse_ body still performs per-column slicing and assignment.
++        return list(reversed(range(rows)))
++
++
++class _SharedEyeTensor:
++    def __init__(self, shared_targets):
++        self._shared_targets = shared_targets
++
++    def _share_underline_tensor_to(self, target):
++        self._shared_targets.append(target)
++
++
++def _load_sparse_function():
++    paddle = _PaddleDouble()
++    normal_calls = []
++
++    def normal_stub(tensor, *, mean, std):
++        normal_calls.append((tensor, mean, std))
++        return tensor
++
++    function = _extract_function(
++        "sparse_",
++        {
++            "math": math,
++            "paddle": paddle,
++            "normal_": normal_stub,
++        },
++    )
++    return function, paddle, normal_calls
++
++
++def test_existing_normal_non_dygraph_path_keeps_initializer_return_value():
++    marker = object()
++    tensor = object()
++    calls = []
++    function = _extract_function(
++        "normal_",
++        _initializer_namespace(
++            dygraph=False, initializer_result=marker, calls=calls
++        ),
++    )
++
++    result = function(tensor, mean=1.5, std=0.25)
++
++    assert result is marker
++    assert len(calls) == 1
++    assert calls[0][0] is tensor
++    assert calls[0][2] == {"mean": 1.5, "std": 0.25}
++
++
++def test_dygraph_inplace_initializer_helpers_return_input_tensor():
++    cases = [
++        ("kaiming_uniform_", (), {}),
++        ("kaiming_normal_", (), {}),
++        ("xavier_uniform_", (), {}),
++        ("xavier_normal_", (), {}),
++        ("uniform_", (), {}),
++        ("normal_", (), {}),
++        ("trunc_normal_", (), {}),
++        ("constant_", (), {"val": 3.0}),
++        ("ones_", (), {}),
++        ("zeros_", (), {}),
++        ("dirac_", (), {}),
++        ("orthogonal_", (), {}),
++    ]
++
++    for name, args, kwargs in cases:
++        marker = object()
++        tensor = object()
++        calls = []
++        function = _extract_function(
++            name,
++            _initializer_namespace(
++                dygraph=True, initializer_result=marker, calls=calls
++            ),
++        )
++
++        result = function(tensor, *args, **kwargs)
++
++        assert result is tensor, name
++        assert len(calls) == 1, name
++        assert calls[0][0] is tensor, name
++
++
++def test_eye_dygraph_returns_input_tensor_after_inplace_share():
++    shared_targets = []
++    created = []
++
++    def eye(rows, cols, dtype):
++        created.append((rows, cols, dtype))
++        return _SharedEyeTensor(shared_targets)
++
++    paddle = types.SimpleNamespace(eye=eye)
++    function = _extract_function(
++        "eye_",
++        {
++            "paddle": paddle,
++            "in_dygraph_mode": lambda: True,
++            "in_pir_mode": lambda: False,
++        },
++    )
++    tensor = _Tensor(2, 3)
++
++    result = function(tensor)
++
++    assert result is tensor
++    assert created == [(2, 3, "float32")]
++    assert shared_targets == [tensor]
++
++
++def test_sparse_initializer_zeros_ceil_fraction_in_every_column():
++    function, paddle, normal_calls = _load_sparse_function()
++    tensor = _Tensor(rows=5, cols=3)
++
++    result = function(tensor, sparsity=0.4, std=0.2)
++
++    assert result is tensor
++    assert normal_calls == [(tensor, 0, 0.2)]
++    assert paddle.randperm_calls == [5, 5, 5]
++    for col_idx in range(3):
++        column = [tensor.values[row_idx][col_idx] for row_idx in range(5)]
++        assert column.count(0) == math.ceil(0.4 * 5)
++        assert all(value > 0 for value in column if value != 0)
++
++
++def test_sparse_initializer_rejects_non_2d_tensor():
++    function, paddle, normal_calls = _load_sparse_function()
++
++    with pytest.raises(ValueError, match="Only tensors with 2 dimensions"):
++        function(_Non2DTensor(), sparsity=0.5)
++
++    assert paddle.randperm_calls == []
++    assert normal_calls == []

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79310/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79310/tests/test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python -m pytest test/swe_paddle/test_pr79310_sparse_initializer.py -q


### PR DESCRIPTION
## 关联

- SWE-Paddle 共建 issue: https://github.com/PaddlePaddle/Paddle/issues/79447
- 来源 PR: https://github.com/PaddlePaddle/Paddle/pull/79310

## 说明

- 新增 SWE-Paddle 任务 `PaddlePaddle__Paddle-79310`

@sunzhongkai588

## 验证结果

| 状态 | Existing static-path P2P | Dynamic in-place return F2P | `eye_` return F2P | `sparse_` behavior F2P | `sparse_` validation F2P |
| --- | --- | --- | --- | --- | --- |
| Base + `tests/test.patch` | PASS | FAIL，符合预期 | FAIL，符合预期 | FAIL，符合预期 | FAIL，符合预期 |
| Base + test patch + `solution/code.patch` | PASS | PASS | PASS | PASS | PASS |

#### Base P2P：Existing non-dygraph initializer behavior

```text
.                                                                        [100%]
1 passed in 0.04s
Base existing static-path P2P exit code: 0
```

#### Base F2P：Dynamic in-place initializer helpers return the input Tensor

```text
F                                                                        [100%]
================================== FAILURES ===================================
________ test_dygraph_inplace_initializer_helpers_return_input_tensor _________

    def test_dygraph_inplace_initializer_helpers_return_input_tensor():
        cases = [
            ("kaiming_uniform_", (), {}),
            ("kaiming_normal_", (), {}),
            ("xavier_uniform_", (), {}),
            ("xavier_normal_", (), {}),
            ("uniform_", (), {}),
            ("normal_", (), {}),
            ("trunc_normal_", (), {}),
            ("constant_", (), {"val": 3.0}),
            ("ones_", (), {}),
            ("zeros_", (), {}),
            ("dirac_", (), {}),
            ("orthogonal_", (), {}),
        ]

        ...

>           assert result is tensor, name
E           AssertionError: kaiming_uniform_

FAILED test/swe_paddle/test_pr79310_sparse_initializer.py::test_dygraph_inplace_initializer_helpers_return_input_tensor
1 failed in 0.72s
Base dynamic in-place-return F2P exit code: 1
```

#### Base F2P：`eye_` returns the input Tensor after in-place sharing

```text
F                                                                        [100%]
================================== FAILURES ===================================
__________ test_eye_dygraph_returns_input_tensor_after_inplace_share __________

    result = function(tensor)

>   assert result is tensor
E   assert None is <test_pr79310_sparse_initializer._Tensor object at ...>

FAILED test/swe_paddle/test_pr79310_sparse_initializer.py::test_eye_dygraph_returns_input_tensor_after_inplace_share
1 failed in 0.58s
Base eye-return F2P exit code: 1
```

#### Base F2P：`sparse_` zeros the required fraction in every column

```text
F                                                                        [100%]
================================== FAILURES ===================================
_________ test_sparse_initializer_zeros_ceil_fraction_in_every_column _________

>       function, paddle, normal_calls = _load_sparse_function()

E       StopIteration

FAILED test/swe_paddle/test_pr79310_sparse_initializer.py::test_sparse_initializer_zeros_ceil_fraction_in_every_column
1 failed in 0.55s
Base sparse-initializer F2P exit code: 1
```

#### Base F2P：`sparse_` rejects non-2D tensors

```text
F                                                                        [100%]
================================== FAILURES ===================================
________________ test_sparse_initializer_rejects_non_2d_tensor ________________

>       function, paddle, normal_calls = _load_sparse_function()

E       StopIteration

FAILED test/swe_paddle/test_pr79310_sparse_initializer.py::test_sparse_initializer_rejects_non_2d_tensor
1 failed in 0.62s
Base sparse-validation F2P exit code: 1
```

#### Solution 测试

```text
Solution existing static-path P2P:
1 passed in 0.03s

Solution dynamic in-place-return F2P:
1 passed in 0.04s

Solution eye-return F2P:
1 passed in 0.03s

Solution sparse-initializer F2P:
1 passed in 0.03s

Solution sparse-validation F2P:
1 passed in 0.02s
```

#### `tests/test.sh`

```text
.....                                                                    [100%]
5 passed in 0.06s
Solution tests/test.sh exit code: 0
```