### PR TITLE
[SWE-Paddle] Add task PaddlePaddle__Paddle-74421

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-74421/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-74421/README.md
@@ -1,0 +1,44 @@
+# PaddlePaddle__Paddle-74421
+
+This directory converts Paddle PR #74421 into a SWE-Paddle community task candidate.
+
+## Source
+
+| Field | Value |
+| --- | --- |
+| Repo | `PaddlePaddle/Paddle` |
+| PR | https://github.com/PaddlePaddle/Paddle/pull/74421 |
+| PR title | `[API compatibility] add msort api` |
+| Base commit | `0b7e62cbfe2368b51e554cc7c0deb3bd94cad8f7` |
+| Merged at | `2025-08-08` |
+| Task type | `feature_enhancement` |
+| Resource | CPU |
+
+## Summary
+
+Add a public `paddle.msort` API that returns the input tensor sorted in ascending order along axis 0 while preserving the existing `paddle.sort` behavior.
+
+## Why This Is A Good SWE-Paddle Candidate
+
+- It comes from a merged API-compatibility change with a small and clearly bounded production diff.
+- The new behavior is directly observable through the public sorting contract and can be separated cleanly from existing `sort` behavior.
+- The implementation is Python-only and can be verified deterministically with an AST overlay and controlled doubles.
+- The task does not require a Paddle source build, GPU, distributed execution, or external data.
+
+## Files
+
+- `proposal.md`: candidate proposal for maintainer triage.
+- `instruction.md`: self-contained problem statement for the coding agent.
+- `solution/code.patch`: production-only Gold patch.
+- `tests/test.patch`: deterministic tests exposing the target behavior.
+- `tests/test.sh`: minimal target test command.
+- `environment/README.md`: environment notes for reproduction.
+- `README.md`: task overview and verification entrypoint.
+
+## Verification
+
+```bash
+bash tests/test.sh
+```
+
+Expected behavior: applying `tests/test.patch` to the base commit keeps the existing `sort` regression test passing while the `msort` target test fails; applying both `tests/test.patch` and `solution/code.patch` makes all target tests pass.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-74421/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-74421/environment/README.md
@@ -1,0 +1,27 @@
+# Environment Notes
+
+This candidate is part of the SWE-Paddle community task set.
+
+## Expected Environment
+
+- Repository: `PaddlePaddle/Paddle`
+- Base commit: `0b7e62cbfe2368b51e554cc7c0deb3bd94cad8f7`
+- Resource: CPU
+- GPU required: no
+- Build path: Paddle source checkout at the base commit. This Python-only task may be verified with an AST overlay and controlled doubles; source build is not required.
+
+## Run Order
+
+1. Check out `PaddlePaddle/Paddle` at the base commit.
+2. Apply `tests/test.patch`.
+3. Run `bash tests/test.sh`; the target behavior should fail before the fix.
+4. Apply `solution/code.patch`.
+5. Run `bash tests/test.sh` again; the target behavior should pass after the gold patch.
+
+## Minimal Test Command
+
+```bash
+bash tests/test.sh
+```
+
+The verifier is responsible for deriving stable F2P and P2P node IDs from repeated runs.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-74421/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-74421/instruction.md
@@ -6,16 +6,24 @@ Paddle 当前没有 `msort` 接口。需要新增 `paddle.msort(input)`，沿输
 
 该接口只接收一个名为 `input` 的 Tensor 参数，不提供 `axis`、`descending` 或 `out` 参数。返回结果的 shape 和 dtype 应与输入保持一致。
 
