### PR TITLE
[SWE-Paddle] Add task PaddlePaddle__Paddle-74221

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-74221/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-74221/README.md
@@ -1,0 +1,51 @@
+# PaddlePaddle__Paddle-74221
+
+This directory converts Paddle PR #74221 into a SWE-Paddle community task candidate.
+
+## Source
+
+| Field | Value |
+| --- | --- |
+| Repo | `PaddlePaddle/Paddle` |
+| PR | [74221](https://github.com/PaddlePaddle/Paddle/pull/74221) |
+| PR title | `[0-size Tensor No.169] Add 0-size Tensor support for paddle.nn.functional.fold` |
+| Base commit | `3bfdd753fa54582b0a2ab6b47e4ea8092cec8187` |
+| Gold commit | `763c9f253350af557a781c27c40bc1a2b7b350d2` |
+| Merged at | `2025-07-26` |
+| Task type | `bug_fix` |
+| Resource | CPU |
+| Scope | Python nn.functional API |
+
+## Summary
+
+Fix `paddle.nn.functional.fold` to properly validate and reject 0-size tensor inputs with a clear `AssertionError`.
+
+## Why This Is A Good SWE-Paddle Candidate
+
+- It is derived from a merged Paddle bug-fix PR rather than a synthetic issue.
+- The target behavior is isolated to the Python nn.functional API and does not require rebuilding C++ kernels.
+- The failure is deterministic: the base revision lacks proper validation for 0-size tensor inputs.
+- The task has clear regression coverage for existing non-zero-size behavior.
+- The task runs on CPU and does not require distributed execution, external services, or additional datasets.
+
+## Files
+
+- `proposal.md`: candidate proposal for maintainer triage.
+- `instruction.md`: self-contained problem statement for the coding agent.
+- `solution/code.patch`: gold implementation patch.
+- `tests/test.patch`: tests exposing the target behavior.
+- `tests/test.sh`: minimal target test command.
+- `environment/README.md`: environment and reproduction notes.
+
+## Verification
+
+```bash
+bash tests/test.sh
+```
+
+Expected behavior:
+
+| Revision state | Existing behavior (P2P) | fold F2P |
+| --- | ---: | ---: |
+| Base + `tests/test.patch` | PASS | FAIL |
+| Base + `tests/test.patch` + `solution/code.patch` | PASS | PASS |

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-74221/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-74221/environment/README.md
@@ -1,0 +1,37 @@
+# Environment Notes
+
+## Expected Environment
+
+- Repository: `PaddlePaddle/Paddle`
+- Base commit: `3bfdd753fa54582b0a2ab6b47e4ea8092cec8187`
+- Gold commit: `763c9f253350af557a781c27c40bc1a2b7b350d2`
+- Resource: CPU
+- GPU required: no
+- Patch type: Python-only
+- Python dependencies: PaddlePaddle, NumPy, pytest
+
+The verifier should execute against the Paddle source revision represented by the selected patch state. A source build is not required when an equivalent Python overlay is available and the underlying runtime remains API-compatible.
+
+## Run Order
+
+1. Check out `PaddlePaddle/Paddle` at the base commit.
+2. Apply `tests/test.patch`.
+3. Run the P2P tests; existing error-handling behavior should pass.
+4. Run the 0-size tensor tests; the target case should fail before the fix.
+5. Apply `solution/code.patch`.
+6. Run `bash tests/test.sh`; all target tests should pass.
+
+## Minimal Test Command
+
+```bash
+bash tests/test.sh
+```
+
+## Expected Matrix
+
+| Revision state | P2P | fold F2P |
+| --- | ---: | ---: |
+| Base + test patch | PASS | FAIL |
+| Base + test patch + solution patch | PASS | PASS |
+
+No GPU, distributed runtime, external service, or additional dataset is required.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-74221/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-74221/instruction.md
@@ -1,0 +1,45 @@
+# 修复 `paddle.nn.functional.fold` 对 0-size Tensor 的处理
+
+## 详细描述
+
+当 `paddle.nn.functional.fold(x, ...)` 的输入 `x` 中存在大小为 `0` 的 dimension，即 `x.numel() == 0` 时，当前实现缺少显式的输入校验，导致后续计算出现不可预期的错误或产生不正确的结果。
+
+典型表现包括：
+
+- 后续计算在处理 0-size tensor 时可能出现除零、索引越界等异常
+- 错误信息不明确，难以定位问题根因
+
+例如：
+
+```python
+import paddle
+from paddle.nn.functional import fold
+
+x = paddle.randn(shape=[0, 1, 1], dtype="float32")
+out = fold(
+    x,
+    output_sizes=[0, 0],
+    kernel_sizes=[0, 0],
+    dilations=0,
+    paddings=[0, 0],
+    strides=0,
+)
+```
+
+上述调用中 `x` 的 shape 为 `[0, 1, 1]`，不包含任何元素。按照 API semantics，`fold` 操作要求输入 tensor 至少包含一个元素，当输入 tensor 的任意维度为 0 时，应抛出明确的 `AssertionError`，提示用户输入不合法。
+
+当前 Python 层在进入后续计算之前，没有对 0-size tensor 输入进行显式的断言检查。当输入 tensor 的元素个数为 0 时，应在现有的 shape 校验之后，添加对元素个数的断言，确保输入 tensor 至少包含一个元素。
+
+## 验收说明
+
+- 当输入 tensor 的元素个数为 0 时，`paddle.nn.functional.fold` 应抛出 `AssertionError`
+- 错误信息应明确指出"The number of elements must greater than zero."
+- 非 0-size tensor 输入下的 fold 行为不得退化
+- 现有的其他错误检查（如 input shape、kernel shape 等）应继续正常工作
+
+## 技术要求
+
+- 熟悉 Python 和 Paddle Tensor API
+- 了解 Tensor shape、0-size Tensor 和动态图执行路径
+- 了解 fold 算子的输入输出语义
+- 了解 Paddle 动态图和静态图执行路径的区别

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-74221/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-74221/proposal.md
@@ -1,0 +1,58 @@
+# Task Proposal: PaddlePaddle__Paddle-74221
+
+## 1. 来源信息
+
+- Instance ID：`PaddlePaddle__Paddle-74221`
+- PR 链接：https://github.com/PaddlePaddle/Paddle/pull/74221
+- PR 标题：`[0-size Tensor No.169] Add 0-size Tensor support for paddle.nn.functional.fold`
+- `base_commit`：`3bfdd753fa54582b0a2ab6b47e4ea8092cec8187`
+- merged 时间：`2025-07-26`
+- 你的身份：原 PR 作者
+
+## 2. 问题一句话
+
+`paddle.nn.functional.fold` 在输入为 0-size tensor 时缺少显式校验，导致后续计算出现不可预期的错误，需要添加 0-size tensor 的断言检查并抛出明确的 `AssertionError`。
+
+## 3. 为什么适合作为 SWE-Paddle 样本
+
+- **真实性**：该问题来自 Paddle 的「0-size Tensor 机制建设」系列任务，是真实研发需求，目标是为 `paddle.nn.functional.fold` 补齐 0-size tensor 的边界处理。
+- **代表性**：覆盖 Python API 层面的算子输入校验，涉及 0-size tensor 的早期断言和错误信息规范化，是 Paddle API 算子机制增强的典型样本。
+- **边界清楚**：目标仅限 0-size tensor 输入时的断言检查，当 `math.prod(x.shape) == 0` 时应抛出 `AssertionError`；正向非零尺寸输入不应受影响。
+- **非平凡性**：修复需要在 `common.py` 中为 `fold` API 添加 `math.prod(x.shape) > 0` 的断言，涉及对 tensor shape 的语义理解和错误信息规范化，不是简单机械修改。
+- **回归护栏明确**：目标 F2P 可覆盖 0-size tensor 输入的 `fold` 调用；同文件中已有的 `TestFoldOpError` 等标准错误处理测试用例可作为 P2P 护栏。
+
+## 4. 任务类型和标签
+
+- 任务类型：`bug_fix`
+- 执行后端：`cpu`
+- 设备范围：`cpu_only`
+- 模块标签：`[python_api, nn_functional, fold, 0-size_tensor, input_validation]`
+
+## 5. 验证思路
+
+- 目标测试命令：`bash tests/test.sh`
+- 目标测试文件：
+  - `test/legacy_test/test_fold_op.py`（`TestFoldOpError` 中的 `test_zero_size` 子测试）
+- P2P 候选：同文件中已有的 `TestFoldOpError` 等标准错误处理测试用例。
+- 修复前预期：`base_commit` + `tests/test.patch` 后，0-size tensor 输入的 `fold` 调用不会抛出 `AssertionError`（缺少校验），导致 `test_zero_size` 测试失败。
+- 修复后预期：继续应用 `solution/code.patch` 后，0-size tensor 输入会触发 `AssertionError`，`test_zero_size` 测试通过，P2P 存量测试仍然通过。
+
+## 6. 环境与资源
+
+- 是否能提供 Docker：无
+- Dockerfile 或镜像地址：暂无
+- Paddle 来源：`PaddlePaddle/Paddle` source checkout at `base_commit`，纯 Python 修改可直接 patch。
+- 如果使用 wheel，请填写 wheel URL、Python 版本和平台标签：可由 verifier 选择与 base 兼容的 CPU wheel 或本地源码环境；proposal 阶段不固定 wheel URL。
+- OS / Python / CUDA / cuDNN / 其他关键依赖：Linux CPU + Python + numpy + pytest；不要求 CUDA/cuDNN。
+- 硬件：CPU 即可。
+- patch 类型：纯 Python 修改 + Python legacy test，无需 C++ rebuild。
+- 最小测试命令：`bash tests/test.sh`
+- 是否有 oracle 日志：无；由 SWE-Paddle verifier 记录 Run/Test/Fix 结果。
+
+## 7. 风险自查
+
+- 泄露风险：正式 `instruction.md` 只描述「fold 对 0-size tensor 输入缺少边界校验」，不指出具体 `math.prod(x.shape) > 0` 断言逻辑或具体代码位置。
+- 环境风险：低。任务为 Python-only，无需特殊镜像、外部服务或不可固定下载。
+- flaky 风险：低。测试使用固定的 0-size tensor 构造，不依赖随机数差异或多设备同步。
+- 拆分风险：低。该 PR 目标集中在 `common.py` 中 `fold` API 的 0-size 断言检查，测试也明确指向 `TestFoldOpError` 的零尺寸分支，适合作为一个独立样本。
+- 其他不确定点：完整任务包阶段应确认新增 F2P（`test_zero_size`）在 `base_commit` 上确实失败，并选择同文件中已有的 `TestFoldOpError` 等标准测试用例作为在 base 与修复后都稳定通过的 P2P nodeid。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-74221/solution/code.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-74221/solution/code.patch
@@ -1,0 +1,22 @@
+diff --git a/python/paddle/nn/functional/common.py b/python/paddle/nn/functional/common.py
+index 39393d5599..66517fc7c0 100644
+--- a/python/paddle/nn/functional/common.py
++++ b/python/paddle/nn/functional/common.py
+@@ -14,6 +14,7 @@
+ 
+ from __future__ import annotations
+ 
++import math
+ from typing import TYPE_CHECKING, Literal
+ 
+ import numpy
+@@ -2753,6 +2754,9 @@ def fold(
+     )
+ 
+     assert len(x.shape) == 3, "input should be the format of [N, C, L]"
++    assert (
++        math.prod(x.shape) > 0
++    ), "The number of elements must greater than zero."
+ 
+     def _is_list_or_tuple_(data):
+         return isinstance(data, (list, tuple))

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-74221/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-74221/tests/test.patch
@@ -1,0 +1,30 @@
+diff --git a/test/legacy_test/test_fold_op.py b/test/legacy_test/test_fold_op.py
+index 78b5f95e4e..4d69dff71c 100644
+--- a/test/legacy_test/test_fold_op.py
++++ b/test/legacy_test/test_fold_op.py
+@@ -283,6 +283,17 @@ class TestFoldOpError(unittest.TestCase):
+                     strides=0,
+                 )
+ 
++            def test_zero_size():
++                x = paddle.randn(shape=[0, 1, 1], dtype="float32")
++                out = fold(
++                    x,
++                    output_sizes=[0, 0],
++                    kernel_sizes=[0, 0],
++                    dilations=0,
++                    paddings=[0, 0],
++                    strides=0,
++                )
++
+             self.assertRaises(AssertionError, test_input_shape)
+             self.assertRaises(AssertionError, test_kernel_shape)
+             self.assertRaises(ValueError, test_padding_shape)
+@@ -292,6 +303,7 @@ class TestFoldOpError(unittest.TestCase):
+             self.assertRaises(TypeError, test_output_size_2)
+             self.assertRaises(ValueError, test_block_h_w)
+             self.assertRaises(ValueError, test_GT_0)
++            self.assertRaises(AssertionError, test_zero_size)
+ 
+ 
+ if __name__ == '__main__':

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-74221/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-74221/tests/test.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# P2P tests (pass-to-pass)
+python -m pytest test/legacy_test/test_fold_op.py::TestFoldOp -q
+
+# F2P tests (fail-to-pass)
 python -m pytest test/legacy_test/test_fold_op.py::TestFoldOpError -q

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-74221/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-74221/tests/test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python -m pytest test/legacy_test/test_fold_op.py::TestFoldOpError -q


