### PR TITLE
[SWE-Paddle] Add task PaddlePaddle__Paddle-72800

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-72800/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-72800/README.md
@@ -1,0 +1,51 @@
+# PaddlePaddle__Paddle-72800
+
+This directory converts Paddle PR #72800 into a SWE-Paddle community task candidate.
+
+## Source
+
+| Field | Value |
+| --- | --- |
+| Repo | `PaddlePaddle/Paddle` |
+| PR | [72800](https://github.com/PaddlePaddle/Paddle/pull/72800) |
+| PR title | `[0-size Tensor No.39、40] Add 0-size Tensor support for cummin/cummax` |
+| Base commit | `705356a392f8cbdf0571cd60f8c0462eab424a80` |
+| Gold commit | `beaa40bddb70ca079979c4a54f053aaf64d549ce` |
+| Merged at | `2025-05-27` |
+| Task type | `bug_fix` |
+| Resource | CPU |
+| Scope | C++ Operator Kernel |
+
+## Summary
+
+Fix `paddle.cummin` and `paddle.cummax` to correctly handle 0-size tensors in CPU/GPU kernels by adding early-return logic when output has 0 elements.
+
+## Why This Is A Good SWE-Paddle Candidate
+
+- It is derived from a merged Paddle bug-fix PR rather than a synthetic issue.
+- The target behavior is isolated to the C++ operator kernel level and requires rebuilding Paddle from source.
+- The failure is deterministic: the base revision fails when processing 0-size tensors due to missing early-return logic in cummin/cummax kernels.
+- The task has clear regression coverage for existing non-zero-size behavior.
+- The task runs on CPU and does not require distributed execution, external services, or additional datasets.
+
+## Files
+
+- `proposal.md`: candidate proposal for maintainer triage.
+- `instruction.md`: self-contained problem statement for the coding agent.
+- `solution/code.patch`: gold implementation patch (C++ kernel changes).
+- `tests/test.patch`: tests exposing the target behavior.
+- `tests/test.sh`: minimal target test command.
+- `environment/README.md`: environment and reproduction notes.
+
+## Verification
+
+```bash
+bash tests/test.sh
+```
+
+Expected behavior:
+
+| Revision state | Existing behavior (P2P) | cummin/cummax F2P |
+| --- | ---: | ---: |
+| Base + `tests/test.patch` | PASS | FAIL |
+| Base + `tests/test.patch` + `solution/code.patch` | PASS | PASS |

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-72800/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-72800/environment/README.md
@@ -1,0 +1,52 @@
+# Environment Notes
+
+## Expected Environment
+
+- Repository: `PaddlePaddle/Paddle`
+- Base commit: `705356a392f8cbdf0571cd60f8c0462eab424a80`
+- Gold commit: `beaa40bddb70ca079979c4a54f053aaf64d549ce`
+- Resource: CPU
+- GPU required: no
+- Patch type: C++ kernel (CPU/GPU backends)
+- Python dependencies: PaddlePaddle (source build), NumPy
+
+The verifier should execute against the Paddle source revision represented by the selected patch state. A source build is required since the patch modifies C++ kernel code.
+
+## Build Instructions
+
+1. Check out `PaddlePaddle/Paddle` at the base commit.
+2. Apply `tests/test.patch`.
+3. Build Paddle from source (CPU-only build is sufficient):
+   ```bash
+   mkdir build && cd build
+   cmake .. -DWITH_GPU=OFF -DWITH_TESTING=ON -DCMAKE_BUILD_TYPE=Release
+   make -j$(nproc)
+   ```
+4. Install the built Paddle package.
+
+## Run Order
+
+1. Check out `PaddlePaddle/Paddle` at the base commit.
+2. Build and install Paddle from source.
+3. Apply `tests/test.patch`.
+4. Run the P2P tests; existing non-zero-size behavior should pass.
+5. Run the 0-size tensor tests; the target case should fail before the fix.
+6. Apply `solution/code.patch`.
+7. Rebuild Paddle from source.
+8. Reinstall Paddle package.
+9. Run `bash tests/test.sh`; all target tests should pass.
+
+## Minimal Test Command
+
+```bash
+bash tests/test.sh
+```
+
+## Expected Matrix
+
+| Revision state | P2P | cummin/cummax F2P |
+| --- | ---: | ---: |
+| Base + test patch | PASS | FAIL |
+| Base + test patch + solution patch | PASS | PASS |
+
+No GPU, distributed runtime, external service, or additional dataset is required.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-72800/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-72800/instruction.md
@@ -1,0 +1,50 @@
+# 修复 `paddle.cummin` 和 `paddle.cummax` 对 0-size Tensor 的处理
+
+## 详细描述
+
+当 `paddle.cummin(x, axis)` 或 `paddle.cummax(x, axis)` 的输入 `x` 为 0-size Tensor 时，当前 CPU/GPU kernel 实现会直接进入后续计算逻辑，导致 kernel 内部对空数据执行计算或产生其他错误。
+
+典型表现包括：
+
+- kernel 在执行累积计算时崩溃或报错
+- 0-size Tensor 输入无法通过 `cummin` 或 `cummax` 算子
+
+例如：
+
+```python
+import numpy as np
+import paddle
+
+paddle.disable_static()
+
+# cummax 0-size tensor 输入
+x = paddle.to_tensor(np.random.rand(20, 0).astype('float64'))
+out, indices = paddle.cummax(x, axis=-1)
+# 期望返回 out shape 为 (20, 0)，indices shape 为 (20, 0) 的空 Tensor
+
+# cummin 0-size tensor 输入
+x = paddle.to_tensor(np.random.rand(10, 0).astype('float64'))
+out, indices = paddle.cummin(x, axis=-1)
+# 期望返回 out shape 为 (10, 0)，indices shape 为 (10, 0) 的空 Tensor
+```
+
+上述调用中 `x` 的 shape 为 `[20, 0]` 或 `[10, 0]`，输出 shape 也为相应的 0-size shape。按照 numpy 的语义，0-size Tensor 的累积最小/最大值计算应正常返回正确 shape 的空 Tensor。
+
+需要在 CPU/GPU kernel 层添加 0-size 早期返回处理：
+- 在 `ScanWithIndicesKernel`（cummin/cummax 前向）中，检查输出 `out->numel() == 0` 并直接返回
+- 在 `CummaxGradKernel` 和 `CumminGradKernel`（反向）中，检查梯度 `x_grad->numel() == 0` 并直接返回
+
+## 验收说明
+
+- 当输入为 0-size Tensor 时，`paddle.cummin` 和 `paddle.cummax` 应正常完成，返回正确 shape 的空 Tensor
+- 输出的 shape 应与输入一致
+- 非 0-size Tensor 输入下的 cummin/cummax 行为不得退化
+- 梯度计算也应正常工作（0-size Tensor 的梯度也为空 Tensor）
+
+## 技术要求
+
+- 熟悉 C++ 和 Paddle PHI kernel 开发
+- 了解 Tensor shape、0-size Tensor 和 kernel 执行路径
+- 了解 cummin 和 cummax 算子的输入输出语义
+- 了解 Paddle CPU/GPU kernel 的实现模式
+- 需要从源码编译 Paddle 以验证修改

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-72800/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-72800/proposal.md
@@ -1,0 +1,59 @@
+# SWE-Paddle Task Proposal: PaddlePaddle__Paddle-72800
+
+## 1. 来源信息
+
+- Instance ID: `PaddlePaddle__Paddle-72800`
+- PR 链接: https://github.com/PaddlePaddle/Paddle/pull/72800
+- PR 标题: `[0-size Tensor No.39、40] Add 0-size Tensor support for cummin/cummax`
+- Base commit: `705356a392f8cbdf0571cd60f8c0462eab424a80`
+- Gold commit: `beaa40bddb70ca079979c4a54f053aaf64d549ce`
+- Merged at: 2025-05-27
+- 你的身份: contributor
+
+## 2. 问题一句话
+
+`paddle.cummin` 和 `paddle.cummax` 在输入为 0-size Tensor 时，CPU/GPU kernel 未处理 0-size 边界情况导致崩溃或报错，需要在 kernel 入口添加 0-size 早期返回逻辑。
+
+## 3. 为什么适合作为 SWE-Paddle 样本
+
+- **真实性**: 来自 Paddle「0-size Tensor 机制建设」系列任务，是真实研发需求。
+- **代表性**: 覆盖 C++ kernel 层面的 0-size Tensor 边界处理，涉及 CPU/GPU 双端 kernel 和梯度 kernel。
+- **边界清楚**: 目标仅限输入为 0-size 时的 kernel 早期返回；正向非零尺寸输入不应受影响。
+- **非平凡性**: 修复需要在 `ScanWithIndicesKernel`（前向）和 `CummaxGradKernel`/`CumminGradKernel`（反向）中分别添加 `numel() == 0` 的早期返回，涉及对 kernel 执行流程的理解。
+- **回归护栏明确**: 目标 F2P 可覆盖 0-size Tensor 输入的 `cummin` 和 `cummax` 算子测试；同文件中已有的标准测试用例可作为 P2P 护栏。
+
+## 4. 任务类型和标签
+
+- 任务类型: `bug_fix`
+- 执行后端: `cpu`
+- 设备范围: `cpu_only`
+- 模块标签: `[operator_kernel, cummin, cummax, 0-size_tensor, cpu_kernel, gpu_kernel]`
+
+## 5. 验证思路
+
+- 目标测试命令: `bash tests/test.sh`
+- 目标测试文件:
+  - `test/legacy_test/test_cummax_op.py`（`TestCummaxOp_ZeroSize`）
+  - `test/legacy_test/test_cummin_op.py`（`TestCumminOp_ZeroSize`）
+- P2P 候选: 同文件中已有的 `TestCummaxOp`、`TestCumminOp` 等标准算子测试用例。
+- 修复前预期: `base_commit` + `tests/test.patch` 后，0-size Tensor 输入的算子测试失败（kernel 崩溃或报错）。
+- 修复后预期: 继续应用 `solution/code.patch` 并重新编译后，0-size Tensor 输入正常返回空 Tensor，P2P 存量测试仍然通过。
+
+## 6. 环境与资源
+
+- 是否能提供 Docker: 无
+- Dockerfile 或镜像地址: 暂无
+- Paddle 来源: `PaddlePaddle/Paddle` source checkout at `base_commit`，需要源码编译。
+- OS / Python / CUDA / cuDNN / 其他关键依赖: Linux CPU + Python + numpy；编译需要 CMake、GCC；不要求 CUDA/cuDNN（CPU 编译即可验证）。
+- 硬件: CPU 即可（编译和测试均不需要 GPU）。
+- patch 类型: 含 C++ kernel 修改（CPU/GPU 双端），需要重新编译 Paddle。
+- 最小测试命令: `bash tests/test.sh`
+- 是否有 oracle 日志: 无
+
+## 7. 风险自查
+
+- 泄露风险: 正式 `instruction.md` 只描述「cummin/cummax 对 0-size Tensor 输入的行为异常」，不指出具体 `numel() == 0` 分支逻辑或具体代码位置。
+- 环境风险: 中。任务涉及 C++ kernel 修改，需要源码编译 Paddle，编译时间较长。
+- flaky 风险: 低。测试使用固定的 0-size Tensor 构造，不依赖随机数差异或多设备同步。
+- 拆分风险: 低。该 PR 目标集中在 `cummin` 和 `cummax` 的 CPU/GPU kernel 0-size 早期返回，测试明确指向新增的 ZeroSize 测试类，适合作为一个独立样本。
+- 其他不确定点: 完整任务包阶段应确认新增 F2P 在 `base_commit` 编译后确实失败。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-72800/solution/code.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-72800/solution/code.patch
@@ -1,0 +1,58 @@
+diff --git a/paddle/phi/kernels/cpu/cum_maxmin_kernel.cc b/paddle/phi/kernels/cpu/cum_maxmin_kernel.cc
+index f126a986947d1..49f58069c27e0 100644
+--- a/paddle/phi/kernels/cpu/cum_maxmin_kernel.cc
++++ b/paddle/phi/kernels/cpu/cum_maxmin_kernel.cc
+@@ -114,6 +114,11 @@ void ScanWithIndicesKernel(const Context& dev_ctx,
+                            int axis,
+                            DenseTensor* out,
+                            DenseTensor* indices) {
++  if (out && out->numel() == 0) {
++    dev_ctx.template Alloc<T1>(out);
++    dev_ctx.template Alloc<T2>(indices);
++    return;
++  }
+   dev_ctx.template Alloc<T1>(out);
+   dev_ctx.template Alloc<T2>(indices);
+ 
+diff --git a/paddle/phi/kernels/gpu/cum_maxmin_grad_kernel.cu b/paddle/phi/kernels/gpu/cum_maxmin_grad_kernel.cu
+index d7341e55e2349..3571789da9897 100644
+--- a/paddle/phi/kernels/gpu/cum_maxmin_grad_kernel.cu
++++ b/paddle/phi/kernels/gpu/cum_maxmin_grad_kernel.cu
+@@ -30,6 +30,10 @@ void CummaxGradKernel(const Context& dev_ctx,
+                       int axis,
+                       DataType dtype,
+                       DenseTensor* x_grad) {
++  if (x_grad && x_grad->numel() == 0) {
++    dev_ctx.template Alloc<T>(x_grad);
++    return;
++  }
+   dev_ctx.template Alloc<T>(x_grad);
+   phi::funcs::SetConstant<Context, T> functor;
+   functor(dev_ctx, x_grad, static_cast<T>(0));
+@@ -54,6 +58,10 @@ void CumminGradKernel(const Context& dev_ctx,
+                       int axis,
+                       DataType dtype,
+                       DenseTensor* x_grad) {
++  if (x_grad && x_grad->numel() == 0) {
++    dev_ctx.template Alloc<T>(x_grad);
++    return;
++  }
+   dev_ctx.template Alloc<T>(x_grad);
+   phi::funcs::SetConstant<Context, T> functor;
+   functor(dev_ctx, x_grad, static_cast<T>(0));
+diff --git a/paddle/phi/kernels/gpu/cum_maxmin_kernel.cu b/paddle/phi/kernels/gpu/cum_maxmin_kernel.cu
+index db5972453f5d5..1c37f2d60f81e 100644
+--- a/paddle/phi/kernels/gpu/cum_maxmin_kernel.cu
++++ b/paddle/phi/kernels/gpu/cum_maxmin_kernel.cu
+@@ -226,6 +226,11 @@ void ScanWithIndicesKernel(const Context& dev_ctx,
+                            T1 init,
+                            DenseTensor* out,
+                            DenseTensor* indices) {
++  if (out && out->numel() == 0) {
++    dev_ctx.template Alloc<T1>(out);
++    dev_ctx.template Alloc<T2>(indices);
++    return;
++  }
+   dev_ctx.template Alloc<T1>(out);
+   dev_ctx.template Alloc<T2>(indices);
+   // For 0D Tensor

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-72800/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-72800/tests/test.patch
@@ -1,0 +1,72 @@
+diff --git a/test/legacy_test/test_cummax_op.py b/test/legacy_test/test_cummax_op.py
+index 3d77a0a5035bb..11be8005b0f07 100644
+--- a/test/legacy_test/test_cummax_op.py
++++ b/test/legacy_test/test_cummax_op.py
+@@ -77,7 +77,8 @@ def setUp(self):
+         self.dtype = np.float64
+         self.axis = -1
+         self.indices_type = paddle.int64
+-        self.input_data = np.random.random((10, 10)).astype(self.dtype)
++        self.init_shape()
++        self.input_data = np.random.random(self.shape).astype(self.dtype)
+         self.set_attrs()
+ 
+         self.inputs = {'x': self.input_data}
+@@ -88,6 +89,9 @@ def setUp(self):
+     def set_attrs(self):
+         pass
+ 
++    def init_shape(self):
++        self.shape = (10, 10)
++
+     def test_check_output(self):
+         paddle.enable_static()
+         self.check_output(check_pir=True)
+@@ -112,6 +116,11 @@ def set_attrs(self):
+         self.indices_type = paddle.int32
+ 
+ 
++class TestCummaxOp_ZeroSize(TestCummaxOp):
++    def init_shape(self):
++        self.shape = (20, 0)
++
++
+ class TestCummaxAPI(unittest.TestCase):
+     def run_cases(self):
+         data_np = np.random.random((100, 100)).astype(np.float32)
+diff --git a/test/legacy_test/test_cummin_op.py b/test/legacy_test/test_cummin_op.py
+index 0c7df3b0cec74..43a394b5b34bf 100644
+--- a/test/legacy_test/test_cummin_op.py
++++ b/test/legacy_test/test_cummin_op.py
+@@ -77,7 +77,8 @@ def setUp(self):
+         self.dtype = np.float64
+         self.axis = -1
+         self.indices_type = paddle.int64
+-        self.input_data = np.random.random((10, 10)).astype(self.dtype)
++        self.init_shape()
++        self.input_data = np.random.random(self.shape).astype(self.dtype)
+         self.set_attrs()
+ 
+         self.inputs = {'x': self.input_data}
+@@ -88,6 +89,9 @@ def setUp(self):
+     def set_attrs(self):
+         pass
+ 
++    def init_shape(self):
++        self.shape = (10, 10)
++
+     def test_check_output(self):
+         paddle.enable_static()
+         self.check_output(check_pir=True)
+@@ -112,6 +116,11 @@ def set_attrs(self):
+         self.indices_type = paddle.int32
+ 
+ 
++class TestCumminOp_ZeroSize(TestCumminOp):
++    def init_shape(self):
++        self.shape = (10, 0)
++
++
+ class TestCumminAPI(unittest.TestCase):
+     def run_cases(self):
+         data_np = np.random.random((100, 100)).astype(np.float32)

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-72800/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-72800/tests/test.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# P2P tests (pass-to-pass)
+python -m pytest test/legacy_test/test_cummax_op.py::TestCummaxOp -q
+python -m pytest test/legacy_test/test_cummin_op.py::TestCumminOp -q
+
+# F2P tests (fail-to-pass)
+python -m pytest test/legacy_test/test_cummax_op.py::TestCummaxOp_ZeroSize -q
+python -m pytest test/legacy_test/test_cummin_op.py::TestCumminOp_ZeroSize -q


### PR DESCRIPTION
### 关联

- SWE-Paddle 共建 issue: [[Call for Bench] SWE-Paddle 社区共建 Paddle#79447](https://github.com/PaddlePaddle/Paddle/issues/79447)
- 来源 PR: [[0-size Tensor No.39、40] Add 0-size Tensor support for cummin/cummax Paddle#72800](https://github.com/PaddlePaddle/Paddle/pull/72800)

### 说明

新增 SWE-Paddle 任务 `PaddlePaddle__Paddle-72800`。

该任务覆盖 `paddle.cummin` 和 `paddle.cummax` 对 0-size Tensor 的处理。测试包含非 0-size Tensor regression case，以及 cummin/cummax 的目标场景，可在 CPU 环境运行。

### 验证结果

| 状态 | P2P | cummin/cummax F2P |
|---|---|---|
| Base + `tests/test.patch` | PASS | FAIL |
| Base + test patch + `solution/code.patch` | PASS | PASS |

#### Base P2P
    
```
2 passed, 3 warnings in 1.35s
2 passed, 3 warnings in 1.30s
```
    

#### Base F2P：cummin/cummax
    
```
Segmentation fault (core dumped)
Segmentation fault (core dumped)
```
    

#### Solution P2P
```
2 passed, 2 warnings in 1.32s
2 passed, 2 warnings in 1.31s
```

#### Solution F2P：cummin/cummax
```
2 passed, 2 warnings in 1.33s
2 passed, 2 warnings in 1.32s
```
    