-除了 `paddle.msort`，还应支持以下调用方式：
+调用方式如下：
 
 ```python
-paddle.tensor.msort(input)
-input.msort()
+import paddle
+x = paddle.to_tensor([[[5,8,9,5],
+                       [0,0,1,7],
+                       [6,9,2,4]],
+                       [[5,2,4,2],
+                       [4,7,7,9],
+                       [1,7,0,6]]],
+                       dtype='float32')
+out = paddle.msort(input=x)
+print(out.numpy())
 ````
 
 ## 验收说明
 
-* `paddle.msort`、`paddle.tensor.msort` 和 `Tensor.msort()` 均可正常调用
+* `paddle.msort` 可正常调用
 * 支持位置参数和 `input=` 关键字参数
 * 无论输入有多少个维度，都固定沿第 0 维升序排序
 * 返回结果的 shape 和 dtype 与输入一致

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-74421/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-74421/instruction.md
@@ -1,0 +1,17 @@
+# 支持 `paddle.msort` 沿第 0 维排序
+
+## 详细描述
+
+Paddle 当前缺少与常见深度学习框架兼容的 `paddle.msort` 公共接口。依赖该接口的代码无法直接在 Paddle 中执行。该接口应接收 Tensor，并返回一个形状和数据类型保持不变的结果，其中元素沿第 0 维按升序排列。
+
+## 验收说明
+
+- `paddle.msort` 应能够接收多维 Tensor，并沿第 0 维按升序返回排序结果。
+- API 应支持通过 `input` 参数调用，并保持返回 Tensor 的形状和数据类型与输入一致。
+- 已有 `paddle.sort` 的有效参数传递和返回行为必须保持不变。
+
+## 技术要求
+
+- 熟悉 Paddle Python Tensor API 及公开 API 暴露方式。
+- 理解多维 Tensor 按指定 axis 排序的行为语义。
+- 能维护新增 API 与既有排序能力之间的兼容性。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-74421/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-74421/instruction.md
@@ -1,17 +1,21 @@
-# 支持 `paddle.msort` 沿第 0 维排序
+# 新增 `paddle.msort` API
 
 ## 详细描述
 
-Paddle 当前缺少与常见深度学习框架兼容的 `paddle.msort` 公共接口。依赖该接口的代码无法直接在 Paddle 中执行。该接口应接收 Tensor，并返回一个形状和数据类型保持不变的结果，其中元素沿第 0 维按升序排列。
+Paddle 当前缺少 `paddle.msort` 公共接口，依赖该接口的代码无法直接在 Paddle 中运行。请新增该 API，使其能够接收一个 Tensor，并沿第 0 维对元素进行升序排序。返回结果的形状和数据类型应与输入保持一致。
 
 ## 验收说明
 
-- `paddle.msort` 应能够接收多维 Tensor，并沿第 0 维按升序返回排序结果。
-- API 应支持通过 `input` 参数调用，并保持返回 Tensor 的形状和数据类型与输入一致。
-- 已有 `paddle.sort` 的有效参数传递和返回行为必须保持不变。
+* `paddle.msort` 应作为公开 API 提供
+* API 应使用 `input` 作为输入参数
+* 对多维 Tensor，应沿第 0 维按升序返回排序结果
+* 返回 Tensor 的形状和数据类型应与输入保持一致
+* API 应能够在动态图和静态图模式下正常使用
+* 现有 `paddle.sort` 的行为不得发生变化
 
 ## 技术要求
 
-- 熟悉 Paddle Python Tensor API 及公开 API 暴露方式。
-- 理解多维 Tensor 按指定 axis 排序的行为语义。
-- 能维护新增 API 与既有排序能力之间的兼容性。
+* 熟悉 Paddle Python Tensor API 及公开 API 的注册方式
+* 理解多维 Tensor 沿指定维度排序的行为
+* 了解 Paddle 动态图和静态图模式下的 API 使用方式
+* 能够维护新增 API 与现有排序功能之间的兼容性

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-74421/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-74421/instruction.md
@@ -2,20 +2,28 @@
 
 ## 详细描述
 
-Paddle 当前缺少 `paddle.msort` 公共接口，依赖该接口的代码无法直接在 Paddle 中运行。请新增该 API，使其能够接收一个 Tensor，并沿第 0 维对元素进行升序排序。返回结果的形状和数据类型应与输入保持一致。
+Paddle 当前没有 `msort` 接口。需要新增 `paddle.msort(input)`，沿输入 Tensor 的第 0 维进行升序排序。
+
+该接口只接收一个名为 `input` 的 Tensor 参数，不提供 `axis`、`descending` 或 `out` 参数。返回结果的 shape 和 dtype 应与输入保持一致。
+
+除了 `paddle.msort`，还应支持以下调用方式：
+
+```python
+paddle.tensor.msort(input)
+input.msort()
+````
 
 ## 验收说明
 
