### PR TITLE
[SWE-Paddle] Add task PaddlePaddle__Paddle-79275

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle_Paddle-79275/README.md
+++ b/swe-paddle/tasks/PaddlePaddle_Paddle-79275/README.md
@@ -1,0 +1,45 @@
+# PaddlePaddle__Paddle-79275
+
+This directory converts Paddle PR #79275 into a SWE-Paddle community task candidate.
+
+## Source
+
+| Field | Value |
+| --- | --- |
+| Repo | `PaddlePaddle/Paddle` |
+| PR | [79275](https://github.com/PaddlePaddle/Paddle/pull/79275) |
+| PR title | `[API Compatibility] Align torch.nn.attention.flex_attention.or_masks/and_masks` |
+| Base commit | `1d14ac949cd00747df9c828537f5fbff51b1f85f` |
+| Merged at | `2026-06-12` |
+| Task type | `feature_enhancement` |
+| Resource | CPU |
+
+## Summary
+
+Add `or_masks` and `and_masks` combination APIs to `paddle.nn.attention.flex_attention` to enable the logical OR/AND combination of multiple attention mask callables, while ensuring consistent boundary conditions and error handling.
+
+## Why This Is A Good SWE-Paddle Candidate
+
+- It adds two user-visible public APIs rather than fixing an internal-only implementation detail.
+- The target contract has clear observable behavior for multiple masks, a single mask, empty input, and invalid non-callable input.
+- Existing `paddle.nn.attention` exports provide a direct regression boundary for P2P verification.
+- The production change is Python-only and can be exercised deterministically with controlled Tensor-like doubles.
+- The task does not require GPU, distributed execution, network access, or a Paddle source build.
+
+## Files
+
+- `proposal.md`: candidate proposal for maintainer triage.
+- `instruction.md`: self-contained problem statement for the coding agent.
+- `solution/code.patch`: gold patch from the merged PR.
+- `tests/test.patch`: test patch exposing the target behavior.
+- `tests/test.sh`: minimal target test command.
+- `environment/README.md`: environment notes for reproduction.
+- `README.md`: task overview and verification entrypoint.
+
+## Verification
+
+```bash
+bash tests/test.sh
+```
+
+Expected behavior: applying `tests/test.patch` to `base_commit` should fail on the target behavior; applying both `tests/test.patch` and `solution/code.patch` should pass the target tests.

--- a/swe-paddle/tasks/PaddlePaddle_Paddle-79275/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle_Paddle-79275/environment/README.md
@@ -1,0 +1,27 @@
+# Environment Notes
+
+This candidate is part of the SWE-Paddle community task set.
+
+## Expected Environment
+
+- Repository: `PaddlePaddle/Paddle`
+- Base commit: `1d14ac949cd00747df9c828537f5fbff51b1f85f`
+- Resource: CPU
+- GPU required: no
+- Build path: Paddle source checkout at the base commit. This Python-only task may be verified with an AST overlay and controlled doubles; source build is not required.
+
+## Run Order
+
+1. Check out `PaddlePaddle/Paddle` at the base commit.
+2. Apply `tests/test.patch`.
+3. Run `bash tests/test.sh`; the target behavior should fail before the fix.
+4. Apply `solution/code.patch`.
+5. Run `bash tests/test.sh` again; the target behavior should pass after the gold patch.
+
+## Minimal Test Command
+
+```bash
+bash tests/test.sh
+```
+
+The verifier is responsible for deriving stable F2P and P2P node IDs from repeated runs.

--- a/swe-paddle/tasks/PaddlePaddle_Paddle-79275/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle_Paddle-79275/instruction.md
@@ -1,0 +1,19 @@
+# 增加 flex_attention mask 组合 API
+
+## 详细描述
+
+Paddle 的 flex attention 接口需要提供 mask 组合能力，使调用方可以将一个或多个满足 attention mask 调用约定的函数组合成新的 mask callable。组合后的 callable 应继续接收 batch、head、query index 和 key/value index 参数，并返回对应的布尔 mask 结果。
+
+需要同时支持逻辑 OR 和逻辑 AND 两种组合方式。单个 mask 的组合结果应与原 mask 等价；空参数调用应具有合理的逻辑恒等行为；传入不可调用对象时应明确拒绝。现有 `paddle.nn.attention` 公共接口必须保持兼容。
+
+## 验收说明
+
+- 提供 `paddle.nn.attention.flex_attention.or_masks` 和 `and_masks`，能够正确组合一个或多个合法 mask callable 的逻辑结果。
+- 单 mask、空 mask 集合以及包含非 callable 输入时，应分别表现出一致的逻辑恒等与输入校验行为。
+- `paddle.nn.attention` 中已有的公共 API 和合法调用方式应保持不变。
+
+## 技术要求
+
+- 熟悉 Python callable、闭包以及布尔 Tensor 运算语义。
+- 了解 Paddle attention API 的模块组织与公共导出方式。
+- 能够为 API 边界、组合行为和异常输入设计稳定的 CPU-only 回归测试。

--- a/swe-paddle/tasks/PaddlePaddle_Paddle-79275/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle_Paddle-79275/instruction.md
@@ -1,19 +1,26 @@
-# 增加 flex_attention mask 组合 API
+# 新增 flex_attention mask 组合 API
 
 ## 详细描述
 
-Paddle 的 flex attention 接口需要提供 mask 组合能力，使调用方可以将一个或多个满足 attention mask 调用约定的函数组合成新的 mask callable。组合后的 callable 应继续接收 batch、head、query index 和 key/value index 参数，并返回对应的布尔 mask 结果。
+Paddle 需要提供与 PyTorch 对齐的 flex attention mask 组合接口，使调用方能够将一个或多个 mask 函数组合成新的 mask 函数。
 
-需要同时支持逻辑 OR 和逻辑 AND 两种组合方式。单个 mask 的组合结果应与原 mask 等价；空参数调用应具有合理的逻辑恒等行为；传入不可调用对象时应明确拒绝。现有 `paddle.nn.attention` 公共接口必须保持兼容。
+每个 mask 函数接收 batch、head、query index 和 key/value index，并返回对应位置的布尔结果。新增接口需要分别支持逻辑 OR 和逻辑 AND 组合，并能够在动态图和静态图模式下正常使用。
 
 ## 验收说明
 
-- 提供 `paddle.nn.attention.flex_attention.or_masks` 和 `and_masks`，能够正确组合一个或多个合法 mask callable 的逻辑结果。
-- 单 mask、空 mask 集合以及包含非 callable 输入时，应分别表现出一致的逻辑恒等与输入校验行为。
-- `paddle.nn.attention` 中已有的公共 API 和合法调用方式应保持不变。
+* 提供 `paddle.nn.attention.flex_attention.or_masks` 和 `paddle.nn.attention.flex_attention.and_masks`
+* 组合后的函数应继续接收 batch、head、query index 和 key/value index，并返回布尔 Tensor
+* `or_masks` 应返回所有输入 mask 结果的逻辑 OR
+* `and_masks` 应返回所有输入 mask 结果的逻辑 AND
+* 仅传入一个 mask 时，组合结果应与该 mask 的结果一致
+* 未传入 mask 时，`or_masks` 应返回 `False`，`and_masks` 应返回 `True`
+* 任一输入不是 callable 时，应抛出 `RuntimeError`
+* 相关接口应支持动态图和静态图模式
+* `paddle.nn.attention` 中已有的公共 API 和合法调用方式不得受到影响
 
 ## 技术要求
 
-- 熟悉 Python callable、闭包以及布尔 Tensor 运算语义。
-- 了解 Paddle attention API 的模块组织与公共导出方式。
-- 能够为 API 边界、组合行为和异常输入设计稳定的 CPU-only 回归测试。
+* 熟悉 Python callable 和布尔 Tensor 运算
+* 了解 Paddle attention API 的模块组织及公共接口导出方式
+* 了解 Paddle 动态图和静态图模式
+* 能够为组合结果、边界输入和异常输入设计稳定的 CPU 测试

--- a/swe-paddle/tasks/PaddlePaddle_Paddle-79275/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle_Paddle-79275/proposal.md
@@ -1,0 +1,55 @@
+# Task Proposal: PaddlePaddle__Paddle-79275
+
+## 1. 来源信息
+
+- Instance ID：`PaddlePaddle__Paddle-79275`
+- PR 链接：https://github.com/PaddlePaddle/Paddle/pull/79275
+- PR 标题：`[API Compatibility] Align torch.nn.attention.flex_attention.or_masks/and_masks`
+- `base_commit`：`1d14ac949cd00747df9c828537f5fbff51b1f85f`
+- merged 时间：`2026-06-12`
+- 你的身份：熟悉该模块的 contributor
+- 后续联系人：TBD
+
+## 2. 问题一句话
+
+为 flex attention 增加可组合多个 mask callable 的 `or_masks` / `and_masks` 公共 API，并对齐单 mask、空输入和非法输入的可观察行为。
+
+## 3. 为什么适合作为 SWE-Paddle 样本
+
+- **真实性**：任务来自已合入的 Paddle PR #79275，不是合成需求。
+- **代表性**：这是 attention 模块的公共 API addition，可补充以 bug fix 为主的任务类型。
+- **边界清楚**：Gold production change 只涉及 attention package 导出和新增的 `flex_attention.py`，目标行为可由独立测试直接观察。
+- **非平凡性**：正确实现需要同时满足多 callable OR/AND 组合、参数透传、单 mask 与空输入恒等语义以及非法输入校验。
+- **环境友好性**：组合控制流可以通过 AST overlay 与 Tensor-like controlled doubles 在 CPU 上稳定验证，无需真实 attention kernel、GPU 或 Paddle source build。
+
+## 4. 任务类型和标签
+
+- 任务类型：`feature_enhancement`
+- 执行后端：`cpu`
+- 设备范围：`cpu_only`
+- 模块标签：`[attention, flex_attention, public_api, api_compatibility, mask, python_only]`
+
+## 5. 验证思路
+
+- 目标测试命令：`bash tests/test.sh`
+- 目标测试文件：`test/swe_paddle/test_pr79275_flex_attention_masks.py`
+- 修复前预期：现有 attention export P2P 通过；`or_masks` / `and_masks` 的组合、恒等和错误输入 F2P 因目标 API 尚不存在而失败。
+- 修复后预期：继续应用 production-only `solution/code.patch` 后，全部目标测试通过。
+- P2P 候选：`paddle.nn.attention` 原有 `SDPBackend`、`sdpa_kernel` 与公开导出集合保持不变。
+
+## 6. 环境与资源
+
+- 资源需求：CPU
+- Paddle 来源：`PaddlePaddle/Paddle` source checkout at `base_commit`
+- 是否能提供 Docker：暂无
+- patch 类型：Python-only
+- 环境建议：通过 AST overlay 执行 checkout 中真实 `or_masks` / `and_masks` 控制流，并使用 controlled Tensor-like doubles 观察逻辑组合、参数透传和 identity 初始化行为；无需 source build。
+- 最小测试命令：`bash tests/test.sh`
+- 是否有 oracle 日志：由 SWE-Paddle verifier 结果另行维护
+
+## 7. 风险自查
+
+- 泄露风险：`instruction.md` 只描述公共 API 的 observable behavior，不给出 Gold patch 的具体实现步骤。
+- 环境风险：测试不导入历史 checkout 的完整 Paddle package，不要求 native extension 与源码版本完全匹配。
+- flaky 风险：所有 mask 输入和布尔结果由 controlled doubles 固定，不依赖随机数、GPU 或并发时序。
+- 拆分风险：`or_masks` 和 `and_masks` 是同一 flex-attention mask composition API 目标，且由同一新增模块提供，适合作为一个任务。

--- a/swe-paddle/tasks/PaddlePaddle_Paddle-79275/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle_Paddle-79275/proposal.md
@@ -2,54 +2,52 @@
 
 ## 1. 来源信息
 
-- Instance ID：`PaddlePaddle__Paddle-79275`
-- PR 链接：https://github.com/PaddlePaddle/Paddle/pull/79275
-- PR 标题：`[API Compatibility] Align torch.nn.attention.flex_attention.or_masks/and_masks`
-- `base_commit`：`1d14ac949cd00747df9c828537f5fbff51b1f85f`
-- merged 时间：`2026-06-12`
-- 你的身份：熟悉该模块的 contributor
-- 后续联系人：TBD
+* Instance ID：`PaddlePaddle__Paddle-79275`
+* PR 链接：https://github.com/PaddlePaddle/Paddle/pull/79275
+* PR 标题：`[API Compatibility] Align torch.nn.attention.flex_attention.or_masks/and_masks`
+* `base_commit`：`1d14ac949cd00747df9c828537f5fbff51b1f85f`
+* merged 时间：`2026-06-12`
+* 你的身份：熟悉该模块的 contributor
+* 后续联系人：TBD
 
 ## 2. 问题一句话
 
-为 flex attention 增加可组合多个 mask callable 的 `or_masks` / `and_masks` 公共 API，并对齐单 mask、空输入和非法输入的可观察行为。
+为 flex attention 新增 `or_masks` 和 `and_masks` 公共 API，使调用方能够组合一个或多个 mask 函数，并正确处理单个 mask、空输入和非法输入。
 
 ## 3. 为什么适合作为 SWE-Paddle 样本
 
-- **真实性**：任务来自已合入的 Paddle PR #79275，不是合成需求。
-- **代表性**：这是 attention 模块的公共 API addition，可补充以 bug fix 为主的任务类型。
-- **边界清楚**：Gold production change 只涉及 attention package 导出和新增的 `flex_attention.py`，目标行为可由独立测试直接观察。
-- **非平凡性**：正确实现需要同时满足多 callable OR/AND 组合、参数透传、单 mask 与空输入恒等语义以及非法输入校验。
-- **环境友好性**：组合控制流可以通过 AST overlay 与 Tensor-like controlled doubles 在 CPU 上稳定验证，无需真实 attention kernel、GPU 或 Paddle source build。
+* **真实性**：任务来自已合入的 Paddle PR #79275，不是人工构造的需求。
+* **代表性**：该任务涉及 attention 模块的公共 API、mask 函数组合和 PyTorch 接口兼容，可补充 SWE-Paddle 中以 bug fix 为主的任务类型。
+* **边界清楚**：Gold production change 集中在 attention 包的模块导出和新增的 `flex_attention.py`，功能范围明确，相关行为可以通过独立测试直接验证。
+* **非平凡性**：任务需要正确实现多个 mask 的 OR/AND 组合，保持四个调用参数不变，并处理单个 mask、空输入和非法输入等边界情况。
 
 ## 4. 任务类型和标签
 
-- 任务类型：`feature_enhancement`
-- 执行后端：`cpu`
-- 设备范围：`cpu_only`
-- 模块标签：`[attention, flex_attention, public_api, api_compatibility, mask, python_only]`
+* 任务类型：`feature_enhancement`
+* 执行后端：`cpu`
+* 设备范围：`cpu_only`
+* 模块标签：`[attention, flex_attention, public_api, api_compatibility, mask, python_only]`
 
 ## 5. 验证思路
 
-- 目标测试命令：`bash tests/test.sh`
-- 目标测试文件：`test/swe_paddle/test_pr79275_flex_attention_masks.py`
-- 修复前预期：现有 attention export P2P 通过；`or_masks` / `and_masks` 的组合、恒等和错误输入 F2P 因目标 API 尚不存在而失败。
-- 修复后预期：继续应用 production-only `solution/code.patch` 后，全部目标测试通过。
-- P2P 候选：`paddle.nn.attention` 原有 `SDPBackend`、`sdpa_kernel` 与公开导出集合保持不变。
+* 目标测试命令：`bash tests/test.sh`
+* 目标测试文件：`test/swe_paddle/test_pr79275_flex_attention_masks.py`
+* 修复前预期：`paddle.nn.attention` 现有公共接口的 P2P 测试应通过；`or_masks` 和 `and_masks` 的组合行为、空输入行为及非法输入处理测试应因目标 API 尚不存在而失败。
+* 修复后预期：继续应用 production-only `solution/code.patch` 后，P2P 与全部 F2P 均应通过；新增 API 应能够正确组合 mask，并保持参数传递和边界输入行为符合预期。
+* P2P 候选：`paddle.nn.attention` 中已有的 `SDPBackend`、`sdpa_kernel` 及相关公共导入行为保持不变。
 
 ## 6. 环境与资源
 
-- 资源需求：CPU
-- Paddle 来源：`PaddlePaddle/Paddle` source checkout at `base_commit`
-- 是否能提供 Docker：暂无
-- patch 类型：Python-only
-- 环境建议：通过 AST overlay 执行 checkout 中真实 `or_masks` / `and_masks` 控制流，并使用 controlled Tensor-like doubles 观察逻辑组合、参数透传和 identity 初始化行为；无需 source build。
-- 最小测试命令：`bash tests/test.sh`
-- 是否有 oracle 日志：由 SWE-Paddle verifier 结果另行维护
+* 资源需求：CPU
+* Paddle 来源：`PaddlePaddle/Paddle` source checkout at `base_commit`
+* 是否能提供 Docker：暂无
+* patch 类型：Python-only
+* 最小测试命令：`bash tests/test.sh`
+* 是否有 oracle 日志：由 SWE-Paddle verifier 结果另行维护
 
 ## 7. 风险自查
 
-- 泄露风险：`instruction.md` 只描述公共 API 的 observable behavior，不给出 Gold patch 的具体实现步骤。
-- 环境风险：测试不导入历史 checkout 的完整 Paddle package，不要求 native extension 与源码版本完全匹配。
-- flaky 风险：所有 mask 输入和布尔结果由 controlled doubles 固定，不依赖随机数、GPU 或并发时序。
-- 拆分风险：`or_masks` 和 `and_masks` 是同一 flex-attention mask composition API 目标，且由同一新增模块提供，适合作为一个任务。
+* 泄露风险：`instruction.md` 只描述公共 API 的组合结果、参数约定和边界行为，不透露 Gold patch 的结果初始化方式、循环结构或具体实现步骤。
+* 环境风险：测试不导入历史 source checkout 的完整 Paddle package，也不要求 native extension 与源码版本完全匹配。
+* flaky 风险：测试使用固定的 mask 输入、Tensor 测试替身和确定性的布尔结果，不依赖随机数、GPU、并发或异步时序。
+* 拆分风险：`or_masks` 和 `and_masks` 属于同一 flex attention mask 组合能力，且由同一新增模块提供，适合作为一个完整任务。

--- a/swe-paddle/tasks/PaddlePaddle_Paddle-79275/solution/code.patch
+++ b/swe-paddle/tasks/PaddlePaddle_Paddle-79275/solution/code.patch
@@ -1,0 +1,139 @@
+diff --git a/python/paddle/nn/attention/__init__.py b/python/paddle/nn/attention/__init__.py
+index ba0ae208316b33decaded039e4ec895e59d458ed..dbc795783c277a1dc12ed0b75aed29f7a0c07f01 100644
+--- a/python/paddle/nn/attention/__init__.py
++++ b/python/paddle/nn/attention/__init__.py
+@@ -12,6 +12,7 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ 
++from . import flex_attention  # noqa: F401
+ from .sdpa import (  # noqa: F401
+     SDPBackend,
+     _cur_sdpa_kernel_backends,
+diff --git a/python/paddle/nn/attention/flex_attention.py b/python/paddle/nn/attention/flex_attention.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..3210cb51088f07dbf2e4835b49747570ff1dda6b
+--- /dev/null
++++ b/python/paddle/nn/attention/flex_attention.py
+@@ -0,0 +1,121 @@
++#   Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++
++from __future__ import annotations
++
++from typing import TYPE_CHECKING
++
++if TYPE_CHECKING:
++    from collections.abc import Callable
++    from typing import TypeAlias
++
++    from paddle import Tensor
++
++    MaskModSignature: TypeAlias = Callable[
++        [Tensor, Tensor, Tensor, Tensor], Tensor
++    ]
++
++__all__ = ["or_masks", "and_masks"]
++
++
++def or_masks(*mask_mods: MaskModSignature) -> MaskModSignature:
++    """
++    Return a mask function that computes the union of provided mask functions.
++
++    Args:
++        *mask_mods (Callable): Mask functions with signature
++            ``mask_mod(b, h, q_idx, kv_idx)``.
++
++    Returns:
++        Callable: A mask function that applies logical OR to all mask results.
++
++    Examples:
++        .. code-block:: pycon
++
++            >>> import paddle
++            >>> from paddle.nn.attention.flex_attention import or_masks
++
++            >>> def mask_a(b, h, q_idx, kv_idx):
++            ...     return q_idx >= kv_idx
++
++            >>> def mask_b(b, h, q_idx, kv_idx):
++            ...     return h == 0
++
++            >>> b = paddle.to_tensor([0])
++            >>> h = paddle.to_tensor([1])
++            >>> q_idx = paddle.to_tensor([2])
++            >>> kv_idx = paddle.to_tensor([3])
++            >>> mask = or_masks(mask_a, mask_b)
++            >>> print(mask(b, h, q_idx, kv_idx))
++            Tensor(shape=[1], dtype=bool, place=Place(cpu), stop_gradient=True,
++                   [False])
++    """
++    if not all(callable(arg) for arg in mask_mods):
++        raise RuntimeError(
++            f"All inputs should be callable mask_mods: {mask_mods}"
++        )
++
++    def or_mask(b: Tensor, h: Tensor, q_idx: Tensor, kv_idx: Tensor) -> Tensor:
++        result = b.new_zeros((), dtype='bool')
++        for mask in mask_mods:
++            result = result | mask(b, h, q_idx, kv_idx)
++        return result
++
++    return or_mask
++
++
++def and_masks(*mask_mods: MaskModSignature) -> MaskModSignature:
++    """
++    Return a mask function that computes the intersection of provided mask functions.
++
++    Args:
++        *mask_mods (Callable): Mask functions with signature
++            ``mask_mod(b, h, q_idx, kv_idx)``.
++
++    Returns:
++        Callable: A mask function that applies logical AND to all mask results.
++
++    Examples:
++        .. code-block:: pycon
++
++            >>> import paddle
++            >>> from paddle.nn.attention.flex_attention import and_masks
++
++            >>> def mask_a(b, h, q_idx, kv_idx):
++            ...     return q_idx >= kv_idx
++
++            >>> def mask_b(b, h, q_idx, kv_idx):
++            ...     return h == 0
++
++            >>> b = paddle.to_tensor([0])
++            >>> h = paddle.to_tensor([0])
++            >>> q_idx = paddle.to_tensor([2])
++            >>> kv_idx = paddle.to_tensor([1])
++            >>> mask = and_masks(mask_a, mask_b)
++            >>> print(mask(b, h, q_idx, kv_idx))
++            Tensor(shape=[1], dtype=bool, place=Place(cpu), stop_gradient=True,
++                   [True])
++    """
++    if not all(callable(arg) for arg in mask_mods):
++        raise RuntimeError(
++            f"All inputs should be callable mask_mods: {mask_mods}"
++        )
++
++    def and_mask(b: Tensor, h: Tensor, q_idx: Tensor, kv_idx: Tensor) -> Tensor:
++        result = b.new_ones((), dtype='bool')
++        for mask in mask_mods:
++            result = result & mask(b, h, q_idx, kv_idx)
++        return result
++
++    return and_mask

--- a/swe-paddle/tasks/PaddlePaddle_Paddle-79275/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle_Paddle-79275/tests/test.patch
@@ -1,0 +1,145 @@
+diff --git a/test/swe_paddle/test_pr79275_flex_attention_masks.py b/test/swe_paddle/test_pr79275_flex_attention_masks.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..67ae99283ffc433008dc49cf06f489db3e3c988d
+--- /dev/null
++++ b/test/swe_paddle/test_pr79275_flex_attention_masks.py
+@@ -0,0 +1,139 @@
++import ast
++import builtins
++import copy
++from pathlib import Path
++import types
++
++import pytest
++
++
++ROOT = Path(__file__).resolve().parents[2]
++ATTENTION_INIT = ROOT / "python/paddle/nn/attention/__init__.py"
++FLEX_ATTENTION = ROOT / "python/paddle/nn/attention/flex_attention.py"
++
++
++class _BoolTensor:
++    def __init__(self, value, creation_calls=None):
++        self.value = bool(value)
++        self.creation_calls = creation_calls if creation_calls is not None else []
++
++    def new_zeros(self, shape, dtype):
++        self.creation_calls.append(("zeros", shape, dtype))
++        return _BoolTensor(False, self.creation_calls)
++
++    def new_ones(self, shape, dtype):
++        self.creation_calls.append(("ones", shape, dtype))
++        return _BoolTensor(True, self.creation_calls)
++
++    def __or__(self, other):
++        return _BoolTensor(self.value or other.value, self.creation_calls)
++
++    def __and__(self, other):
++        return _BoolTensor(self.value and other.value, self.creation_calls)
++
++
++class _Mask:
++    def __init__(self, value):
++        self.value = value
++        self.calls = []
++
++    def __call__(self, b, h, q_idx, kv_idx):
++        self.calls.append((b, h, q_idx, kv_idx))
++        return _BoolTensor(self.value, b.creation_calls)
++
++
++def _load_attention_public_namespace():
++    sdpa_backend = object()
++    sdpa_kernel = object()
++    current_backends = object()
++    sdpa_module = types.SimpleNamespace(
++        SDPBackend=sdpa_backend,
++        _cur_sdpa_kernel_backends=current_backends,
++        sdpa_kernel=sdpa_kernel,
++    )
++    flex_module = types.SimpleNamespace()
++    package_module = types.SimpleNamespace(flex_attention=flex_module)
++
++    real_import = builtins.__import__
++
++    def controlled_import(name, globals=None, locals=None, fromlist=(), level=0):
++        if level == 1 and name == "sdpa":
++            return sdpa_module
++        if level == 1 and name == "" and "flex_attention" in fromlist:
++            return package_module
++        return real_import(name, globals, locals, fromlist, level)
++
++    builtins_dict = dict(vars(builtins))
++    builtins_dict["__import__"] = controlled_import
++    namespace = {
++        "__name__": "paddle.nn.attention",
++        "__package__": "paddle.nn.attention",
++        "__builtins__": builtins_dict,
++    }
++    exec(compile(ATTENTION_INIT.read_text(encoding="utf-8"), str(ATTENTION_INIT), "exec"), namespace)
++    return namespace, sdpa_backend, sdpa_kernel
++
++
++def _load_flex_functions():
++    assert FLEX_ATTENTION.exists(), (
++        "paddle.nn.attention.flex_attention must provide the mask-combination APIs"
++    )
++    tree = ast.parse(FLEX_ATTENTION.read_text(encoding="utf-8"), filename=str(FLEX_ATTENTION))
++    nodes = {
++        node.name: copy.deepcopy(node)
++        for node in tree.body
++        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
++        and node.name in {"or_masks", "and_masks"}
++    }
++    assert set(nodes) == {"or_masks", "and_masks"}
++    namespace = {"MaskModSignature": object, "Tensor": object}
++    module = ast.Module(body=[nodes["or_masks"], nodes["and_masks"]], type_ignores=[])
++    ast.fix_missing_locations(module)
++    exec(compile(module, str(FLEX_ATTENTION), "exec"), namespace)
++    return namespace["or_masks"], namespace["and_masks"]
++
++
++def test_existing_attention_exports_remain_available():
++    namespace, sdpa_backend, sdpa_kernel = _load_attention_public_namespace()
++    assert namespace["SDPBackend"] is sdpa_backend
++    assert namespace["sdpa_kernel"] is sdpa_kernel
++    assert namespace["__all__"] == ["SDPBackend", "sdpa_kernel"]
++
++
++def test_or_and_masks_combine_results_and_forward_arguments():
++    or_masks, and_masks = _load_flex_functions()
++    b = _BoolTensor(False)
++    h, q_idx, kv_idx = object(), object(), object()
++    args = (b, h, q_idx, kv_idx)
++
++    or_parts = [_Mask(False), _Mask(True), _Mask(False)]
++    and_parts = [_Mask(True), _Mask(True), _Mask(False)]
++
++    assert or_masks(*or_parts)(*args).value is True
++    assert and_masks(*and_parts)(*args).value is False
++    assert all(mask.calls == [args] for mask in or_parts + and_parts)
++    assert ("zeros", (), "bool") in b.creation_calls
++    assert ("ones", (), "bool") in b.creation_calls
++
++
++def test_single_and_empty_mask_combinations_have_identity_behavior():
++    or_masks, and_masks = _load_flex_functions()
++    b = _BoolTensor(False)
++    args = (b, object(), object(), object())
++
++    true_mask = _Mask(True)
++    false_mask = _Mask(False)
++    assert or_masks(true_mask)(*args).value is True
++    assert and_masks(false_mask)(*args).value is False
++    assert or_masks()(*args).value is False
++    assert and_masks()(*args).value is True
++
++
++def test_non_callable_mask_inputs_are_rejected():
++    or_masks, and_masks = _load_flex_functions()
++    valid = _Mask(True)
++
++    with pytest.raises(RuntimeError, match="callable"):
++        or_masks(valid, 1)
++    with pytest.raises(RuntimeError, match="callable"):
++        and_masks(None, valid)

--- a/swe-paddle/tasks/PaddlePaddle_Paddle-79275/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle_Paddle-79275/tests/test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python -m pytest test/swe_paddle/test_pr79275_flex_attention_masks.py -q


### PR DESCRIPTION
## 关联

- SWE-Paddle 共建 issue: https://github.com/PaddlePaddle/Paddle/issues/79447
- 来源 PR: https://github.com/PaddlePaddle/Paddle/pull/79275

## 说明

- 新增 SWE-Paddle 任务 `PaddlePaddle__Paddle-79275`

@sunzhongkai588

## 验证结果

| 状态 | Existing attention exports P2P | Multi-mask composition F2P | Identity behavior F2P | Invalid-input validation F2P |
| --- | --- | --- | --- | --- |
| Base + `tests/test.patch` | PASS | FAIL，符合预期 | FAIL，符合预期 | FAIL，符合预期 |
| Base + test patch + `solution/code.patch` | PASS | PASS | PASS | PASS |

#### Base P2P：Existing attention exports remain available

```text
.                                                                        [100%]
1 passed in 0.05s
Base existing-attention-exports P2P exit code: 0
```

#### Base F2P：Compose multiple masks and forward arguments

```text
F                                                                        [100%]
================================== FAILURES ===================================
___________ test_or_and_masks_combine_results_and_forward_arguments ___________

    def test_or_and_masks_combine_results_and_forward_arguments():
>       or_masks, and_masks = _load_flex_functions()

E       AssertionError: paddle.nn.attention.flex_attention must provide the mask-combination APIs
E       assert False
E        +  where False = exists()

test\swe_paddle\test_pr79275_flex_attention_masks.py:78: AssertionError
=========================== short test summary info ===========================
FAILED test/swe_paddle/test_pr79275_flex_attention_masks.py::test_or_and_masks_combine_results_and_forward_arguments
1 failed in 0.54s
Base multi-mask-composition F2P exit code: 1
```

#### Base F2P：Single-mask and empty-mask identity behavior

```text
F                                                                        [100%]
================================== FAILURES ===================================
_______ test_single_and_empty_mask_combinations_have_identity_behavior ________

    def test_single_and_empty_mask_combinations_have_identity_behavior():
>       or_masks, and_masks = _load_flex_functions()

E       AssertionError: paddle.nn.attention.flex_attention must provide the mask-combination APIs
E       assert False

FAILED test/swe_paddle/test_pr79275_flex_attention_masks.py::test_single_and_empty_mask_combinations_have_identity_behavior
1 failed in 0.48s
Base identity-behavior F2P exit code: 1
```

#### Base F2P：Reject non-callable mask inputs

```text
F                                                                        [100%]
================================== FAILURES ===================================
_________________ test_non_callable_mask_inputs_are_rejected __________________

    def test_non_callable_mask_inputs_are_rejected():
>       or_masks, and_masks = _load_flex_functions()

E       AssertionError: paddle.nn.attention.flex_attention must provide the mask-combination APIs
E       assert False

FAILED test/swe_paddle/test_pr79275_flex_attention_masks.py::test_non_callable_mask_inputs_are_rejected
1 failed in 0.41s
Base invalid-input-validation F2P exit code: 1
```

#### Base 完整任务脚本

```text
.FFF                                                                     [100%]
================================== FAILURES ===================================
FAILED test/swe_paddle/test_pr79275_flex_attention_masks.py::test_or_and_masks_combine_results_and_forward_arguments
FAILED test/swe_paddle/test_pr79275_flex_attention_masks.py::test_single_and_empty_mask_combinations_have_identity_behavior
FAILED test/swe_paddle/test_pr79275_flex_attention_masks.py::test_non_callable_mask_inputs_are_rejected
3 failed, 1 passed in 0.56s
Base tests/test.sh exit code: 1
```

#### Solution 测试

```text
Solution existing-attention-exports P2P:
1 passed in 0.02s

Solution multi-mask-composition F2P:
1 passed in 0.03s

Solution identity-behavior F2P:
1 passed in 0.03s

Solution invalid-input-validation F2P:
1 passed in 0.03s
```

#### `tests/test.sh`

```text
....                                                                     [100%]
4 passed in 0.03s
Solution tests/test.sh exit code: 0
```