### PR TITLE
[SWE-Paddle] Add task PaddlePaddle__Paddle-73569

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73569/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73569/README.md
@@ -1,0 +1,51 @@
+# PaddlePaddle__Paddle-73569
+
+This directory converts Paddle PR #73569 into a SWE-Paddle community task candidate.
+
+## Source
+
+| Field | Value |
+| --- | --- |
+| Repo | `PaddlePaddle/Paddle` |
+| PR | [73569](https://github.com/PaddlePaddle/Paddle/pull/73569) |
+| PR title | `[Accuracy diff No.104] Fix accuracy diff for paddle.matmul API` |
+| Base commit | `434044ec20095341e74558c4612a0fe62fcc6508` |
+| Gold commit | `1399f8e514c134020f260ad3a79bc889dde810b4` |
+| Merged at | `2025-06-27` |
+| Task type | `bug_fix` |
+| Resource | CPU |
+| Scope | C++ Operator Kernel |
+
+## Summary
+
+Fix accuracy difference for `paddle.matmul` API when `y` is a 1-D tensor and `transpose_y` is True. The issue was that the gradient kernel incorrectly handled the transpose flag for 1-D `y` tensors.
+
+## Why This Is A Good SWE-Paddle Candidate
+
+- It is derived from a merged Paddle bug-fix PR rather than a synthetic issue.
+- The target behavior is isolated to the C++ operator kernel level and requires rebuilding Paddle from source.
+- The failure is deterministic: the base revision produces incorrect gradient results when `y` is 1-D and `transpose_y=True`.
+- The task has clear regression coverage for existing matmul behavior.
+- The task runs on CPU and does not require distributed execution, external services, or additional datasets.
+
+## Files
+
+- `proposal.md`: candidate proposal for maintainer triage.
+- `instruction.md`: self-contained problem statement for the coding agent.
+- `solution/code.patch`: gold implementation patch (C++ kernel changes).
+- `tests/test.patch`: tests exposing the target behavior.
+- `tests/test.sh`: minimal target test command.
+- `environment/README.md`: environment and reproduction notes.
+
+## Verification
+
+```bash
+bash tests/test.sh
+```
+
+Expected behavior:
+
+| Revision state | Existing behavior (P2P) | matmul F2P |
+| --- | ---: | ---: |
+| Base + `tests/test.patch` | PASS | FAIL |
+| Base + `tests/test.patch` + `solution/code.patch` | PASS | PASS |

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73569/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73569/environment/README.md
@@ -1,0 +1,52 @@
+# Environment Notes
+
+## Expected Environment
+
+- Repository: `PaddlePaddle/Paddle`
+- Base commit: `434044ec20095341e74558c4612a0fe62fcc6508`
+- Gold commit: `1399f8e514c134020f260ad3a79bc889dde810b4`
+- Resource: CPU
+- GPU required: no
+- Patch type: C++ kernel (CPU/XPU backends)
+- Python dependencies: PaddlePaddle (source build), NumPy
+
+The verifier should execute against the Paddle source revision represented by the selected patch state. A source build is required since the patch modifies C++ kernel code.
+
+## Build Instructions
+
+1. Check out `PaddlePaddle/Paddle` at the base commit.
+2. Apply `tests/test.patch`.
+3. Build Paddle from source (CPU-only build is sufficient):
+   ```bash
+   mkdir build && cd build
+   cmake .. -DWITH_GPU=OFF -DWITH_TESTING=ON -DCMAKE_BUILD_TYPE=Release
+   make -j$(nproc)
+   ```
+4. Install the built Paddle package.
+
+## Run Order
+
+1. Check out `PaddlePaddle/Paddle` at the base commit.
+2. Build and install Paddle from source.
+3. Apply `tests/test.patch`.
+4. Run the P2P tests; existing non-1-D y behavior should pass.
+5. Run the 1-D y tensor test; the target case should fail before the fix.
+6. Apply `solution/code.patch`.
+7. Rebuild Paddle from source.
+8. Reinstall Paddle package.
+9. Run `bash tests/test.sh`; all target tests should pass.
+
+## Minimal Test Command
+
+```bash
+bash tests/test.sh
+```
+
+## Expected Matrix
+
+| Revision state | P2P | matmul F2P |
+| --- | ---: | ---: |
+| Base + test patch | PASS | FAIL |
+| Base + test patch + solution patch | PASS | PASS |
+
+No GPU, distributed runtime, external service, or additional dataset is required.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73569/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73569/instruction.md
@@ -1,0 +1,52 @@
+# 修复 `paddle.matmul` 在 y 为 1-D 张量且 transpose_y=True 时的精度问题
+
+## 详细描述
+
+当 `paddle.matmul(x, y, transpose_y=True)` 中 `y` 为 1-D 张量时，当前 CPU/XPU 梯度 kernel 实现存在精度问题。问题出在梯度计算时，对于 1-D 的 `y` 张量，`transpose_y` 标志的处理不正确，导致梯度计算结果与预期不符。
+
+典型表现包括：
+
+- 梯度计算结果与 numpy 参考实现不一致
+- 在 `y` 为 1-D 且 `transpose_y=True` 时，梯度检查失败
+
+例如：
+
+```python
+import numpy as np
+import paddle
+
+paddle.disable_static()
+
+# x: (2, 100), y: (100,), transpose_y=True
+x = np.random.random((2, 100)).astype('float64')
+y = np.random.random((100,)).astype('float64')
+
+x_tensor = paddle.to_tensor(x, stop_gradient=False)
+y_tensor = paddle.to_tensor(y, stop_gradient=False)
+
+out = paddle.matmul(x_tensor, y_tensor, transpose_y=True)
+# out shape should be (2,)
+
+out.sum().backward()
+# x.grad and y.grad should match numpy reference
+```
+
+上述调用中 `y` 的 shape 为 `(100,)`，是一个 1-D 张量。当 `transpose_y=True` 时，按照 matmul 的语义，1-D 张量的转置应该被视为列向量，但在梯度计算中，这个标志的处理存在错误。
+
+需要在梯度 kernel 中添加对 1-D `y` 张量的特殊处理：
+- 在 `MatmulGradKernel` 中，当 `!transpose_x && transpose_y && y.dims().size() < 2` 时，将 `transpose_y` 设置为 `false`
+
+## 验收说明
+
+- 当 `y` 为 1-D 张量且 `transpose_y=True` 时，`paddle.matmul` 的前向和梯度计算应正确
+- 梯度结果应与 numpy 参考实现一致
+- 非 1-D `y` 张量输入下的 matmul 行为不得退化
+- `transpose_x` 和 `transpose_y` 的其他组合也应正常工作
+
+## 技术要求
+
+- 熟悉 C++ 和 Paddle PHI kernel 开发
+- 了解 matmul 算子的数学语义和梯度计算
+- 了解 1-D 张量在矩阵乘法中的特殊处理
+- 了解 Paddle CPU/XPU kernel 的实现模式
+- 需要从源码编译 Paddle 以验证修改

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73569/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73569/proposal.md
@@ -1,0 +1,58 @@
+# SWE-Paddle Task Proposal: PaddlePaddle__Paddle-73569
+
+## 1. 来源信息
+
+- Instance ID: `PaddlePaddle__Paddle-73569`
+- PR 链接: https://github.com/PaddlePaddle/Paddle/pull/73569
+- PR 标题: `[Accuracy diff No.104] Fix accuracy diff for paddle.matmul API`
+- Base commit: `434044ec20095341e74558c4612a0fe62fcc6508`
+- Gold commit: `1399f8e514c134020f260ad3a79bc889dde810b4`
+- Merged at: 2025-06-27
+- 你的身份: contributor
+
+## 2. 问题一句话
+
+`paddle.matmul` 在 `y` 为 1-D 张量且 `transpose_y=True` 时，梯度 kernel 对 `transpose_y` 标志处理不正确，导致梯度计算结果与预期不符。
+
+## 3. 为什么适合作为 SWE-Paddle 样本
+
+- **真实性**: 来自 Paddle「精度差异修复」系列任务，是真实研发需求。
+- **代表性**: 覆盖 C++ kernel 层面的 matmul 梯度计算边界情况处理，涉及 CPU 和 XPU 两端 kernel。
+- **边界清楚**: 目标仅限 `y` 为 1-D 且 `transpose_y=True` 时的特殊处理；其他情况不应受影响。
+- **非平凡性**: 修复需要在 `MatmulGradKernel` 中添加对 `!transpose_x && transpose_y && y.dims().size() < 2` 的检查，涉及对 matmul 数学语义和 1-D 张量特殊处理的理解。
+- **回归护栏明确**: 目标 F2P 可覆盖 1-D `y` 张量且 `transpose_y=True` 的 matmul 测试；同文件中已有的标准测试用例可作为 P2P 护栏。
+
+## 4. 任务类型和标签
+
+- 任务类型: `bug_fix`
+- 执行后端: `cpu`
+- 设备范围: `cpu_only`
+- 模块标签: `[operator_kernel, matmul, accuracy_diff, cpu_kernel, xpu_kernel]`
+
+## 5. 验证思路
+
+- 目标测试命令: `bash tests/test.sh`
+- 目标测试文件:
+  - `test/legacy_test/test_matmul_v2_op.py`（`TestMatMulOp_trans_y`）
+- P2P 候选: 同文件中已有的 `TestMatMulV2Op` 等标准 matmul 算子测试用例。
+- 修复前预期: `base_commit` + `tests/test.patch` 后，1-D `y` 张量且 `transpose_y=True` 的测试失败（梯度检查不通过）。
+- 修复后预期: 继续应用 `solution/code.patch` 并重新编译后，梯度计算正确，P2P 存量测试仍然通过。
+
+## 6. 环境与资源
+
+- 是否能提供 Docker: 无
+- Dockerfile 或镜像地址: 暂无
+- Paddle 来源: `PaddlePaddle/Paddle` source checkout at `base_commit`，需要源码编译。
+- OS / Python / CUDA / cuDNN / 其他关键依赖: Linux CPU + Python + numpy；编译需要 CMake、GCC；不要求 CUDA/cuDNN（CPU 编译即可验证）。
+- 硬件: CPU 即可（编译和测试均不需要 GPU）。
+- patch 类型: 含 C++ kernel 修改（CPU/XPU 双端），需要重新编译 Paddle。
+- 最小测试命令: `bash tests/test.sh`
+- 是否有 oracle 日志: 无
+
+## 7. 风险自查
+
+- 泄露风险: 正式 `instruction.md` 只描述「matmul 在 y 为 1-D 且 transpose_y=True 时的精度问题」，不指出具体 `!transpose_x && transpose_y && y.dims().size() < 2` 分支逻辑或具体代码位置。
+- 环境风险: 中。任务涉及 C++ kernel 修改，需要源码编译 Paddle，编译时间较长。
+- flaky 风险: 低。测试使用固定种子的随机数据，不依赖随机数差异或多设备同步。
+- 拆分风险: 低。该 PR 目标集中在 matmul 梯度 kernel 的 1-D y 张量特殊处理，测试明确指向 `TestMatMulOp_trans_y`，适合作为一个独立样本。
+- 其他不确定点: 完整任务包阶段应确认新增 F2P 在 `base_commit` 编译后确实失败。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73569/solution/code.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73569/solution/code.patch
@@ -1,0 +1,28 @@
+diff --git a/paddle/phi/kernels/impl/matmul_grad_kernel_impl.h b/paddle/phi/kernels/impl/matmul_grad_kernel_impl.h
+index 5b02a5e88a2829..a08f2fe7d95910 100644
+--- a/paddle/phi/kernels/impl/matmul_grad_kernel_impl.h
++++ b/paddle/phi/kernels/impl/matmul_grad_kernel_impl.h
+@@ -241,6 +241,9 @@ void MatmulGradKernel(const Context& dev_ctx,
+         dev_ctx, phi::IntArray(common::vectorize(x.dims())), 0, dx);
+     return;
+   }
++  if (!transpose_x && transpose_y && y.dims().size() < 2) {
++    transpose_y = false;
++  }
+   // get dims
+   std::vector<std::int64_t> x_dims = common::vectorize(x.dims());
+   std::vector<std::int64_t> y_dims = common::vectorize(y.dims());
+diff --git a/paddle/phi/kernels/xpu/matmul_grad_kernel.cc b/paddle/phi/kernels/xpu/matmul_grad_kernel.cc
+index 33fcab2308ec41..349a72277e7aa0 100644
+--- a/paddle/phi/kernels/xpu/matmul_grad_kernel.cc
++++ b/paddle/phi/kernels/xpu/matmul_grad_kernel.cc
+@@ -37,6 +37,9 @@ void MatmulGradKernel(const Context& dev_ctx,
+     dev_ctx.template Alloc<T>(dy);
+   }
+ 
++  if (!transpose_x && transpose_y && y.dims().size() < 2) {
++    transpose_y = false;
++  }
+   const XPUType* dout_ptr = reinterpret_cast<const XPUType*>(dout.data<T>());
+   const XPUType* x_ptr = reinterpret_cast<const XPUType*>(x.data<T>());
+   const XPUType* y_ptr = reinterpret_cast<const XPUType*>(y.data<T>());

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73569/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73569/tests/test.patch
@@ -1,0 +1,55 @@
+diff --git a/test/legacy_test/test_matmul_v2_op.py b/test/legacy_test/test_matmul_v2_op.py
+index b3c25f7cd7397a..2f0d9425000461 100644
+--- a/test/legacy_test/test_matmul_v2_op.py
++++ b/test/legacy_test/test_matmul_v2_op.py
+@@ -978,6 +978,50 @@ def init_input_output(self):
+         self.y = np.random.random((1, 3, 3, 2))
+ 
+ 
++class TestMatMulOp_trans_y(TestMatMulV2Op):
++    # y is 1-D and trans_y is True
++    def config(self):
++        self.x_shape = (2, 100)
++        self.y_shape = (100,)
++        self.trans_x = False
++        self.trans_y = True
++
++    def init_kernel_type(self):
++        self.dtype = "float32" if core.is_compiled_with_rocm() else "float64"
++
++    def setUp(self):
++        self.init_kernel_type()
++        self.config()
++        self.op_type = "matmul_v2"
++        self.python_api = paddle.tensor.matmul
++        self.public_python_api = paddle.tensor.matmul
++        x = np.random.random(self.x_shape).astype(self.dtype)
++        y = np.random.random(self.y_shape).astype(self.dtype)
++        # -0.1 ~ 0.1
++        x = -0.1 + 0.2 * x
++        y = -0.1 + 0.2 * y
++        result = reference_matmul(x, y, self.trans_x, self.trans_y)
++        result = result.astype(self.dtype)
++        self.inputs = {
++            'X': x,
++            'Y': y,
++        }
++        self.attrs = {'trans_x': self.trans_x, 'trans_y': self.trans_y}
++        self.outputs = {'Out': result}
++
++    def test_check_output(self):
++        self.check_output(
++            check_pir=True,
++        )
++
++    def test_check_grad(self):
++        self.check_grad(
++            ['X', 'Y'],
++            'Out',
++            check_pir=True,
++        )
++
++
+ if __name__ == "__main__":
+     paddle.enable_static()
+     unittest.main()

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73569/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73569/tests/test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# P2P tests (pass-to-pass)
+python -m pytest test/legacy_test/test_matmul_v2_op.py::TestMatMulV2Op -q
+
+# F2P tests (fail-to-pass)
+python -m pytest test/legacy_test/test_matmul_v2_op.py::TestMatMulOp_trans_y::test_check_grad -q