-* `paddle.msort` 应作为公开 API 提供
-* API 应使用 `input` 作为输入参数
-* 对多维 Tensor，应沿第 0 维按升序返回排序结果
-* 返回 Tensor 的形状和数据类型应与输入保持一致
-* API 应能够在动态图和静态图模式下正常使用
-* 现有 `paddle.sort` 的行为不得发生变化
+* `paddle.msort`、`paddle.tensor.msort` 和 `Tensor.msort()` 均可正常调用
+* 支持位置参数和 `input=` 关键字参数
+* 无论输入有多少个维度，都固定沿第 0 维升序排序
+* 返回结果的 shape 和 dtype 与输入一致
+* 在动态图和 `static mode` 下均可正常使用
+* 现有 `paddle.sort` 的行为保持不变
 
 ## 技术要求
 
-* 熟悉 Paddle Python Tensor API 及公开 API 的注册方式
-* 理解多维 Tensor 沿指定维度排序的行为
-* 了解 Paddle 动态图和静态图模式下的 API 使用方式
-* 能够维护新增 API 与现有排序功能之间的兼容性
+* 熟悉 Python
+* 了解 Paddle Tensor API
+* 了解 Paddle API 的导出和 Tensor 方法注册方式

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-74421/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-74421/proposal.md
@@ -1,0 +1,55 @@
+# Task Proposal: PaddlePaddle__Paddle-74421
+
+## 1. 来源信息
+
+- Instance ID：`PaddlePaddle__Paddle-74421`
+- Issue 链接：无独立 issue
+- PR 链接：https://github.com/PaddlePaddle/Paddle/pull/74421
+- PR 标题：`[API compatibility] add msort api`
+- `base_commit`：`0b7e62cbfe2368b51e554cc7c0deb3bd94cad8f7`
+- merged 时间：`2025-08-08`
+- 你的身份：熟悉该模块的 contributor
+- 后续联系人：TBD
+
+## 2. 问题一句话
+
+Paddle 缺少与 `torch.msort` 对齐的公开 API，用户无法通过 `paddle.msort` 将 Tensor 沿第 0 维按升序排序。
+
+## 3. 为什么适合作为 SWE-Paddle 样本
+
+- **真实性**：任务来自已经合入 Paddle `develop` 的 API compatibility PR #74421。
+- **代表性**：覆盖公开 Tensor 排序 API、兼容性迁移以及已有排序能力的复用边界。
+- **边界清楚**：production change 仅涉及 `paddle`/`paddle.tensor` 导出和 `python/paddle/tensor/search.py` 中的新 API。
+- **非平凡性**：修复不仅要提供新入口，还必须保证固定沿 axis 0 升序排序，并保持现有 `sort` contract 不变。
+
+## 4. 任务类型和标签
+
+- 任务类型：`feature_enhancement`
+- 执行后端：`cpu`
+- 设备范围：`cpu_only`
+- 模块标签：`[api_compatibility, tensor, sorting, msort]`
+
+## 5. 验证思路
+
+- 目标测试命令：`bash tests/test.sh`
+- 目标测试文件：`test/swe_paddle/test_pr74421_msort.py`
+- 修复前预期：已有 `sort` dynamic-path contract 继续通过，但 `msort` API 行为测试失败，因为 Base 尚未提供该入口。
+- 修复后预期：已有 `sort` regression 继续通过，`msort` 在 `paddle` 和 `paddle.tensor` 公共命名空间可用，并对多维输入执行 axis 0 升序排序且支持 `input=` 调用。
+- P2P 候选：已有 `sort` 在 dynamic/PIR 路径继续把 axis、descending、stable 参数传递给底层排序并返回排序结果。
+
+## 6. 环境与资源
+
+- 资源需求：CPU
+- Paddle 来源：`PaddlePaddle/Paddle` source checkout at `base_commit`
+- 是否能提供 Docker：暂无
+- patch 类型：Python-only
+- 环境建议：使用 pytest、AST overlay 和 controlled doubles 直接验证 checkout 源码中的 Python control flow。
+- 最小测试命令：`bash tests/test.sh`
+- 是否有 oracle 日志：由 SWE-Paddle verifier 结果另行维护
+
+## 7. 风险自查
+
+- 泄露风险：测试只验证公开排序行为和已有 contract，不匹配 Gold 源码字符串或局部变量名。
+- 环境风险：低；无需导入历史 Paddle native runtime，也无需编译源码。
+- flaky 风险：低；测试使用固定数组和 deterministic doubles，不依赖随机数或并发。
+- 拆分风险：低；新 API 行为与三个 production export/implementation 文件构成单一完整能力。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-74421/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-74421/proposal.md
@@ -2,54 +2,54 @@
 
 ## 1. 来源信息
 
