### PR TITLE
[SWE-Paddle] Add task PaddlePaddle__Paddle-73122

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73122/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73122/README.md
@@ -1,0 +1,51 @@
+# PaddlePaddle__Paddle-73122
+
+This directory converts Paddle PR #73122 into a SWE-Paddle community task candidate.
+
+## Source
+
+| Field | Value |
+| --- | --- |
+| Repo | `PaddlePaddle/Paddle` |
+| PR | [73122](https://github.com/PaddlePaddle/Paddle/pull/73122) |
+| PR title | `[0-size Tensor No.112] Add 0-size Tensor support for multi_dot` |
+| Base commit | `2624aee95b82873848e34fc3e5673a1ac42f84c4` |
+| Gold commit | `29b711ba8db211ed31b3354562f62fb5ce568b40` |
+| Merged at | `2025-06-11` |
+| Task type | `bug_fix` |
+| Resource | CPU |
+| Scope | C++ Operator Kernel |
+
+## Summary
+
+Fix `paddle.linalg.multi_dot` to correctly handle 0-size tensors in CPU/GPU kernels by adding early-return logic when any input has 0 elements, with special handling for the case where the output tensor has non-zero size but inputs contain 0-size dimensions.
+
+## Why This Is A Good SWE-Paddle Candidate
+
+- It is derived from a merged Paddle bug-fix PR rather than a synthetic issue.
+- The target behavior is isolated to the C++ operator kernel level and requires rebuilding Paddle from source.
+- The failure is deterministic: the base revision fails when processing 0-size tensors due to missing early-return logic in the multi_dot kernel.
+- The task has clear regression coverage for existing non-zero-size behavior.
+- The task runs on CPU and does not require distributed execution, external services, or additional datasets.
+
+## Files
+
+- `proposal.md`: candidate proposal for maintainer triage.
+- `instruction.md`: self-contained problem statement for the coding agent.
+- `solution/code.patch`: gold implementation patch (C++ kernel changes).
+- `tests/test.patch`: tests exposing the target behavior.
+- `tests/test.sh`: minimal target test command.
+- `environment/README.md`: environment and reproduction notes.
+
+## Verification
+
+```bash
+bash tests/test.sh
+```
+
+Expected behavior:
+
+| Revision state | Existing behavior (P2P) | multi_dot F2P |
+| --- | ---: | ---: |
+| Base + `tests/test.patch` | PASS | FAIL |
+| Base + `tests/test.patch` + `solution/code.patch` | PASS | PASS |

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73122/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73122/environment/README.md
@@ -1,0 +1,52 @@
+# Environment Notes
+
+## Expected Environment
+
+- Repository: `PaddlePaddle/Paddle`
+- Base commit: `2624aee95b82873848e34fc3e5673a1ac42f84c4`
+- Gold commit: `29b711ba8db211ed31b3354562f62fb5ce568b40`
+- Resource: CPU
+- GPU required: no
+- Patch type: C++ kernel (CPU/GPU backends)
+- Python dependencies: PaddlePaddle (source build), NumPy
+
+The verifier should execute against the Paddle source revision represented by the selected patch state. A source build is required since the patch modifies C++ kernel code.
+
+## Build Instructions
+
+1. Check out `PaddlePaddle/Paddle` at the base commit.
+2. Apply `tests/test.patch`.
+3. Build Paddle from source (CPU-only build is sufficient):
+   ```bash
+   mkdir build && cd build
+   cmake .. -DWITH_GPU=OFF -DWITH_TESTING=ON -DCMAKE_BUILD_TYPE=Release
+   make -j$(nproc)
+   ```
+4. Install the built Paddle package.
+
+## Run Order
+
+1. Check out `PaddlePaddle/Paddle` at the base commit.
+2. Build and install Paddle from source.
+3. Apply `tests/test.patch`.
+4. Run the P2P tests; existing non-zero-size behavior should pass.
+5. Run the 0-size tensor tests; the target case should fail before the fix.
+6. Apply `solution/code.patch`.
+7. Rebuild Paddle from source.
+8. Reinstall Paddle package.
+9. Run `bash tests/test.sh`; all target tests should pass.
+
+## Minimal Test Command
+
+```bash
+bash tests/test.sh
+```
+
+## Expected Matrix
+
+| Revision state | P2P | multi_dot F2P |
+| --- | ---: | ---: |
+| Base + test patch | PASS | FAIL |
+| Base + test patch + solution patch | PASS | PASS |
+
+No GPU, distributed runtime, external service, or additional dataset is required.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73122/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73122/instruction.md
@@ -1,0 +1,60 @@
+# 修复 `paddle.linalg.multi_dot` 对 0-size Tensor 的处理
+
+## 详细描述
+
+当 `paddle.linalg.multi_dot(x)` 的输入 `x` 中包含 0-size Tensor 时，当前 C++ kernel 实现会直接进入后续计算逻辑，导致 kernel 内部对空数据执行 BLAS 调用或产生其他错误。
+
+典型表现包括：
+
+- kernel 在执行 BLAS 矩阵乘法时崩溃或报错
+- 0-size Tensor 输入无法通过 `multi_dot` 算子
+
+例如：
+
+```python
+import numpy as np
+import paddle
+
+paddle.disable_static()
+
+# multi_dot 0-size tensor 输入
+A = np.random.random((2, 10)).astype('float64')
+B = np.random.random((10, 0)).astype('float64')
+C = np.random.random((0, 3)).astype('float64')
+
+x_A = paddle.to_tensor(A)
+x_B = paddle.to_tensor(B)
+x_C = paddle.to_tensor(C)
+
+out = paddle.linalg.multi_dot([x_A, x_B, x_C])
+# 期望返回 shape 为 (2, 3) 的全零 Tensor
+```
+
+上述调用中 `B` 的 shape 为 `[10, 0]`，`C` 的 shape 为 `[0, 3]`，最终输出 shape 为 `[2, 3]`（非零大小）。按照 `numpy.linalg.multi_dot` 的语义，当输入中包含 0-size Tensor 时，该调用应正常完成：
+- 如果输出 tensor 的 numel 为 0，直接返回空 Tensor
+- 如果输出 tensor 的 numel 大于 0（如上述例子），应返回全零 Tensor
+
+需要在 C++ kernel 层添加 0-size 早期返回处理：
+- 在 `MultiDotKernel` 中，检查是否有任何输入 `x[i]->numel() == 0`，如果有：
+  - 当输出 `out->numel() > 0` 时，用 `phi::Full` 填充全零
+  - 直接返回，跳过后续 BLAS 计算
+- 在 `MultiDotGradKernel` 中，检查是否有任何梯度 `dx[i]->numel() == 0`，如果有：
+  - 对 numel > 0 的梯度用 `phi::Full` 填充全零
+  - 直接返回，跳过后续梯度计算
+
+## 验收说明
+
+- 当输入中包含 0-size Tensor 时，`paddle.linalg.multi_dot` 应正常完成
+- 输出 shape 应正确（按照矩阵乘法链式规则推导）
+- 当输出 numel > 0 时，应返回全零 Tensor
+- 当输出 numel == 0 时，应返回空 Tensor
+- 非 0-size Tensor 输入下的 multi_dot 行为不得退化
+- 梯度计算也应正常工作
+
+## 技术要求
+
+- 熟悉 C++ 和 Paddle PHI kernel 开发
+- 了解 Tensor shape、0-size Tensor 和 kernel 执行路径
+- 了解 multi_dot 算子的输入输出语义（多矩阵链式乘法）
+- 了解 Paddle CPU/GPU kernel 的模板实现模式
+- 需要从源码编译 Paddle 以验证修改

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73122/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73122/proposal.md
@@ -1,0 +1,58 @@
+# SWE-Paddle Task Proposal: PaddlePaddle__Paddle-73122
+
+## 1. 来源信息
+
+- Instance ID: `PaddlePaddle__Paddle-73122`
+- PR 链接: https://github.com/PaddlePaddle/Paddle/pull/73122
+- PR 标题: `[0-size Tensor No.112] Add 0-size Tensor support for multi_dot`
+- Base commit: `2624aee95b82873848e34fc3e5673a1ac42f84c4`
+- Gold commit: `29b711ba8db211ed31b3354562f62fb5ce568b40`
+- Merged at: 2025-06-11
+- 你的身份: contributor
+
+## 2. 问题一句话
+
+`paddle.linalg.multi_dot` 在输入中包含 0-size Tensor 时，C++ kernel 未处理 0-size 边界情况导致崩溃或报错，需要在 kernel 入口添加 0-size 早期返回逻辑，并对输出 numel > 0 的情况填充全零。
+
+## 3. 为什么适合作为 SWE-Paddle 样本
+
+- **真实性**: 来自 Paddle「0-size Tensor 机制建设」系列任务，是真实研发需求。
+- **代表性**: 覆盖 C++ kernel 层面的 0-size Tensor 边界处理，涉及前向和反向两个 kernel。
+- **边界清楚**: 目标仅限输入包含 0-size 时的 kernel 早期返回；正向非零尺寸输入不应受影响。
+- **非平凡性**: 修复需要在 `MultiDotKernel` 和 `MultiDotGradKernel` 中分别添加 0-size 检查，且需要处理输出 numel > 0 的特殊情况（用 `phi::Full` 填充全零），涉及对多矩阵链式乘法语义和 kernel 执行流程的理解。
+- **回归护栏明确**: 目标 F2P 可覆盖 0-size Tensor 输入的 `multi_dot` 算子测试；同文件中已有的 `TestMultiDotOp` 等标准测试用例可作为 P2P 护栏。
+
+## 4. 任务类型和标签
+
+- 任务类型: `bug_fix`
+- 执行后端: `cpu`
+- 设备范围: `cpu_only`
+- 模块标签: `[operator_kernel, multi_dot, 0-size_tensor, cpu_kernel, gpu_kernel]`
+
+## 5. 验证思路
+
+- 目标测试命令: `bash tests/test.sh`
+- 目标测试文件:
+  - `test/legacy_test/test_multi_dot_op.py`（`TestMultiDotOp_ZeroSize1`）
+- P2P 候选: 同文件中已有的 `TestMultiDotOp`、`TestMultiDotOp_Float16` 等标准 multi_dot 算子测试用例。
+- 修复前预期: `base_commit` + `tests/test.patch` 后，0-size Tensor 输入的 `multi_dot` 算子测试失败（kernel 崩溃或 BLAS 报错）。
+- 修复后预期: 继续应用 `solution/code.patch` 并重新编译后，0-size Tensor 输入正常返回正确结果，P2P 存量测试仍然通过。
+
+## 6. 环境与资源
+
+- 是否能提供 Docker: 无
+- Dockerfile 或镜像地址: 暂无
+- Paddle 来源: `PaddlePaddle/Paddle` source checkout at `base_commit`，需要源码编译。
+- OS / Python / CUDA / cuDNN / 其他关键依赖: Linux CPU + Python + numpy；编译需要 CMake、GCC；不要求 CUDA/cuDNN（CPU 编译即可验证）。
+- 硬件: CPU 即可（编译和测试均不需要 GPU）。
+- patch 类型: 含 C++ kernel 修改（模板头文件，CPU/GPU 双端），需要重新编译 Paddle。
+- 最小测试命令: `bash tests/test.sh`
+- 是否有 oracle 日志: 无
+
+## 7. 风险自查
+
+- 泄露风险: 正式 `instruction.md` 只描述「multi_dot 对 0-size Tensor 输入的行为异常」，不指出具体 `numel() == 0` 分支逻辑或具体代码位置。
+- 环境风险: 中。任务涉及 C++ kernel 修改，需要源码编译 Paddle，编译时间较长。
+- flaky 风险: 低。测试使用固定的 0-size Tensor 构造，不依赖随机数差异或多设备同步。
+- 拆分风险: 低。该 PR 目标集中在 `multi_dot` 的前向和反向 kernel 的 0-size 早期返回，测试明确指向 `TestMultiDotOp_ZeroSize1`，适合作为一个独立样本。
+- 其他不确定点: 完整任务包阶段应确认新增 F2P 在 `base_commit` 编译后确实失败。注意该 PR 修改的是模板头文件 `multi_dot_kernel_impl.h`，CPU 和 GPU kernel 都会受影响。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73122/solution/code.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73122/solution/code.patch
@@ -1,0 +1,75 @@
+diff --git a/paddle/phi/kernels/impl/multi_dot_kernel_impl.h b/paddle/phi/kernels/impl/multi_dot_kernel_impl.h
+index dfd985769abdb..3300f843c2d38 100644
+--- a/paddle/phi/kernels/impl/multi_dot_kernel_impl.h
++++ b/paddle/phi/kernels/impl/multi_dot_kernel_impl.h
+@@ -12,25 +12,11 @@
+ // See the License for the specific language governing permissions and
+ // limitations under the License.
+ 
+-/* Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+-
+-Licensed under the Apache License, Version 2.0 (the "License");
+-you may not use this file except in compliance with the License.
+-You may obtain a copy of the License at
+-
+-    http://www.apache.org/licenses/LICENSE-2.0
+-
+-Unless required by applicable law or agreed to in writing, software
+-distributed under the License is distributed on an "AS IS" BASIS,
+-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-See the License for the specific language governing permissions and
+-limitations under the License. */
+-
+ #pragma once
+ 
+ #include "paddle/phi/core/dense_tensor.h"
++#include "paddle/phi/kernels/full_kernel.h"
+ #include "paddle/phi/kernels/funcs/blas/blas.h"
+-
+ namespace phi {
+ 
+ template <typename Context, typename T>
+@@ -195,6 +181,19 @@ void MultiDotKernel(const Context& dev_ctx,
+   std::vector<phi::DDim> ins_dims(n);
+   GetDims<Context, T>(ins, &ins_dims);
+ 
++  // If any numel is 0, then return.
++  bool size_0 = false;
++  for (size_t i = 0; i < n; i++) {
++    if (x[i]->numel() == 0) size_0 = true;
++  }
++  if (size_0) {
++    // For example: [2, 0], [0, 4] -> [2, 4]
++    if (out && out->numel() > 0) {
++      phi::Full<T, Context>(
++          dev_ctx, phi::IntArray(common::vectorize(out->dims())), 0, out);
++    }
++    return;
++  }
+   const T scale = static_cast<T>(1.0);
+   if (n == 2) {
+     auto mat_dim_a = phi::funcs::CreateMatrixDescriptor(ins_dims[0], 0, false);
+@@ -347,9 +346,23 @@ void MultiDotGradKernel(const Context& dev_ctx,
+ 
+   auto blas = phi::funcs::GetBlas<Context, T>(ctx);
+ 
++  bool size_0 = false;
+   const auto n = ins.size();
+   for (size_t i = 0; i < n; i++) {
+     ctx.template Alloc<T>(dx[i]);
++
++    if (dx[i]->numel() == 0) {
++      size_0 = true;
++    }
++  }
++  if (size_0) {
++    for (size_t i = 0; i < n; i++) {
++      if (dx[i]->numel() > 0) {
++        phi::Full<T, Context>(
++            dev_ctx, phi::IntArray(common::vectorize(dx[i]->dims())), 0, dx[i]);
++      }
++    }
++    return;
+   }
+ 
+   std::vector<phi::DDim> ins_dims(n);

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73122/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73122/tests/test.patch
@@ -1,0 +1,48 @@
+diff --git a/test/legacy_test/test_multi_dot_op.py b/test/legacy_test/test_multi_dot_op.py
+index 308b9c1cc0652..2335ed31fb33e 100644
+--- a/test/legacy_test/test_multi_dot_op.py
++++ b/test/legacy_test/test_multi_dot_op.py
+@@ -31,14 +31,19 @@ def setUp(self):
+         self.op_type = "multi_dot"
+         self.python_api = paddle.linalg.multi_dot
+         self.dtype = self.get_dtype()
++        self.init_shape()
+         self.get_inputs_and_outputs()
+ 
++    def init_shape(self):
++        self.A_shape = (2, 8)
++        self.B_shape = (8, 4)
++
+     def get_dtype(self):
+         return "float64"
+ 
+     def get_inputs_and_outputs(self):
+-        self.A = np.random.random((2, 8)).astype(self.dtype)
+-        self.B = np.random.random((8, 4)).astype(self.dtype)
++        self.A = np.random.random(self.A_shape).astype(self.dtype)
++        self.B = np.random.random(self.B_shape).astype(self.dtype)
+         self.inputs = {'X': [('x0', self.A), ('x1', self.B)]}
+         self.outputs = {'Out': multi_dot([self.A, self.B])}
+ 
+@@ -55,6 +60,36 @@ def get_dtype(self):
+         return "float16"
+ 
+ 
++class TestMultiDotOp_ZeroSize1(TestMultiDotOp):
++    def get_inputs_and_outputs(self):
++        # result shape: [2, 3]
++        self.A = np.random.random((2, 10)).astype(self.dtype)
++        self.B = np.random.random((10, 0)).astype(self.dtype)
++        self.C = np.random.random((0, 3)).astype(self.dtype)
++        self.inputs = {'X': [('x0', self.A), ('x1', self.B), ('x2', self.C)]}
++        self.outputs = {'Out': multi_dot([self.A, self.B, self.C])}
++
++    def test_check_grad(self):
++        self.check_grad(['x0'], 'Out', check_pir=True)
++        self.check_grad(['x1'], 'Out', check_pir=True)
++        self.check_grad(['x2'], 'Out', check_pir=True)
++
++
+ @unittest.skipIf(
+     not core.is_compiled_with_cuda()
+     or not core.is_bfloat16_supported(core.CUDAPlace(0)),

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73122/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73122/tests/test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# P2P tests (pass-to-pass)
+python -m pytest test/legacy_test/test_multi_dot_op.py::TestMultiDotOp -q
+
+# F2P tests (fail-to-pass)
+python -m pytest test/legacy_test/test_multi_dot_op.py::TestMultiDotOp_ZeroSize1 -q


### PR DESCRIPTION
### 关联

- SWE-Paddle 共建 issue: [[Call for Bench] SWE-Paddle 社区共建 Paddle#79447](https://github.com/PaddlePaddle/Paddle/issues/79447)
- 来源 PR: [[0-size Tensor No.112] Add 0-size Tensor support for multi_dot Paddle#73122](https://github.com/PaddlePaddle/Paddle/pull/73122)

### 说明

新增 SWE-Paddle 任务 `PaddlePaddle__Paddle-73122`。

该任务覆盖 `paddle.linalg.multi_dot` 对 0-size Tensor 的处理。测试包含非 0-size Tensor regression case，以及 `multi_dot` 的目标场景，可在 CPU 环境运行。

### 验证结果

状态 | P2P | multi_dot F2P  
---|---|---  
Base + `tests/test.patch` | PASS | FAIL  
Base + test patch + `solution/code.patch` | PASS | PASS  

#### Base P2P 
```
2 passed, 2 warnings in 1.36s
```    

#### Base F2P：multi_dot
```
FAILED test/legacy_test/test_multi_dot_op.py::TestMultiDotOp_ZeroSize1::test_check_output - AssertionError: 
1 failed, 1 passed, 2 warnings in 1.65s
```  

#### Solution P2P
```
2 passed, 2 warnings in 1.46s
```
    

#### Solution F2P：multi_dot
```
2 passed, 2 warnings in 1.42s
```
    