### PR DESCRIPTION
### 关联

- SWE-Paddle 共建 issue: [[Call for Bench] SWE-Paddle 社区共建 Paddle#79447](https://github.com/PaddlePaddle/Paddle/issues/79447)
- 来源 PR: [[Accuracy diff No.104] Fix accuracy diff for paddle.matmul API Paddle#73569](https://github.com/PaddlePaddle/Paddle/pull/73569)

### 说明

新增 SWE-Paddle 任务 `PaddlePaddle__Paddle-73569`。

该任务覆盖 `paddle.matmul` 在 `y` 为 1-D 张量且 `transpose_y=True` 时的精度问题修复。测试包含非 1-D y 张量 regression case，以及 matmul 的目标场景，可在 CPU 环境运行。

### 验证结果

| 状态 | P2P | matmul F2P |
|---|---|---|
| Base + `tests/test.patch` | PASS | FAIL |
| Base + test patch + `solution/code.patch` | PASS | PASS |

#### Base P2P
    
```
2 passed, 2 warnings in 1.60s
```
    

#### Base F2P：matmul
    
```
FAILED test/legacy_test/test_matmul_v2_op.py::TestMatMulOp_trans_y::test_check_grad - RuntimeError: In user code:
1 failed, 1 warning in 1.64s
```
    

#### Solution P2P
    
```
2 passed, 2 warnings in 1.53s
```
    

#### Solution F2P：matmul
    
```
1 passed, 2 warnings in 1.38s
```
    