### PR TITLE
[SWE-Paddle] Fix test launcher for PaddlePaddle__Paddle-77078

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-77078/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-77078/tests/test.sh
@@ -2,5 +2,5 @@
 set -euo pipefail
 
 # Target test for PaddlePaddle__Paddle-77078.
-# Run from the root of a built PaddlePaddle/Paddle source checkout.
-python -m pytest test/legacy_test/test_inverse_op.py -q
+# Run the file directly so its __main__ block enables Paddle static mode.
+python test/legacy_test/test_inverse_op.py


### PR DESCRIPTION
## What changed

- Run test_inverse_op.py directly instead of importing it through pytest.
- This executes the file’s __main__ block, which enables Paddle static mode before the unittest suite.

## Validation

- Exact Base build: 36 tests run; 3 task-relevant TypeError failures (expected).
- Clean Gold build: 36/36 tests passed.
- Both checks used fresh containers with networking disabled and no host mounts.