-- Instance ID：`PaddlePaddle__Paddle-74421`
-- Issue 链接：无独立 issue
-- PR 链接：https://github.com/PaddlePaddle/Paddle/pull/74421
-- PR 标题：`[API compatibility] add msort api`
-- `base_commit`：`0b7e62cbfe2368b51e554cc7c0deb3bd94cad8f7`
-- merged 时间：`2025-08-08`
-- 你的身份：熟悉该模块的 contributor
-- 后续联系人：TBD
+* Instance ID：`PaddlePaddle__Paddle-74421`
+* Issue 链接：无独立 issue
+* PR 链接：https://github.com/PaddlePaddle/Paddle/pull/74421
+* PR 标题：`[API compatibility] add msort api`
+* `base_commit`：`0b7e62cbfe2368b51e554cc7c0deb3bd94cad8f7`
+* merged 时间：`2025-08-08`
+* 你的身份：熟悉该模块的 contributor
+* 后续联系人：TBD
 
 ## 2. 问题一句话
 
-Paddle 缺少与 `torch.msort` 对齐的公开 API，用户无法通过 `paddle.msort` 将 Tensor 沿第 0 维按升序排序。
+Paddle 缺少与 `torch.msort` 对齐的公开接口，用户无法通过 `paddle.msort` 对 Tensor 沿第 0 维进行升序排序。
 
 ## 3. 为什么适合作为 SWE-Paddle 样本
 
-- **真实性**：任务来自已经合入 Paddle `develop` 的 API compatibility PR #74421。
-- **代表性**：覆盖公开 Tensor 排序 API、兼容性迁移以及已有排序能力的复用边界。
-- **边界清楚**：production change 仅涉及 `paddle`/`paddle.tensor` 导出和 `python/paddle/tensor/search.py` 中的新 API。
-- **非平凡性**：修复不仅要提供新入口，还必须保证固定沿 axis 0 升序排序，并保持现有 `sort` contract 不变。
+* **真实性**：该任务来自已经合入 Paddle `develop` 分支的 API compatibility PR #74421，不是合成任务。
+* **代表性**：该任务涉及 Tensor 排序 API、公共命名空间导出，以及与其他深度学习框架的接口兼容。
+* **边界清楚**：production change 集中在 `paddle`、`paddle.tensor` 的 API 导出，以及 `python/paddle/tensor/search.py` 中新增的公开接口，改动范围明确。
+* **非平凡性**：任务不仅需要提供新的公开入口，还要保证接口固定沿第 0 维升序排序、支持 `input` 关键字调用，并且不影响现有 `sort` 的行为。
 
 ## 4. 任务类型和标签
 
-- 任务类型：`feature_enhancement`
-- 执行后端：`cpu`
-- 设备范围：`cpu_only`
-- 模块标签：`[api_compatibility, tensor, sorting, msort]`
+* 任务类型：`feature_enhancement`
+* 执行后端：`cpu`
+* 设备范围：`cpu_only`
+* 模块标签：`[api_compatibility, tensor, sorting, msort]`
 
 ## 5. 验证思路
 