### PR DESCRIPTION
### 关联

  * SWE-Paddle 共建 issue: [[Call for Bench] SWE-Paddle 社区共建 Paddle#79447](https://github.com/PaddlePaddle/Paddle/issues/79447)
  * 来源 PR: [[0-size Tensor No.169] Add 0-size Tensor support for paddle.nn.functional.fold Paddle#74221](https://github.com/PaddlePaddle/Paddle/pull/74221)

### 说明

新增 SWE-Paddle 任务 `PaddlePaddle__Paddle-74221`。

该任务覆盖 `paddle.nn.functional.fold` 对 0-size Tensor 的处理。测试包含非 0-size Tensor regression case，以及 `fold` 的目标场景，可在 CPU 环境运行。

### 验证结果

| 状态 | P2P | fold F2P |
| --- | ---: | ---: |
| Base + `tests/test.patch` | PASS | FAIL |
| Base + test patch + `solution/code.patch` | PASS | PASS |

#### Base P2P

```
======================================================== 2 passed, 2 warnings in 1.37s =========================================================
```

#### Base F2P：fold

```
=========================================================== short test summary info ============================================================
FAILED test_fold_op.py::TestFoldOpError::test_errors - ValueError: (InvalidArgument) The `kernel_sizes` should be greater than zero, but received kernel_height: 0 kernel_width: 0.
========================================================= 1 failed, 1 warning in 1.40s =========================================================
```

#### Solution P2P

```
======================================================== 2 passed, 2 warnings in 1.38s =========================================================
```

#### Solution F2P：fold

```
========================================================= 1 passed, 1 warning in 1.25s =========================================================
```