### PR TITLE
[SWE-Paddle] Add task PaddlePaddle__Paddle-74586

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-74586/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-74586/README.md
@@ -1,0 +1,44 @@
+# PaddlePaddle__Paddle-74586
+
+This directory converts Paddle PR #74586 into a SWE-Paddle community task candidate.
+
+## Source
+
+| Field | Value |
+| --- | --- |
+| Repo | `PaddlePaddle/Paddle` |
+| PR | [74586](https://github.com/PaddlePaddle/Paddle/pull/74586) |
+| PR title | `[API compatibility] add scatter_add api` |
+| Base commit | `e5c11eb4ab20851a6ab76bd0a85c8650b20b0692` |
+| Merged at | `2025-08-21` |
+| Task type | `feature_enhancement` |
+| Resource | CPU |
+
+## Summary
+
+Add the public `paddle.scatter_add` API so indexed source values are accumulated into an input tensor along a selected dimension, while preserving existing tensor-manipulation behavior.
+
+## Why This Is A Good SWE-Paddle Candidate
+
+- The change comes from a merged Paddle API-compatibility PR with a compact Python production scope.
+- The target behavior is externally observable through indexed additive updates and public namespace exposure.
+- The task has a clear fail-to-pass boundary because the API is absent at the base commit.
+- Existing manipulation behavior can be protected with a stable P2P regression test.
+
+## Files
+
+- `proposal.md`: candidate proposal for maintainer triage.
+- `instruction.md`: self-contained problem statement for the coding agent.
+- `solution/code.patch`: production-only gold patch derived from the merged PR.
+- `tests/test.patch`: test patch exposing the target behavior.
+- `tests/test.sh`: minimal target test command.
+- `environment/README.md`: environment notes for reproduction.
+- `README.md`: task overview and verification entrypoint.
+
+## Verification
+
+```bash
+bash tests/test.sh
+```
+
+Expected behavior: applying `tests/test.patch` to the base commit should fail on the new `scatter_add` behavior while the P2P case remains valid; applying both `tests/test.patch` and `solution/code.patch` should pass all target tests.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-74586/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-74586/environment/README.md
@@ -1,0 +1,27 @@
+# Environment Notes
+
+This candidate is part of the SWE-Paddle community task set.
+
+## Expected Environment
+
+- Repository: `PaddlePaddle/Paddle`
+- Base commit: `e5c11eb4ab20851a6ab76bd0a85c8650b20b0692`
+- Resource: CPU
+- GPU required: no
+- Build path: Paddle source checkout at the base commit. This Python-only task may be verified with an AST overlay and controlled doubles; source build is not required.
+
+## Run Order
+
+1. Check out `PaddlePaddle/Paddle` at the base commit.
+2. Apply `tests/test.patch`.
+3. Run `bash tests/test.sh`; the target behavior should fail before the fix.
+4. Apply `solution/code.patch`.
+5. Run `bash tests/test.sh` again; the target behavior should pass after the gold patch.
+
+## Minimal Test Command
+
+```bash
+bash tests/test.sh
+```
+
+The verifier is responsible for deriving stable F2P and P2P node IDs from repeated runs.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-74586/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-74586/instruction.md
@@ -1,0 +1,17 @@
+# 为 Paddle 增加 scatter_add 张量累加接口
+
+## 详细描述
+
+Paddle 当前缺少与常见张量库兼容的 `scatter_add` 公共接口。用户需要能够根据索引张量，在指定维度上把源张量中的值累加到输入张量对应位置，并从 `paddle` 与 `paddle.tensor` 公共命名空间访问该接口。重复索引应产生累加效果，而不是覆盖已有值。
+
+## 验收说明
+
+- `scatter_add` 应支持按指定维度根据索引将源值累加到输入张量，并正确处理重复索引。
+- 该接口应能够通过 `paddle.scatter_add` 和 `paddle.tensor.scatter_add` 访问。
+- 已有的张量 manipulation API 行为应保持兼容，不因新增接口发生回归。
+
+## 技术要求
+
+- 熟悉 Python API 设计与张量索引语义。
+- 理解 scatter/add 类操作的维度、索引和累加行为。
+- 能够维护 Paddle 公共 API 导出与现有 manipulation 模块兼容性。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-74586/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-74586/instruction.md
@@ -2,27 +2,34 @@
 
 ## 详细描述
 
-Paddle 当前缺少用于按索引累加 Tensor 元素的 `scatter_add` 公共接口。为提升接口兼容性，调用方需要能够指定操作维度，并根据索引将源 Tensor 中的值累加到输入 Tensor 的对应位置。
+Paddle 目前缺少 `scatter_add` 接口。
 
-请新增 `paddle.scatter_add`。当多个源元素指向同一位置时，应对这些值进行累加，而不是相互覆盖。返回结果应保留输入 Tensor 的形状和数据类型。
+现在需要新增 `paddle.scatter_add(input, dim, index, src)`，以 `input` 为初始结果，按照 `index` 指定的位置，将 `src` 中的值沿 `dim` 维累加进去。
 
-该接口应支持动态图和静态图模式，并能够从 `paddle` 和 `paddle.tensor` 公共命名空间访问。现有 Tensor 操作接口的合法调用方式和行为不得受到影响。
+当多个索引指向同一位置时，这些值都应累加，不能相互覆盖。该接口返回新的 Tensor，不修改输入的 `input`。
+
+同时支持以下调用方式：
+
+```python
+paddle.scatter_add(input, dim, index, src)
+paddle.tensor.scatter_add(input, dim, index, src)
+input.scatter_add(dim, index, src)
+````
 
 ## 验收说明
 
-* 提供公开的 `paddle.scatter_add` API，并能够通过 `paddle.tensor.scatter_add` 访问
-* API 应支持通过 `input`、`dim`、`index` 和 `src` 参数调用
-* 应根据 `index` 在指定维度上将 `src` 中的值累加到 `input` 的对应位置
-* 多个索引指向同一位置时，对应值应正确累加
-* 返回 Tensor 的形状和数据类型应与输入保持一致
-* 有效的正维度和负维度参数均应得到正确处理
-* API 应能够在动态图和静态图模式下正常使用
-* 反向传播行为应保持正确
-* 索引类型不合法、输入形状不兼容或索引越界时，应给出明确的异常
-* 现有 Tensor manipulation API 的行为不得发生变化
+* 支持 `input`、`dim`、`index` 和 `src` 参数
+* 应在 `input` 原有数据的基础上累加 `src`
+* 多个索引指向同一位置时，应正确累加所有对应值
+* 返回结果的 shape 和 dtype 应与 `input` 保持一致
+* `index` 支持 `int32` 和 `int64`
+* `src` 的 dtype 应与 `input` 一致
+* 调用后不应修改 `input`
+* 三种调用方式应得到相同结果
+* 现有 Tensor 操作接口的行为保持不变
 
 ## 技术要求
 
-* 熟悉 Paddle Python Tensor API 及公共接口导出方式
-* 理解 scatter 类操作的维度、索引和累加语义
-* 了解 Paddle 动态图、静态图和自动求导机制
+* 熟悉 Python
+* 了解 Paddle Tensor API
+* 了解按索引进行数据更新和累加的方式

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-74586/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-74586/instruction.md
@@ -1,17 +1,28 @@
-# 为 Paddle 增加 scatter_add 张量累加接口
+# 新增 `paddle.scatter_add` API
 
 ## 详细描述
 
-Paddle 当前缺少与常见张量库兼容的 `scatter_add` 公共接口。用户需要能够根据索引张量，在指定维度上把源张量中的值累加到输入张量对应位置，并从 `paddle` 与 `paddle.tensor` 公共命名空间访问该接口。重复索引应产生累加效果，而不是覆盖已有值。
+Paddle 当前缺少用于按索引累加 Tensor 元素的 `scatter_add` 公共接口。为提升接口兼容性，调用方需要能够指定操作维度，并根据索引将源 Tensor 中的值累加到输入 Tensor 的对应位置。
+
+请新增 `paddle.scatter_add`。当多个源元素指向同一位置时，应对这些值进行累加，而不是相互覆盖。返回结果应保留输入 Tensor 的形状和数据类型。
+
+该接口应支持动态图和静态图模式，并能够从 `paddle` 和 `paddle.tensor` 公共命名空间访问。现有 Tensor 操作接口的合法调用方式和行为不得受到影响。
 
 ## 验收说明
 
-- `scatter_add` 应支持按指定维度根据索引将源值累加到输入张量，并正确处理重复索引。
-- 该接口应能够通过 `paddle.scatter_add` 和 `paddle.tensor.scatter_add` 访问。
-- 已有的张量 manipulation API 行为应保持兼容，不因新增接口发生回归。
+* 提供公开的 `paddle.scatter_add` API，并能够通过 `paddle.tensor.scatter_add` 访问
+* API 应支持通过 `input`、`dim`、`index` 和 `src` 参数调用
+* 应根据 `index` 在指定维度上将 `src` 中的值累加到 `input` 的对应位置
+* 多个索引指向同一位置时，对应值应正确累加
+* 返回 Tensor 的形状和数据类型应与输入保持一致
+* 有效的正维度和负维度参数均应得到正确处理
+* API 应能够在动态图和静态图模式下正常使用
+* 反向传播行为应保持正确
+* 索引类型不合法、输入形状不兼容或索引越界时，应给出明确的异常
+* 现有 Tensor manipulation API 的行为不得发生变化
 
 ## 技术要求
 
-- 熟悉 Python API 设计与张量索引语义。
-- 理解 scatter/add 类操作的维度、索引和累加行为。
-- 能够维护 Paddle 公共 API 导出与现有 manipulation 模块兼容性。
+* 熟悉 Paddle Python Tensor API 及公共接口导出方式
+* 理解 scatter 类操作的维度、索引和累加语义
+* 了解 Paddle 动态图、静态图和自动求导机制

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-74586/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-74586/proposal.md
@@ -2,55 +2,53 @@
 
 ## 1. 来源信息
 
-- Instance ID：`PaddlePaddle__Paddle-74586`
-- PR 链接：https://github.com/PaddlePaddle/Paddle/pull/74586
-- PR 标题：`[API compatibility] add scatter_add api`
-- `base_commit`：`e5c11eb4ab20851a6ab76bd0a85c8650b20b0692`
-- merged 时间：`2025-08-21`
-- 你的身份：熟悉该模块的 contributor
-- 后续联系人：TBD
+* Instance ID：`PaddlePaddle__Paddle-74586`
+* PR 链接：https://github.com/PaddlePaddle/Paddle/pull/74586
+* PR 标题：`[API compatibility] add scatter_add api`
+* `base_commit`：`e5c11eb4ab20851a6ab76bd0a85c8650b20b0692`
+* merged 时间：`2025-08-21`
+* 你的身份：熟悉该模块的 contributor
+* 后续联系人：TBD
 
 ## 2. 问题一句话
 
-Paddle 缺少可从公共命名空间调用、并按索引在指定维度执行累加语义的 `scatter_add` API。
+为 Paddle 新增公开的 `scatter_add` API，使调用方能够根据索引在指定维度上，将源 Tensor 中的值累加到输入 Tensor 的对应位置。
 
 ## 3. 为什么适合作为 SWE-Paddle 样本
 
-- **真实性**：来源于已合入 Paddle `develop` 的 API compatibility PR。
-- **代表性**：覆盖常见的张量 scatter-add 兼容接口与公共 API 暴露问题。
-- **边界清楚**：Base 不提供该 API，Gold 提供后可直接观察重复索引的累加结果。
-- **非平凡性**：不仅需要新增接口，还必须保持指定维度、索引映射和 existing-input accumulation 的语义。
-- **环境友好性**：核心 Python 控制流可通过 AST overlay 与 controlled double 稳定验证，无需完整 source build。
+* **真实性**：该任务来自已合入 Paddle `develop` 分支的 API compatibility PR，不是人工构造的需求。
+* **代表性**：该任务涉及常用的 Tensor 索引累加操作、公共 API 导出，以及与其他深度学习框架的接口兼容。
+* **边界清楚**：Base 中尚未提供 `scatter_add`，新增接口后的公共可见性和索引累加结果均可通过独立测试直接验证。
+* **非平凡性**：任务不仅需要新增公共接口，还要正确处理指定维度、索引映射、重复索引累加，以及在输入 Tensor 原有值基础上的更新语义。
 
 ## 4. 任务类型和标签
 
-- 任务类型：`feature_enhancement`
-- 执行后端：`cpu`
-- 设备范围：`cpu_only`
-- 模块标签：`[api_compatibility, tensor, manipulation, scatter]`
+* 任务类型：`feature_enhancement`
+* 执行后端：`cpu`
+* 设备范围：`cpu_only`
+* 模块标签：`[api_compatibility, tensor, manipulation, scatter]`
 
 ## 5. 验证思路
 
-- 目标测试命令：`bash tests/test.sh`
-- 目标测试文件：`test/swe_paddle/test_pr74586_scatter_add.py`
-- 修复前预期：已有 manipulation P2P 通过；`scatter_add` 行为与公共导出 F2P 失败。
-- 修复后预期：P2P 与所有 F2P 均通过。
-- P2P 候选：验证现有 `index_add` dynamic path 的参数传递和返回值保持不变。
-- F2P 设计：通过 AST overlay 执行 checkout 中真实 `scatter_add` 函数体，并使用 controlled `put_along_axis` double 验证重复索引累加结果；另验证两个公共命名空间导出。
+* 目标测试命令：`bash tests/test.sh`
+* 目标测试文件：`test/swe_paddle/test_pr74586_scatter_add.py`
+* 修复前预期：现有 Tensor manipulation 接口的 P2P 测试应通过；`scatter_add` 的公共导出和索引累加行为测试应失败。
+* 修复后预期：继续应用 `solution/code.patch` 后，P2P 与全部 F2P 均应通过；`scatter_add` 应能够从两个公共命名空间访问，并正确执行索引累加。
+* P2P 候选：现有 `index_add` 在动态图路径下的参数传递、底层调用和返回行为保持不变。
+* F2P 设计：验证 `scatter_add` 能够在输入 Tensor 原有值的基础上进行累加，并正确处理不同维度和重复索引；同时验证该接口能够从 `paddle` 和 `paddle.tensor` 公共命名空间访问。
 
 ## 6. 环境与资源
 
-- 资源需求：CPU
-- Paddle 来源：`PaddlePaddle/Paddle` source checkout at `base_commit`
-- 是否能提供 Docker：暂无
-- patch 类型：Python-only
-- 环境建议：使用 pytest、NumPy 和 AST overlay；无需导入历史源码对应的完整 Paddle wheel。
-- 最小测试命令：`bash tests/test.sh`
-- 是否有 oracle 日志：由 SWE-Paddle verifier 结果另行维护
+* 资源需求：CPU
+* Paddle 来源：`PaddlePaddle/Paddle` source checkout at `base_commit`
+* 是否能提供 Docker：暂无
+* patch 类型：Python-only
+* 最小测试命令：`bash tests/test.sh`
+* 是否有 oracle 日志：由 SWE-Paddle verifier 结果另行维护
 
 ## 7. 风险自查
 
-- 泄露风险：测试验证公开行为和真实函数控制流，不检查 Gold 源码字符串或内部局部变量名。
-- 环境风险：低；Python-only，CPU 即可，无需 CUDA 或 source build。
-- flaky 风险：低；测试使用固定 NumPy 输入和 controlled doubles，不依赖随机时序。
-- 拆分风险：低；production 改动集中在 manipulation API 及两处公共导出。
+* 泄露风险：`instruction.md` 只描述 `scatter_add` 的公共接口、索引累加语义和兼容性要求，不透露 Gold patch 使用的内部函数、参数组合或具体修改位置。
+* 环境风险：通过 AST overlay 隔离 source checkout 与当前运行环境之间的版本差异，避免依赖历史 Paddle package 的完整导入和 native extension。
+* flaky 风险：测试使用固定的 NumPy 输入、索引和确定性的 Tensor 操作替身，不依赖随机数、GPU、并发或异步时序。
+* 拆分风险：`scatter_add` 的函数实现和两个公共命名空间导出共同构成一项完整的 API compatibility 能力，适合作为单个任务。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-74586/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-74586/proposal.md
@@ -1,0 +1,56 @@
+# Task Proposal: PaddlePaddle__Paddle-74586
+
+## 1. 来源信息
+
+- Instance ID：`PaddlePaddle__Paddle-74586`
+- PR 链接：https://github.com/PaddlePaddle/Paddle/pull/74586
+- PR 标题：`[API compatibility] add scatter_add api`
+- `base_commit`：`e5c11eb4ab20851a6ab76bd0a85c8650b20b0692`
+- merged 时间：`2025-08-21`
+- 你的身份：熟悉该模块的 contributor
+- 后续联系人：TBD
+
+## 2. 问题一句话
+
+Paddle 缺少可从公共命名空间调用、并按索引在指定维度执行累加语义的 `scatter_add` API。
+
+## 3. 为什么适合作为 SWE-Paddle 样本
+
+- **真实性**：来源于已合入 Paddle `develop` 的 API compatibility PR。
+- **代表性**：覆盖常见的张量 scatter-add 兼容接口与公共 API 暴露问题。
+- **边界清楚**：Base 不提供该 API，Gold 提供后可直接观察重复索引的累加结果。
+- **非平凡性**：不仅需要新增接口，还必须保持指定维度、索引映射和 existing-input accumulation 的语义。
+- **环境友好性**：核心 Python 控制流可通过 AST overlay 与 controlled double 稳定验证，无需完整 source build。
+
+## 4. 任务类型和标签
+
+- 任务类型：`feature_enhancement`
+- 执行后端：`cpu`
+- 设备范围：`cpu_only`
+- 模块标签：`[api_compatibility, tensor, manipulation, scatter]`
+
+## 5. 验证思路
+
+- 目标测试命令：`bash tests/test.sh`
+- 目标测试文件：`test/swe_paddle/test_pr74586_scatter_add.py`
+- 修复前预期：已有 manipulation P2P 通过；`scatter_add` 行为与公共导出 F2P 失败。
+- 修复后预期：P2P 与所有 F2P 均通过。
+- P2P 候选：验证现有 `index_add` dynamic path 的参数传递和返回值保持不变。
+- F2P 设计：通过 AST overlay 执行 checkout 中真实 `scatter_add` 函数体，并使用 controlled `put_along_axis` double 验证重复索引累加结果；另验证两个公共命名空间导出。
+
+## 6. 环境与资源
+
+- 资源需求：CPU
+- Paddle 来源：`PaddlePaddle/Paddle` source checkout at `base_commit`
+- 是否能提供 Docker：暂无
+- patch 类型：Python-only
+- 环境建议：使用 pytest、NumPy 和 AST overlay；无需导入历史源码对应的完整 Paddle wheel。
+- 最小测试命令：`bash tests/test.sh`
+- 是否有 oracle 日志：由 SWE-Paddle verifier 结果另行维护
+
+## 7. 风险自查
+
+- 泄露风险：测试验证公开行为和真实函数控制流，不检查 Gold 源码字符串或内部局部变量名。
+- 环境风险：低；Python-only，CPU 即可，无需 CUDA 或 source build。
+- flaky 风险：低；测试使用固定 NumPy 输入和 controlled doubles，不依赖随机时序。
+- 拆分风险：低；production 改动集中在 manipulation API 及两处公共导出。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-74586/solution/code.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-74586/solution/code.patch
@@ -1,0 +1,92 @@
+diff --git a/python/paddle/__init__.py b/python/paddle/__init__.py
+index 3ebe1ebb0fdddcba22c6435fc85ea93ad2d3cc21..ef49fc73690d71db7a13bb333f9bbb1f2d4b83bf 100644
+--- a/python/paddle/__init__.py
++++ b/python/paddle/__init__.py
+@@ -368,6 +368,7 @@ from .tensor.manipulation import (
+     row_stack,
+     scatter,
+     scatter_,
++    scatter_add,
+     scatter_nd,
+     scatter_nd_add,
+     scatter_reduce,
+@@ -1262,6 +1263,7 @@ __all__ = [
+     'take_along_axis',
+     'scatter_reduce',
+     'put_along_axis',
++    'scatter_add',
+     'select_scatter',
+     'multigammaln',
+     'multigammaln_',
+diff --git a/python/paddle/tensor/__init__.py b/python/paddle/tensor/__init__.py
+index 61d2d9913846cad681072cca2a38ff770f8bf0b8..6b7f497615d8045126243e80f8130565ad2093b6 100644
+--- a/python/paddle/tensor/__init__.py
++++ b/python/paddle/tensor/__init__.py
+@@ -205,6 +205,7 @@ from .manipulation import (  # noqa: F401
+     row_stack,
+     scatter,
+     scatter_,
++    scatter_add,
+     scatter_nd,
+     scatter_nd_add,
+     scatter_reduce,
+@@ -822,6 +823,7 @@ tensor_method_func = [
+     'take_along_axis',
+     'scatter_reduce',
+     'put_along_axis',
++    'scatter_add',
+     'select_scatter',
+     'put_along_axis_',
+     'bernoulli_',
+diff --git a/python/paddle/tensor/manipulation.py b/python/paddle/tensor/manipulation.py
+index 9497ab0f7568fc2a151f344ddb1e8dbf9c97942e..403f48d17c23343f4b2ddf95d3e543b7db48d8f3 100644
+--- a/python/paddle/tensor/manipulation.py
++++ b/python/paddle/tensor/manipulation.py
+@@ -6866,6 +6866,47 @@ def infer_broadcast_shape(
+     return broadcast_shape
+ 
+ 
++def scatter_add(
++    input: Tensor,
++    dim: int,
++    index: Tensor,
++    src: Tensor,
++) -> Tensor:
++    """
++    Scatter the values of the source tensor to the target tensor according to the given indices, and perform a add operation along the designated axis.
++
++    Args:
++        input (Tensor) : The Input Tensor. Supported data types are bfloat16, float16, float32, float64,
++            int32, int64, uint8.
++        dim (int) : The axis to scatter 1d slices along.
++        index (Tensor) : Indices to scatter along each 1d slice of input. This must match the dimension of input,
++             Supported data type are int32 and int64.
++        src (Tensor) : The value element(s) to scatter. The data types should be same as input.
++
++    Returns:
++        Tensor, The indexed element, same dtype with input
++
++    Examples:
++        .. code-block:: python
++
++            >>> import paddle
++
++            >>> x = paddle.to_tensor([[10, 20, 30], [40, 50, 60]])
++            >>> indices = paddle.zeros((2,3)).astype("int32")
++            >>> values = paddle.to_tensor([[1, 2, 3],[4, 5, 6]]).astype(x.dtype)
++            >>> result = paddle.scatter_add(x, 0, indices, values)
++            >>> print(result)
++            Tensor(shape=[2, 3], dtype=int64, place=Place(cpu), stop_gradient=True,
++            [[15, 27, 39],
++             [40, 50, 60]])
++
++    """
++
++    return put_along_axis(
++        input, index, src, dim, 'add', include_self=True, broadcast=False
++    )
++
++
+ @ParamAliasDecorator({"arr": ["input"], "axis": ["dim"]})
+ def take_along_axis(
+     arr: Tensor, indices: Tensor, axis: int, broadcast: bool = True

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-74586/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-74586/tests/test.patch
@@ -1,0 +1,180 @@
+diff --git a/test/swe_paddle/test_pr74586_scatter_add.py b/test/swe_paddle/test_pr74586_scatter_add.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..c08c0ef7ffef990e371d95c1d41a56eee1c5b9c2
+--- /dev/null
++++ b/test/swe_paddle/test_pr74586_scatter_add.py
+@@ -0,0 +1,174 @@
++import ast
++import copy
++import sys
++import types
++from pathlib import Path
++
++import numpy as np
++
++
++TARGET = Path("python/paddle/tensor/manipulation.py")
++
++
++def _extract_function(name, namespace):
++    tree = ast.parse(TARGET.read_text(encoding="utf-8"), filename=str(TARGET))
++    node = next(
++        (
++            copy.deepcopy(item)
++            for item in tree.body
++            if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef))
++            and item.name == name
++        ),
++        None,
++    )
++    assert node is not None, f"paddle.tensor.manipulation must provide {name}"
++    node.decorator_list = []
++    module = ast.Module(body=[node], type_ignores=[])
++    ast.fix_missing_locations(module)
++    scope = dict(namespace)
++    scope.setdefault("Tensor", object)
++    exec(compile(module, str(TARGET), "exec"), scope)
++    return scope[name]
++
++
++def _execute_public_import(path, package_name):
++    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
++    node = next(
++        (
++            copy.deepcopy(item)
++            for item in tree.body
++            if isinstance(item, ast.ImportFrom)
++            and any(alias.name == "scatter_add" for alias in item.names)
++        ),
++        None,
++    )
++    assert node is not None, f"{path} must publicly import scatter_add"
++    assert node.level == 1 and node.module
++
++    module_parts = node.module.split(".")
++    module_name = ".".join([package_name, *module_parts])
++    module_names = [package_name]
++    for index in range(1, len(module_parts)):
++        module_names.append(".".join([package_name, *module_parts[:index]]))
++    module_names.append(module_name)
++
++    saved = {name: sys.modules.get(name) for name in module_names}
++    for name in module_names[:-1]:
++        package = types.ModuleType(name)
++        package.__path__ = []
++        sys.modules[name] = package
++
++    imported = types.ModuleType(module_name)
++    marker = object()
++    for alias in node.names:
++        setattr(
++            imported,
++            alias.name,
++            marker if alias.name == "scatter_add" else object(),
++        )
++    sys.modules[module_name] = imported
++
++    try:
++        scope = {"__package__": package_name, "__name__": f"{package_name}.probe"}
++        ast.fix_missing_locations(node)
++        exec(
++            compile(ast.Module(body=[node], type_ignores=[]), str(path), "exec"),
++            scope,
++        )
++    finally:
++        for name in reversed(module_names):
++            previous = saved[name]
++            if previous is None:
++                sys.modules.pop(name, None)
++            else:
++                sys.modules[name] = previous
++
++    return scope, marker
++
++
++def test_existing_index_add_dynamic_path_remains_compatible():
++    calls = []
++    result_marker = object()
++
++    class _COps:
++        @staticmethod
++        def index_add(x, index, value, axis):
++            calls.append((x, index, value, axis))
++            return result_marker
++
++    function = _extract_function(
++        "index_add",
++        {
++            "Tensor": object,
++            "in_dynamic_or_pir_mode": lambda: True,
++            "_C_ops": _COps,
++        },
++    )
++    x = object()
++    index = object()
++    value = object()
++
++    result = function(x, index, 1, value)
++
++    assert result is result_marker
++    assert calls == [(x, index, value, 1)]
++
++
++def test_scatter_add_accumulates_repeated_indices_along_requested_dim():
++    calls = []
++
++    def controlled_put_along_axis(
++        arr,
++        indices,
++        values,
++        axis,
++        reduce="assign",
++        include_self=True,
++        broadcast=True,
++    ):
++        calls.append((axis, reduce, include_self, broadcast))
++        assert reduce == "add"
++        assert include_self is True
++        assert broadcast is False
++        result = np.array(arr, copy=True)
++        for source_position in np.ndindex(indices.shape):
++            target_position = list(source_position)
++            target_position[axis] = int(indices[source_position])
++            result[tuple(target_position)] += values[source_position]
++        return result
++
++    function = _extract_function(
++        "scatter_add",
++        {
++            "Tensor": object,
++            "put_along_axis": controlled_put_along_axis,
++        },
++    )
++
++    input_value = np.array([[10, 20, 30], [40, 50, 60]], dtype="int64")
++    index = np.array([[0, 1, 1], [0, 1, 1]], dtype="int64")
++    src = np.array([[1, 2, 3], [4, 5, 6]], dtype="int64")
++
++    result = function(input_value, 1, index, src)
++
++    expected = np.array([[11, 25, 30], [44, 61, 60]], dtype="int64")
++    np.testing.assert_array_equal(result, expected)
++    np.testing.assert_array_equal(
++        input_value,
++        np.array([[10, 20, 30], [40, 50, 60]], dtype="int64"),
++    )
++    assert calls == [(1, "add", True, False)]
++
++
++def test_scatter_add_is_reexported_from_public_namespaces():
++    tensor_scope, tensor_marker = _execute_public_import(
++        Path("python/paddle/tensor/__init__.py"),
++        "swe_fake_paddle_tensor",
++    )
++    assert tensor_scope.get("scatter_add") is tensor_marker
++
++    root_scope, root_marker = _execute_public_import(
++        Path("python/paddle/__init__.py"),
++        "swe_fake_paddle",
++    )
++    assert root_scope.get("scatter_add") is root_marker

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-74586/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-74586/tests/test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python -m pytest test/swe_paddle/test_pr74586_scatter_add.py -q


### PR DESCRIPTION
# 关联

- SWE-Paddle 共建 issue: https://github.com/PaddlePaddle/Paddle/issues/79447
- 来源 PR: https://github.com/PaddlePaddle/Paddle/pull/74586

## 说明

- 新增 SWE-Paddle 任务 `PaddlePaddle__Paddle-74586`

@sunzhongkai588

## 验证结果

| 状态 | Existing `index_add` P2P | Repeated-index accumulation F2P | Public export F2P |
| --- | --- | --- | --- |
| Base + `tests/test.patch` | PASS | FAIL，符合预期 | FAIL，符合预期 |
| Base + test patch + `solution/code.patch` | PASS | PASS | PASS |

Base：

```text
P2P: 1 passed
F2P: 2 failed, 1 passed
```

Solution：

```text
P2P: PASS
F2P: PASS
Full target test: 3 passed in 0.23s
tests/test.sh: 3 passed in 0.19s
```