-- 目标测试命令：`bash tests/test.sh`
-- 目标测试文件：`test/swe_paddle/test_pr74421_msort.py`
-- 修复前预期：已有 `sort` dynamic-path contract 继续通过，但 `msort` API 行为测试失败，因为 Base 尚未提供该入口。
-- 修复后预期：已有 `sort` regression 继续通过，`msort` 在 `paddle` 和 `paddle.tensor` 公共命名空间可用，并对多维输入执行 axis 0 升序排序且支持 `input=` 调用。
-- P2P 候选：已有 `sort` 在 dynamic/PIR 路径继续把 axis、descending、stable 参数传递给底层排序并返回排序结果。
+* 目标测试命令：`bash tests/test.sh`
+* 目标测试文件：`test/swe_paddle/test_pr74421_msort.py`
+* 修复前预期：在 `base_commit` 上应用 `tests/test.patch` 后，现有 `sort` 动态图路径的行为测试应继续通过；`msort` 相关测试应失败，因为 Base 中尚未提供该公开接口。
+* 修复后预期：继续应用 `solution/code.patch` 后，现有 `sort` 回归测试应继续通过；`msort` 应同时在 `paddle` 和 `paddle.tensor` 公共命名空间中可用，支持通过 `input=` 调用，并能够对多维输入沿第 0 维进行升序排序。
+* P2P 候选：现有 `sort` 在 dynamic/PIR 路径下仍能正确传递 `axis`、`descending` 和 `stable` 参数，并返回原有排序结果。
 
 ## 6. 环境与资源
 
-- 资源需求：CPU
-- Paddle 来源：`PaddlePaddle/Paddle` source checkout at `base_commit`
-- 是否能提供 Docker：暂无
-- patch 类型：Python-only
-- 环境建议：使用 pytest、AST overlay 和 controlled doubles 直接验证 checkout 源码中的 Python control flow。
-- 最小测试命令：`bash tests/test.sh`
-- 是否有 oracle 日志：由 SWE-Paddle verifier 结果另行维护
+* 资源需求：CPU
+* Paddle 来源：`PaddlePaddle/Paddle` source checkout at `base_commit`
+* 是否能提供 Docker：暂无
+* patch 类型：Python-only
+* 环境建议：使用能够运行 `pytest` 的 Python 环境，通过 AST overlay 加载 source checkout 中的相关 Python 逻辑，并使用可控的测试替身补充运行依赖，无需编译 Paddle 源码。
+* 最小测试命令：`bash tests/test.sh`
+* 是否有 oracle 日志：由 SWE-Paddle verifier 结果另行维护
 
 ## 7. 风险自查
 
