### PR TITLE
[SWE-Paddle] Complete task package for PaddlePaddle__Paddle-78342

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78342/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78342/README.md
@@ -1,0 +1,41 @@
+# PaddlePaddle__Paddle-78342
+
+This directory packages Paddle PR #78342 as a SWE-Paddle task.
+
+## Source Metadata
+
+| Field | Value |
+| --- | --- |
+| Repository | `PaddlePaddle/Paddle` |
+| Pull request | [#78342](https://github.com/PaddlePaddle/Paddle/pull/78342) |
+| Title | `[API Compatibility] add new api paddle._assert -part` |
+| Base commit | `fa323f323bb35359c9d4ba77763834fee82a87b4` |
+| Gold commit | `f92a35feea4acf62b2df2259ae491b992851f854` |
+| Resource scope | CPU |
+| Patch scope | Python API and legacy unittest coverage |
+
+## Behavior Summary
+
+The task adds the public `paddle._assert(condition, message="")` API with a calling convention compatible with `torch._assert`. In dynamic mode, truthy Python and Tensor conditions return normally, while falsy conditions raise `AssertionError` with the supplied message or an empty default message. Positional, keyword, and mixed argument forms are supported.
+
+In static mode, a Tensor condition contributes an executable assertion to the program rather than being checked while the program is constructed. The existing compatibility APIs in the same regression file must continue to pass.
+
+## Test Classification
+
+- **F2P:** the seven `TestAssertAPI` cases added to `test/legacy_test/test_api_compatibility_part2.py` cover truthy and falsy Python conditions, truthy and falsy Tensor conditions, the default message, compatible calling forms, and static-graph execution.
+- **P2P:** all pre-existing tests in `test/legacy_test/test_api_compatibility_part2.py` remain the regression baseline and should pass before and after the solution.
+
+## Artifact Map
+
+- `proposal.md`: approved source proposal; preserved unchanged.
+- `instruction.md`: self-contained observable public API requirements.
+- `solution/code.patch`: exact base-to-gold diff for the three production files.
+- `tests/test.patch`: exact base-to-gold diff for the legacy unittest file.
+- `tests/test.sh`: strict direct-Python unittest wrapper.
+- `environment/README.md`: revisions, runtime assumptions, patch order, and verification guidance.
+
+## Verification Summary
+
+- Both patches are exported from the exact base-to-gold Git diff with the required production/test boundary.
+- Packaging checks cover patch whitespace, shell syntax, isolated test-first application order, byte-for-byte gold equivalence, and Python syntax.
+- Runtime execution is best-effort when the exact base build is unavailable. The target class was verified fail-before/pass-after with a loadable runtime from ancestor commit `56be465924264e1251cf127dbff56d17a7554d01`, 91 commits before the base; full-file P2P limitations are recorded in `environment/README.md`.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78342/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78342/environment/README.md
@@ -1,0 +1,51 @@
+# Environment Notes
+
+## Exact Revisions
+
+- Repository: `PaddlePaddle/Paddle`
+- Base commit: `fa323f323bb35359c9d4ba77763834fee82a87b4`
+- Gold commit: `f92a35feea4acf62b2df2259ae491b992851f854`
+- Gold parent: `fa323f323bb35359c9d4ba77763834fee82a87b4`
+- Available local Python 3.9 historical build: `555b4a95615a35b301f348e081e56435a6d75da6` (113 commits behind the base; native extension is not loadable in this container)
+- Loadable local Python 3.10 build: `56be465924264e1251cf127dbff56d17a7554d01` (91 commits behind the base)
+- Resource scope: CPU; no GPU is required.
+
+## Paddle Runtime Requirements
+
+The changes are Python-only. Preferred verification uses a Paddle build produced from the exact base revision, with the patched checkout's Python package installed or copied into the build output.
+
+A Python overlay is also valid when it starts from a compatible Paddle package and replaces the three patched production files. The overlay must load the patched top-level and testing modules while retaining the build's compiled extension, generated modules, and shared libraries. Confirm the loaded package path and Paddle commit before interpreting results.
+
+No C++, CUDA, kernel, infermeta, or generated binding changes are present, so the solution does not require recompiling the native extension. A stale Python package in an existing build directory must still be refreshed after applying the solution patch.
+
+## Patch And Test Order
+
+Run from the root of a clean Paddle checkout at the exact base commit:
+
+```bash
+git apply /path/to/PaddlePaddle__Paddle-78342/tests/test.patch
+PYTHON_BIN=python bash /path/to/PaddlePaddle__Paddle-78342/tests/test.sh
+git apply /path/to/PaddlePaddle__Paddle-78342/solution/code.patch
+PYTHON_BIN=python bash /path/to/PaddlePaddle__Paddle-78342/tests/test.sh
+```
+
+The first run is expected to fail the seven new `TestAssertAPI` cases because `paddle._assert` is absent. Existing tests in the file remain the P2P baseline. After applying the solution and refreshing the runtime's Python package, the full unittest file should pass.
+
+The wrapper deliberately executes the Paddle unittest file directly:
+
+```bash
+"${PYTHON_BIN:-python}" test/legacy_test/test_api_compatibility_part2.py
+```
+
+## Compatibility Risks
+
+- The available historical build predates the exact base by 113 commits. It can provide best-effort evidence only; Python/native or Python/generated-module incompatibilities do not invalidate exact source verification.
+- A runtime that imports the unpatched installed package instead of the isolated overlay will report `paddle._assert` as missing after the solution.
+- Static execution depends on the runtime's control-flow assertion support. A substantially older or newer runtime may differ from the exact base even though this task changes only Python files.
+- Do not patch, reset, clean, or otherwise alter the dirty `/workspace/Paddle` checkout. Use an isolated snapshot or worktree.
+
+## Local Verification Record
+
+Package validation passed for artifact presence, unchanged `proposal.md`, shell syntax, patch whitespace, exact file boundaries, test-first then solution application, byte-for-byte equality with the gold revision, and Python syntax compilation. Neither the wrapper nor the environment commands invokes an alternate test runner.
+
+Runtime validation used an isolated overlay backed by the loadable Python 3.10 build at `56be465924264e1251cf127dbff56d17a7554d01`, 91 commits behind the exact base. Before the solution, all seven `TestAssertAPI` cases errored because `paddle._assert` was absent. After the solution, all seven target cases passed, including static execution. The full direct-Python wrapper ran 80 tests but reported 23 errors in unrelated compatibility APIs whose required changes postdate the older runtime, so this run is not claimed as complete P2P validation. The Python 3.9 build at `555b4a95615a35b301f348e081e56435a6d75da6` remains unusable because loading its native extension raises `SIGBUS`. The dirty `/workspace/Paddle` checkout was not modified.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78342/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78342/instruction.md
@@ -1,0 +1,31 @@
+# Add the public `paddle._assert` API
+
+Implement a public assertion API callable as `paddle._assert(condition, message="")`. Its observable calling convention and behavior must be compatible with `torch._assert` while supporting Paddle dynamic and static execution.
+
+## Calling Convention
+
+The API must accept:
+
+- positional arguments, such as `paddle._assert(condition, "message")`;
+- keyword arguments, such as `paddle._assert(condition=True, message="message")`;
+- a positional condition with a keyword message;
+- an omitted message, which defaults to the empty string.
+
+## Dynamic Behavior
+
+In dynamic mode:
+
+- a truthy Python condition returns normally;
+- a falsy Python condition raises `AssertionError`;
+- a truthy Tensor condition returns normally;
+- a falsy Tensor condition raises `AssertionError`;
+- the raised exception contains the supplied message exactly;
+- when the message is omitted, the raised exception message is empty.
+
+## Static Behavior
+
+In static mode, a Tensor condition must add an executable assertion to the program. A program with a true condition must execute successfully. The condition must not be reduced to a Python boolean while the static program is being built.
+
+## Regression Requirements
+
+The API must be exposed from the top-level `paddle` namespace. Existing dynamic-mode, static-graph, and API compatibility behavior covered by the surrounding regression suite must remain unchanged.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78342/solution/code.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78342/solution/code.patch
@@ -1,0 +1,78 @@
+diff --git a/python/paddle/__init__.py b/python/paddle/__init__.py
+index 5873508243..e3470a8293 100644
+--- a/python/paddle/__init__.py
++++ b/python/paddle/__init__.py
+@@ -794,6 +794,7 @@ from .tensor.stat import (
+     var,
+ )
+ from .tensor.to_string import set_printoptions
++from .testing import _assert as _assert
+ from .utils.dlpack import (
+     from_dlpack,
+     to_dlpack,
+diff --git a/python/paddle/testing/__init__.py b/python/paddle/testing/__init__.py
+index a228d3d9b2..5ab072e8cc 100644
+--- a/python/paddle/testing/__init__.py
++++ b/python/paddle/testing/__init__.py
+@@ -13,8 +13,9 @@
+ # limitations under the License.
+ from __future__ import annotations
+ 
+-from ._comparison import assert_close
++from ._comparison import _assert, assert_close
+ 
+ __all__ = [
++    '_assert',
+     'assert_close',
+ ]
+diff --git a/python/paddle/testing/_comparison.py b/python/paddle/testing/_comparison.py
+index fce8d43306..7793791d7a 100644
+--- a/python/paddle/testing/_comparison.py
++++ b/python/paddle/testing/_comparison.py
+@@ -1060,3 +1060,46 @@ def assert_close(
+ 
+     if error_metas:
+         raise error_metas[0].to_error(msg)
++
++
++def _assert(condition, message=""):
++    r"""
++    A wrapper around Python's assert which is symbolically traceable.
++
++    In dynamic graph mode, this function behaves like a regular Python assert.
++    In static graph mode, when the condition is a Tensor, it creates an Assert
++    op in the computation graph.
++
++    Args:
++        condition (bool or Tensor): The condition to assert. If a Tensor, it
++            must be a boolean scalar (numel=1).
++        message (str, optional): The error message to display when the assertion
++            fails. Default: "".
++
++    Examples:
++        .. code-block:: pycon
++
++            >>> import paddle
++            >>> # Non-tensor condition
++            >>> paddle._assert(1 == 1, "This should pass")
++
++            >>> # Tensor condition
++            >>> x = paddle.to_tensor([True])
++            >>> paddle._assert(x, "Tensor assertion")
++
++    """
++    from paddle.base.framework import Variable
++    from paddle.framework import in_dynamic_mode
++
++    if isinstance(condition, (paddle.Tensor, paddle.pir.Value, Variable)):
++        if in_dynamic_mode():
++            if not condition:
++                raise AssertionError(message)
++        else:
++            condition = paddle.cast(condition, "bool")
++            from paddle.static.nn.control_flow import Assert
++
++            return Assert(condition)
++    else:
++        if not condition:
++            raise AssertionError(message)

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78342/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78342/tests/test.patch
@@ -1,0 +1,83 @@
+diff --git a/test/legacy_test/test_api_compatibility_part2.py b/test/legacy_test/test_api_compatibility_part2.py
+index a8dc3f5a68..6a215630ea 100644
+--- a/test/legacy_test/test_api_compatibility_part2.py
++++ b/test/legacy_test/test_api_compatibility_part2.py
+@@ -928,6 +928,78 @@ class TestCloneAPI(unittest.TestCase):
+                 np.testing.assert_allclose(out, self.np_x)
+ 
+ 
++# Edit By AI Agent
++# Test _assert compatibility
++class TestAssertAPI(unittest.TestCase):
++    def test_dygraph_non_tensor_pass(self):
++        """Test _assert with non-tensor condition that passes."""
++        paddle.disable_static()
++        paddle._assert(True, "should pass")
++        paddle._assert(1, "should pass")
++        paddle._assert(1 == 1, "should pass")
++        paddle.enable_static()
++
++    def test_dygraph_non_tensor_fail(self):
++        """Test _assert with non-tensor condition that fails."""
++        paddle.disable_static()
++        with self.assertRaises(AssertionError) as ctx:
++            paddle._assert(False, "error message")
++        self.assertEqual(str(ctx.exception), "error message")
++
++        with self.assertRaises(AssertionError) as ctx:
++            paddle._assert(0, "zero is falsy")
++        self.assertEqual(str(ctx.exception), "zero is falsy")
++        paddle.enable_static()
++
++    def test_dygraph_tensor_pass(self):
++        """Test _assert with tensor condition that passes."""
++        paddle.disable_static()
++        cond = paddle.to_tensor([True])
++        paddle._assert(cond, "tensor assert should pass")
++        paddle.enable_static()
++
++    def test_dygraph_tensor_fail(self):
++        """Test _assert with tensor condition that fails."""
++        paddle.disable_static()
++        cond = paddle.to_tensor([False])
++        with self.assertRaises(AssertionError):
++            paddle._assert(cond, "tensor assert should fail")
++        paddle.enable_static()
++
++    def test_dygraph_default_message(self):
++        """Test _assert with default empty message."""
++        paddle.disable_static()
++        with self.assertRaises(AssertionError) as ctx:
++            paddle._assert(False)
++        self.assertEqual(str(ctx.exception), "")
++        paddle.enable_static()
++
++    def test_dygraph_compatibility_with_torch(self):
++        """Test that paddle._assert matches torch._assert calling convention."""
++        paddle.disable_static()
++        # Positional args (matching torch._assert(condition, message))
++        paddle._assert(True, "positional args")
++
++        # Keyword args (matching torch._assert(condition=..., message=...))
++        paddle._assert(condition=True, message="keyword args")
++
++        # Mixed args
++        paddle._assert(True, message="mixed args")
++        paddle.enable_static()
++
++    def test_static_tensor_condition(self):
++        """Test _assert with tensor condition in static graph mode."""
++        paddle.enable_static()
++        main = paddle.static.Program()
++        startup = paddle.static.Program()
++        with paddle.base.program_guard(main, startup):
++            cond = paddle.full(shape=[1], fill_value=True, dtype='bool')
++            paddle._assert(cond, "static assert")
++
++            exe = paddle.base.Executor(paddle.CPUPlace())
++            exe.run(main)
++
++
+ class TestHsplitAPI(unittest.TestCase):
+     def setUp(self):
+         np.random.seed(2025)

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78342/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78342/tests/test.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PYTHON_BIN="${PYTHON_BIN:-python}"
+
+"${PYTHON_BIN}" test/legacy_test/test_api_compatibility_part2.py


### PR DESCRIPTION
# 关联

* SWE-Paddle 共建 issue: https://github.com/PaddlePaddle/Paddle/issues/79447
* 来源 PR: https://github.com/PaddlePaddle/Paddle/pull/78342

## 说明

* 新增 SWE-Paddle 任务 `PaddlePaddle__Paddle-78342 `

@sunzhongkai588 Thx

## 验证结果
```bash
# 修复前 F2P & P2P
λ /workspace/Paddle python3.10 test/legacy_test/test_api_compatibility_part2.py
======================================================================
ERROR: test_dygraph_compatibility_with_torch (__main__.TestAssertAPI)
Test that paddle._assert matches torch._assert calling convention.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/Paddle/test/legacy_test/test_api_compatibility_part2.py", line 981, in test_dygraph_compatibility_with_torch
    paddle._assert(True, "positional args")
AttributeError: module 'paddle' has no attribute '_assert'

======================================================================
ERROR: test_dygraph_default_message (__main__.TestAssertAPI)
Test _assert with default empty message.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/Paddle/test/legacy_test/test_api_compatibility_part2.py", line 973, in test_dygraph_default_message
    paddle._assert(False)
AttributeError: module 'paddle' has no attribute '_assert'

======================================================================
ERROR: test_dygraph_non_tensor_fail (__main__.TestAssertAPI)
Test _assert with non-tensor condition that fails.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/Paddle/test/legacy_test/test_api_compatibility_part2.py", line 946, in test_dygraph_non_tensor_fail
    paddle._assert(False, "error message")
AttributeError: module 'paddle' has no attribute '_assert'

======================================================================
ERROR: test_dygraph_non_tensor_pass (__main__.TestAssertAPI)
Test _assert with non-tensor condition that passes.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/Paddle/test/legacy_test/test_api_compatibility_part2.py", line 937, in test_dygraph_non_tensor_pass
    paddle._assert(True, "should pass")
AttributeError: module 'paddle' has no attribute '_assert'

======================================================================
ERROR: test_dygraph_tensor_fail (__main__.TestAssertAPI)
Test _assert with tensor condition that fails.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/Paddle/test/legacy_test/test_api_compatibility_part2.py", line 966, in test_dygraph_tensor_fail
    paddle._assert(cond, "tensor assert should fail")
AttributeError: module 'paddle' has no attribute '_assert'

======================================================================
ERROR: test_dygraph_tensor_pass (__main__.TestAssertAPI)
Test _assert with tensor condition that passes.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/Paddle/test/legacy_test/test_api_compatibility_part2.py", line 958, in test_dygraph_tensor_pass
    paddle._assert(cond, "tensor assert should pass")
AttributeError: module 'paddle' has no attribute '_assert'

======================================================================
ERROR: test_static_tensor_condition (__main__.TestAssertAPI)
Test _assert with tensor condition in static graph mode.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/Paddle/test/legacy_test/test_api_compatibility_part2.py", line 997, in test_static_tensor_condition
    paddle._assert(cond, "static assert")
AttributeError: module 'paddle' has no attribute '_assert'

----------------------------------------------------------------------
Ran 80 tests in 1.412s

FAILED (errors=7)


# 修复后 F2P & P2P
λ /workspace/Paddle python3.10 test/legacy_test/test_api_compatibility_part2.py
grep: warning: GREP_OPTIONS is deprecated; please use an alias or script
......I0804 10:37:54.429710  1134 pir_interpreter.cc:1528] New Executor is Running ...
I0804 10:37:54.430122  1134 pir_interpreter.cc:1551] pir interpreter is running by multi-thread mode ...
.W0804 10:37:54.433455  1134 gpu_resources.cc:116] Please NOTE: device: 0, GPU Compute Capability: 7.0, Driver API Version: 12.6, Runtime API Version: 11.8
.W0804 10:37:54.447962  1134 eager_utils.cc:3618] Paddle static graph(PIR) not support input out tensor for now!!!!!
.<frozen importlib._bootstrap>:914: ImportWarning: _SixMetaPathImporter.find_spec() not found; falling back to find_module()
................................./usr/local/lib/python3.10/dist-packages/paddle/pir/math_op_patch.py:261: UserWarning: Tensor do not have 'place' interface for pir graph mode, try not to use it. None will be returned.
  warnings.warn(
......................................
----------------------------------------------------------------------
Ran 80 tests in 1.390s

OK
```