### PR TITLE
[SWE-Paddle] Complete task package for PaddlePaddle__Paddle-78082

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78082/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78082/README.md
@@ -1,0 +1,44 @@
+# PaddlePaddle__Paddle-78082
+
+This directory packages Paddle PR #78082 as a SWE-Paddle task.
+
+## Source Metadata
+
+| Field | Value |
+| --- | --- |
+| Repository | `PaddlePaddle/Paddle` |
+| Pull request | [#78082](https://github.com/PaddlePaddle/Paddle/pull/78082) |
+| Title | `[API Compatibility] add method pop(), values() and keys() to paddle.nn.ParameterDict` |
+| Base commit | `ae907b878e91dbabf3582da99f8b05a46b588fc2` |
+| Gold commit | `a2e4e5062dacbfef63cf4b08981b74b72ad21214` |
+| Resource scope | CPU |
+| Patch scope | Python API and legacy unittest coverage |
+
+## Behavior Summary
+
+The task adds PyTorch-compatible container operations to `paddle.nn.ParameterDict` without changing parameter registration or existing container behavior.
+
+- `pop(key)` removes the named parameter and returns the same Parameter. A missing key raises `KeyError`.
+- `keys()` exposes the current keys in insertion order, including order changes caused by `update()`.
+- `values()` exposes the current Parameters in matching order. Returned values are Parameters, and the collection reflects removals.
+- Existing indexing, iteration, update, forward/backward, registration, and state-dict behavior remains intact.
+
+## Test Classification
+
+- **F2P:** `TestParameterDictPopKeysValues` adds nine cases covering returned Parameters, missing keys, clearing by repeated pop, insertion order, update order, value shapes and types, value count, and synchronization after pop.
+- **P2P:** `TestParameterDictStateDictRoundtrip` adds three state-dict roundtrip cases, while all pre-existing tests in `test_imperative_container_parameterdict.py` remain regression coverage.
+
+## Artifact Map
+
+- `proposal.md`: approved source proposal; preserved unchanged.
+- `instruction.md`: self-contained observable requirements for the public container behavior.
+- `solution/code.patch`: exact base-to-gold diff for the production file.
+- `tests/test.patch`: exact base-to-gold diff for the legacy unittest file.
+- `tests/test.sh`: strict direct-Python unittest wrapper.
+- `environment/README.md`: revisions, runtime assumptions, patch order, and verification guidance.
+
+## Verification Summary
+
+- The production and test patches are exported from the exact base-to-gold Git diff with the requested one-file boundaries.
+- Packaging checks cover patch whitespace, shell syntax, test-first application order, byte-for-byte gold equivalence, and Python syntax.
+- Runtime verification is best-effort when the exact historical build is unavailable; the runtime commit and any compatibility limitation are recorded in `environment/README.md`.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78082/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78082/environment/README.md
@@ -1,0 +1,50 @@
+# Environment Notes
+
+## Exact Revisions
+
+- Repository: `PaddlePaddle/Paddle`
+- Base commit: `ae907b878e91dbabf3582da99f8b05a46b588fc2`
+- Gold commit: `a2e4e5062dacbfef63cf4b08981b74b72ad21214`
+- Gold parent: `ae907b878e91dbabf3582da99f8b05a46b588fc2`
+- Loadable local runtime commit: `fa323f323bb35359c9d4ba77763834fee82a87b4` (131 commits after the exact base)
+- Resource scope: CPU; no GPU is required.
+
+## Paddle Runtime Requirements
+
+The change is Python-only. Preferred verification uses a Paddle build produced from the exact base revision, with the patched Python package installed or copied into the build output.
+
+A Python overlay is also valid when it starts from a compatible Paddle package and replaces the production file from the base snapshot before the test-only run, then replaces it with the solution version for the post-solution run. The overlay must retain the runtime's compiled extension, generated modules, and shared libraries while importing the overlaid Python package.
+
+No C++, CUDA, kernel, infermeta, or native binding changes are present, so applying the solution does not require recompiling the native extension. A stale Python package in an existing build directory must still be refreshed after applying the solution patch.
+
+## Patch And Test Order
+
+Run from the root of a clean Paddle checkout at the exact base commit:
+
+```bash
+git apply /path/to/PaddlePaddle__Paddle-78082/tests/test.patch
+PYTHON_BIN=python bash /path/to/PaddlePaddle__Paddle-78082/tests/test.sh
+git apply /path/to/PaddlePaddle__Paddle-78082/solution/code.patch
+PYTHON_BIN=python bash /path/to/PaddlePaddle__Paddle-78082/tests/test.sh
+```
+
+The first run is expected to fail the nine new `TestParameterDictPopKeysValues` cases because the methods are absent. Existing container tests and the three state-dict roundtrip cases provide the P2P baseline. After applying the solution and refreshing the runtime's Python package, the full unittest file should pass.
+
+The wrapper deliberately executes the legacy unittest file directly:
+
+```bash
+"${PYTHON_BIN:-python}" test/legacy_test/test_imperative_container_parameterdict.py
+```
+
+## Compatibility Risks
+
+- The available loadable runtime is 131 commits newer than the exact base. It provides useful best-effort coverage but is not an exact historical P2P environment.
+- A runtime that imports an installed package instead of the isolated overlay can make the pre-solution cases pass falsely because newer versions may already contain these methods.
+- Layer parameter registration and state-dict behavior are sensitive to container internals. Verify both returned values and serialization tests after applying the solution.
+- Do not patch, reset, clean, or otherwise alter the dirty `/workspace/Paddle` checkout. Use an isolated snapshot or worktree.
+
+## Local Verification Record
+
+Package validation passed for artifact presence, unchanged `proposal.md`, shell syntax, patch whitespace, exact file boundaries, test-first then solution application, byte-for-byte equality with the gold revision, and Python syntax compilation. Neither the wrapper nor the environment commands invokes an alternate test runner.
+
+Runtime validation used isolated overlays backed by the loadable runtime at `fa323f323bb35359c9d4ba77763834fee82a87b4`, 131 commits after the exact base. Before the solution, all nine `TestParameterDictPopKeysValues` cases failed because the methods were absent. After the solution, all nine target cases passed, and the complete direct-Python file ran 32 tests with `OK`. The newer runtime was used only as a best-effort compiled environment; the Python production file was replaced with the exact base or gold version for each phase. The dirty `/workspace/Paddle` checkout was not modified.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78082/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78082/instruction.md
@@ -1,0 +1,30 @@
+# Add mapping-style operations to `ParameterDict`
+
+Extend `paddle.nn.ParameterDict` with public `pop()`, `keys()`, and `values()` operations while preserving its existing parameter-container behavior.
+
+## `pop()` Behavior
+
+- `pop(key)` removes the parameter stored under `key` and returns that same Parameter object.
+- The container length decreases after a successful removal.
+- Repeated calls can remove every entry and leave an empty container.
+- Removing an unknown key raises `KeyError`.
+- Removed parameters must no longer appear through the container's keys or values.
+
+## `keys()` Behavior
+
+- `keys()` exposes every current key exactly once.
+- Keys preserve the ParameterDict's insertion order.
+- Parameters appended through `update()` appear after existing entries in update order.
+- The returned keys stay consistent with the container length and removals.
+
+## `values()` Behavior
+
+- `values()` exposes every current value exactly once and in the order corresponding to `keys()`.
+- Every returned value is a Paddle Parameter.
+- Parameter shapes and identities are preserved.
+- The number of values equals the current container length.
+- Values removed through `pop()` no longer appear.
+
+## Regression Requirements
+
+Existing indexing, iteration, update, forward and backward execution, parameter registration, serialization, state-dict keys, state-dict loading, and output equivalence after loading must continue to work.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78082/solution/code.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78082/solution/code.patch
@@ -1,0 +1,38 @@
+diff --git a/python/paddle/nn/layer/container.py b/python/paddle/nn/layer/container.py
+index fbf6ad4911..6d03dd2b25 100644
+--- a/python/paddle/nn/layer/container.py
++++ b/python/paddle/nn/layer/container.py
+@@ -434,6 +434,33 @@ class ParameterDict(Layer):
+                     )
+                 self.add_parameter(kv[0], kv[1])
+ 
++    def pop(self, key: str) -> Tensor:
++        """Remove key from the ParameterDict and return its parameter.
++
++        Parameters:
++            key (str): the key to be removed.
++        """
++        v = self[key]
++        del self._parameters[key]
++        return v
++
++    def keys(self) -> Iterable[str]:
++        """Return an iterable of the keys in the ParameterDict.
++
++        Parameters:
++            None.
++        """
++        return self._parameters.keys()
++
++    def values(self) -> Iterable[Tensor]:
++        """Return an iterable of the parameters in the ParameterDict.
++
++        Parameters:
++            None.
++        """
++        with param_guard(self._parameters):
++            return list(self._parameters.values())
++
+ 
+ class ParameterList(Layer):
+     """ParameterList Container.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78082/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78082/tests/test.patch
@@ -1,0 +1,112 @@
+diff --git a/test/legacy_test/test_imperative_container_parameterdict.py b/test/legacy_test/test_imperative_container_parameterdict.py
+index 3db5c70df8..1fdfd55409 100644
+--- a/test/legacy_test/test_imperative_container_parameterdict.py
++++ b/test/legacy_test/test_imperative_container_parameterdict.py
+@@ -280,5 +280,107 @@ class TestParameterDictForwardBackward(unittest.TestCase):
+         self.assertEqual(out.dtype, paddle.float64)
+ 
+ 
++class TestParameterDictPopKeysValues(unittest.TestCase):
++    def setUp(self):
++        self.pd = paddle.nn.ParameterDict(
++            {
++                'w1': _make_param([2, 3]),
++                'w2': _make_param([3, 4]),
++                'w3': _make_param([4, 5]),
++            }
++        )
++
++    def test_pop_returns_correct_param(self):
++        p = self.pd.pop('w2')
++        self.assertEqual(list(p.shape), [3, 4])
++        self.assertEqual(len(self.pd), 2)
++        self.assertNotIn('w2', list(self.pd.keys()))
++
++    def test_pop_missing_key_raises(self):
++        with self.assertRaises(KeyError):
++            self.pd.pop('nonexistent')
++
++    def test_pop_all_items_leaves_empty(self):
++        for k in list(self.pd.keys()):
++            self.pd.pop(k)
++        self.assertEqual(len(self.pd), 0)
++
++    def test_keys_returns_all_in_order(self):
++        self.assertEqual(list(self.pd.keys()), ['w1', 'w2', 'w3'])
++
++    def test_keys_after_update(self):
++        self.pd.update({'w4': _make_param([5, 6])})
++        self.assertIn('w4', list(self.pd.keys()))
++        self.assertEqual(len(self.pd), 4)
++
++    def test_values_shapes(self):
++        shapes = [list(v.shape) for v in self.pd.values()]
++        self.assertEqual(shapes, [[2, 3], [3, 4], [4, 5]])
++
++    def test_values_are_parameters(self):
++        from paddle.base.framework import Parameter
++
++        for v in self.pd.values():
++            self.assertIsInstance(v, Parameter)
++
++    def test_values_count_matches_len(self):
++        self.assertEqual(len(self.pd.values()), len(self.pd))
++
++    def test_pop_reduces_values(self):
++        self.pd.pop('w1')
++        shapes = [list(v.shape) for v in self.pd.values()]
++        self.assertEqual(shapes, [[3, 4], [4, 5]])
++
++
++class TestParameterDictStateDictRoundtrip(unittest.TestCase):
++    def _make_model(self):
++        class M(paddle.nn.Layer):
++            def __init__(self):
++                super().__init__()
++                self.pd = paddle.nn.ParameterDict(
++                    {
++                        'w1': _make_param([2, 3]),
++                        'w2': _make_param([3, 4]),
++                    }
++                )
++
++            def forward(self, x):
++                return paddle.matmul(
++                    paddle.matmul(x, self.pd['w1']), self.pd['w2']
++                )
++
++        return M()
++
++    def test_state_dict_roundtrip_values(self):
++        model_a = self._make_model()
++        state_a = model_a.state_dict()
++        w1_a = state_a['pd.w1'].numpy().copy()
++        w2_a = state_a['pd.w2'].numpy().copy()
++
++        model_b = self._make_model()
++        model_b.set_state_dict(state_a)
++        state_b = model_b.state_dict()
++
++        np.testing.assert_array_equal(state_b['pd.w1'].numpy(), w1_a)
++        np.testing.assert_array_equal(state_b['pd.w2'].numpy(), w2_a)
++
++    def test_output_matches_after_load(self):
++        model_a = self._make_model()
++        model_b = self._make_model()
++        model_b.set_state_dict(model_a.state_dict())
++
++        x = paddle.uniform([2, 2])
++        np.testing.assert_array_almost_equal(
++            model_a(x).numpy(), model_b(x).numpy()
++        )
++
++    def test_state_dict_keys_present(self):
++        model = self._make_model()
++        state = model.state_dict()
++        self.assertIn('pd.w1', state)
++        self.assertIn('pd.w2', state)
++        self.assertEqual(len(state), 2)
++
++
+ if __name__ == '__main__':
+     unittest.main()

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78082/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78082/tests/test.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PYTHON_BIN="${PYTHON_BIN:-python}"
+
+"${PYTHON_BIN}" test/legacy_test/test_imperative_container_parameterdict.py


### PR DESCRIPTION
# 关联

* SWE-Paddle 共建 issue: https://github.com/PaddlePaddle/Paddle/issues/79447
* 来源 PR: https://github.com/PaddlePaddle/Paddle/pull/78082

## 说明

* 新增 SWE-Paddle 任务 `PaddlePaddle__Paddle-78082 `

@sunzhongkai588 Thx

## 验证结果
```bash
# 修复前 F2P & P2P
λ /workspace/Paddle python3.10 test/legacy_test/test_imperative_container_parameterdict.py
grep: warning: GREP_OPTIONS is deprecated; please use an alias or script
W0804 13:30:44.352741 13851 gpu_resources.cc:116] Please NOTE: device: 0, GPU Compute Capability: 7.0, Driver API Version: 12.6, Runtime API Version: 11.8
.............EEEEEEEEE..........
======================================================================
ERROR: test_keys_after_update (__main__.TestParameterDictPopKeysValues)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/Paddle/test/legacy_test/test_imperative_container_parameterdict.py", line 313, in test_keys_after_update
    self.assertIn('w4', list(self.pd.keys()))
  File "/usr/local/lib/python3.10/dist-packages/paddle/nn/layer/layers.py", line 2140, in __getattr__
    return object.__getattribute__(self, name)
AttributeError: 'ParameterDict' object has no attribute 'keys'

======================================================================
ERROR: test_keys_returns_all_in_order (__main__.TestParameterDictPopKeysValues)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/Paddle/test/legacy_test/test_imperative_container_parameterdict.py", line 309, in test_keys_returns_all_in_order
    self.assertEqual(list(self.pd.keys()), ['w1', 'w2', 'w3'])
  File "/usr/local/lib/python3.10/dist-packages/paddle/nn/layer/layers.py", line 2140, in __getattr__
    return object.__getattribute__(self, name)
AttributeError: 'ParameterDict' object has no attribute 'keys'

======================================================================
ERROR: test_pop_all_items_leaves_empty (__main__.TestParameterDictPopKeysValues)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/Paddle/test/legacy_test/test_imperative_container_parameterdict.py", line 304, in test_pop_all_items_leaves_empty
    for k in list(self.pd.keys()):
  File "/usr/local/lib/python3.10/dist-packages/paddle/nn/layer/layers.py", line 2140, in __getattr__
    return object.__getattribute__(self, name)
AttributeError: 'ParameterDict' object has no attribute 'keys'

======================================================================
ERROR: test_pop_missing_key_raises (__main__.TestParameterDictPopKeysValues)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/Paddle/test/legacy_test/test_imperative_container_parameterdict.py", line 301, in test_pop_missing_key_raises
    self.pd.pop('nonexistent')
  File "/usr/local/lib/python3.10/dist-packages/paddle/nn/layer/layers.py", line 2140, in __getattr__
    return object.__getattribute__(self, name)
AttributeError: 'ParameterDict' object has no attribute 'pop'

======================================================================
ERROR: test_pop_reduces_values (__main__.TestParameterDictPopKeysValues)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/Paddle/test/legacy_test/test_imperative_container_parameterdict.py", line 330, in test_pop_reduces_values
    self.pd.pop('w1')
  File "/usr/local/lib/python3.10/dist-packages/paddle/nn/layer/layers.py", line 2140, in __getattr__
    return object.__getattribute__(self, name)
AttributeError: 'ParameterDict' object has no attribute 'pop'

======================================================================
ERROR: test_pop_returns_correct_param (__main__.TestParameterDictPopKeysValues)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/Paddle/test/legacy_test/test_imperative_container_parameterdict.py", line 294, in test_pop_returns_correct_param
    p = self.pd.pop('w2')
  File "/usr/local/lib/python3.10/dist-packages/paddle/nn/layer/layers.py", line 2140, in __getattr__
    return object.__getattribute__(self, name)
AttributeError: 'ParameterDict' object has no attribute 'pop'

======================================================================
ERROR: test_values_are_parameters (__main__.TestParameterDictPopKeysValues)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/Paddle/test/legacy_test/test_imperative_container_parameterdict.py", line 323, in test_values_are_parameters
    for v in self.pd.values():
  File "/usr/local/lib/python3.10/dist-packages/paddle/nn/layer/layers.py", line 2140, in __getattr__
    return object.__getattribute__(self, name)
AttributeError: 'ParameterDict' object has no attribute 'values'

======================================================================
ERROR: test_values_count_matches_len (__main__.TestParameterDictPopKeysValues)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/Paddle/test/legacy_test/test_imperative_container_parameterdict.py", line 327, in test_values_count_matches_len
    self.assertEqual(len(self.pd.values()), len(self.pd))
  File "/usr/local/lib/python3.10/dist-packages/paddle/nn/layer/layers.py", line 2140, in __getattr__
    return object.__getattribute__(self, name)
AttributeError: 'ParameterDict' object has no attribute 'values'

======================================================================
ERROR: test_values_shapes (__main__.TestParameterDictPopKeysValues)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/Paddle/test/legacy_test/test_imperative_container_parameterdict.py", line 317, in test_values_shapes
    shapes = [list(v.shape) for v in self.pd.values()]
  File "/usr/local/lib/python3.10/dist-packages/paddle/nn/layer/layers.py", line 2140, in __getattr__
    return object.__getattribute__(self, name)
AttributeError: 'ParameterDict' object has no attribute 'values'

----------------------------------------------------------------------
Ran 32 tests in 0.389s

FAILED (errors=9)

# 修复后 F2P & P2P
λ /workspace/Paddle python3.10 test/legacy_test/test_imperative_container_parameterdict.py
grep: warning: GREP_OPTIONS is deprecated; please use an alias or script
W0804 13:33:49.047814 15328 gpu_resources.cc:116] Please NOTE: device: 0, GPU Compute Capability: 7.0, Driver API Version: 12.6, Runtime API Version: 11.8
................................
----------------------------------------------------------------------
Ran 32 tests in 0.416s

OK
```