-- 泄露风险：测试只验证公开排序行为和已有 contract，不匹配 Gold 源码字符串或局部变量名。
-- 环境风险：低；无需导入历史 Paddle native runtime，也无需编译源码。
-- flaky 风险：低；测试使用固定数组和 deterministic doubles，不依赖随机数或并发。
-- 拆分风险：低；新 API 行为与三个 production export/implementation 文件构成单一完整能力。
+* 泄露风险：测试仅验证公开 API 的可用性、排序语义和现有接口的回归行为，不匹配 Gold patch 中的源码文本、局部变量名或具体实现形式。
+* 环境风险：低；测试无需导入历史版本的 Paddle native runtime，也无需编译源码。
+* flaky 风险：低；测试使用固定输入和确定性的测试替身，不依赖随机数、并发执行或异步时序。
+* 拆分风险：低；`msort` 的接口定义、公共命名空间导出和排序行为共同构成一项完整能力，适合作为一个独立样本。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-74421/solution/code.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-74421/solution/code.patch
@@ -1,0 +1,89 @@
+diff --git a/python/paddle/__init__.py b/python/paddle/__init__.py
+index 9111fe8eda5af17c0377cf53e67a212c9630dea4..a138b8d52324f1dd99ddc9526270e25cf529fbbb 100644
+--- a/python/paddle/__init__.py
++++ b/python/paddle/__init__.py
+@@ -579,6 +579,7 @@ from .tensor.search import (
+     kthvalue,
+     masked_select,
+     mode,
++    msort,
+     nonzero,
+     searchsorted,
+     sort,
+@@ -879,6 +880,7 @@ __all__ = [
+     'summary',
+     'flops',
+     'sort',
++    'msort',
+     'searchsorted',
+     'bucketize',
+     'split',
+diff --git a/python/paddle/tensor/__init__.py b/python/paddle/tensor/__init__.py
+index 75d2882a04006fbf085bc95d08f2687db5b7c015..3f0495ac94fffc7bdcc95a557c40f57900136351 100644
+--- a/python/paddle/tensor/__init__.py
++++ b/python/paddle/tensor/__init__.py
+@@ -459,6 +459,7 @@ from .search import (  # noqa: F401
+     kthvalue,
+     masked_select,
+     mode,
++    msort,
+     nonzero,
+     searchsorted,
+     sort,
+@@ -726,6 +727,7 @@ tensor_method_func = [
+     'index_select',
+     'nonzero',
+     'sort',
++    'msort',
+     'index_sample',
+     'mean',
+     'std',
+diff --git a/python/paddle/tensor/search.py b/python/paddle/tensor/search.py
+index 3837d7595f8cc7a33554e33616e29859a0f76891..6b91b36f40fa3a493f8babed6d8f759880bb2381 100755
+--- a/python/paddle/tensor/search.py
++++ b/python/paddle/tensor/search.py
+@@ -676,6 +676,44 @@ def sort(
+         return out
+ 
+ 
++def msort(input: Tensor) -> Tensor:
++    """
++
++    Sorts the input along the given axis = 0, and returns the sorted output tensor. The sort algorithm is ascending.
++
++    Args:
++        input (Tensor): An input N-D Tensor with type float32, float64, int16,
++            int32, int64, uint8.
++
++    Returns:
++        Tensor, sorted tensor(with the same shape and data type as ``input``).
++
++    Examples:
++
++        .. code-block:: python
++
++            >>> import paddle
++
++            >>> x = paddle.to_tensor([[[5,8,9,5],
++            ...                        [0,0,1,7],
++            ...                        [6,9,2,4]],
++            ...                       [[5,2,4,2],
++            ...                        [4,7,7,9],
++            ...                        [1,7,0,6]]],
++            ...                      dtype='float32')
++            >>> out1 = paddle.msort(input=x)
++            >>> print(out1.numpy())
++            [[[5. 2. 4. 2.]
++              [0. 0. 1. 7.]
++              [1. 7. 0. 4.]]
++             [[5. 8. 9. 5.]
++              [4. 7. 7. 9.]
++              [6. 9. 2. 6.]]]
++    """
++
++    return sort(input, axis=0)
++
++
+ def mode(
+     x: Tensor, axis: int = -1, keepdim: bool = False, name: str | None = None
+ ) -> tuple[Tensor, Tensor]:

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-74421/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-74421/tests/test.patch
@@ -1,0 +1,162 @@
+diff --git a/test/swe_paddle/test_pr74421_msort.py b/test/swe_paddle/test_pr74421_msort.py
+new file mode 100644
+index 0000000..54c89f9
+--- /dev/null
++++ b/test/swe_paddle/test_pr74421_msort.py
+@@ -0,0 +1,156 @@
++import ast
++import copy
++import sys
++import types
++from pathlib import Path
++
++import numpy as np
++
++
++TARGET = Path("python/paddle/tensor/search.py")
++
++
++def _extract_function(name, namespace):
++    tree = ast.parse(TARGET.read_text(encoding="utf-8"), filename=str(TARGET))
++    node = next(
++        (
++            copy.deepcopy(item)
++            for item in tree.body
++            if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef))
++            and item.name == name
++        ),
++        None,
++    )
++    assert node is not None, f"paddle.tensor.search must provide {name}"
++    node.decorator_list = []
++    module = ast.Module(body=[node], type_ignores=[])
++    ast.fix_missing_locations(module)
++    scope = dict(namespace)
++    scope.setdefault("Tensor", object)
++    exec(compile(module, str(TARGET), "exec"), scope)
++    return scope[name]
++
++
++def _execute_msort_public_import(path, package_name):
++    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
++    node = next(
++        (
++            copy.deepcopy(item)
++            for item in tree.body
++            if isinstance(item, ast.ImportFrom)
++            and any(alias.name == "msort" for alias in item.names)
++        ),
++        None,
++    )
++    assert node is not None, f"{path} must publicly import msort"
++    assert node.level == 1 and node.module, "msort export must come from paddle package"
++
++    module_parts = node.module.split(".")
++    module_name = ".".join([package_name, *module_parts])
++    module_names = [package_name]
++    for index in range(1, len(module_parts)):
++        module_names.append(".".join([package_name, *module_parts[:index]]))
++    module_names.append(module_name)
++
++    saved = {name: sys.modules.get(name) for name in module_names}
++    for name in module_names[:-1]:
++        package = types.ModuleType(name)
++        package.__path__ = []
++        sys.modules[name] = package
++
++    imported = types.ModuleType(module_name)
++    msort_marker = object()
++    for alias in node.names:
++        setattr(imported, alias.name, msort_marker if alias.name == "msort" else object())
++    sys.modules[module_name] = imported
++
++    try:
++        scope = {"__package__": package_name, "__name__": f"{package_name}.probe"}
++        ast.fix_missing_locations(node)
++        exec(compile(ast.Module(body=[node], type_ignores=[]), str(path), "exec"), scope)
++    finally:
++        for name in reversed(module_names):
++            previous = saved[name]
++            if previous is None:
++                sys.modules.pop(name, None)
++            else:
++                sys.modules[name] = previous
++
++    return scope, msort_marker
++
++
++def test_existing_sort_dynamic_path_remains_compatible():
++    calls = []
++    sorted_result = object()
++    index_result = object()
++
++    class _COps:
++        @staticmethod
++        def argsort(value, axis, descending, stable):
++            calls.append((value, axis, descending, stable))
++            return sorted_result, index_result
++
++    function = _extract_function(
++        "sort",
++        {
++            "Tensor": object,
++            "in_dynamic_or_pir_mode": lambda: True,
++            "_C_ops": _COps,
++        },
++    )
++    tensor = object()
++
++    result = function(tensor, axis=1, descending=True, stable=True)
++
++    assert result is sorted_result
++    assert calls == [(tensor, 1, True, True)]
++
++
++def test_msort_is_reexported_from_public_namespaces():
++    tensor_scope, tensor_marker = _execute_msort_public_import(
++        Path("python/paddle/tensor/__init__.py"),
++        "swe_fake_paddle_tensor",
++    )
++    assert tensor_scope.get("msort") is tensor_marker
++
++    root_scope, root_marker = _execute_msort_public_import(
++        Path("python/paddle/__init__.py"),
++        "swe_fake_paddle",
++    )
++    assert root_scope.get("msort") is root_marker
++
++
++def test_msort_sorts_multidimensional_input_along_axis_zero():
++    calls = []
++
++    def controlled_sort(value, axis=-1, descending=False, stable=False, name=None):
++        calls.append((id(value), axis, descending, stable))
++        return np.sort(value, axis=axis)
++
++    function = _extract_function(
++        "msort",
++        {
++            "Tensor": object,
++            "sort": controlled_sort,
++        },
++    )
++    values = np.array(
++        [
++            [[5, 8, 9, 5], [0, 0, 1, 7], [6, 9, 2, 4]],
++            [[5, 2, 4, 2], [4, 7, 7, 9], [1, 7, 0, 6]],
++        ],
++        dtype="float32",
++    )
++
++    keyword_result = function(input=values)
++    positional_result = function(values)
++
++    expected = np.sort(values, axis=0)
++    np.testing.assert_array_equal(keyword_result, expected)
++    np.testing.assert_array_equal(positional_result, expected)
++    assert keyword_result.shape == values.shape
++    assert keyword_result.dtype == values.dtype
++    assert calls == [
++        (id(values), 0, False, False),
++        (id(values), 0, False, False),
++    ]

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-74421/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-74421/tests/test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python -m pytest test/swe_paddle/test_pr74421_msort.py -q


### PR DESCRIPTION
## 关联

- SWE-Paddle 共建 issue: https://github.com/PaddlePaddle/Paddle/issues/79447
- 来源 PR: https://github.com/PaddlePaddle/Paddle/pull/74421

## 说明

- 新增 SWE-Paddle 任务 `PaddlePaddle__Paddle-74421`

@sunzhongkai588

## 验证结果

| 状态 | Existing `sort` P2P | Public `msort` export F2P | Axis-0 sorting F2P |
| --- | --- | --- | --- |
| Base + `tests/test.patch` | PASS | FAIL，符合预期 | FAIL，符合预期 |
| Base + test patch + `solution/code.patch` | PASS | PASS | PASS |

Base：

```text
P2P: 1 passed
F2P: 2 failed, 1 passed
tests/test.sh exit code: 1
```

Solution：

```text
P2P: PASS
F2P: PASS
Full target test: 3 passed in 0.15s
tests/test.sh: 3 passed in 0.15s
```