### PR TITLE
[SWE-Paddle] Add task PaddlePaddle__Paddle_79035

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79035/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79035/README.md
@@ -1,0 +1,44 @@
+# PaddlePaddle__Paddle-79035
+
+This directory converts Paddle PR #79035 into a SWE-Paddle community task candidate.
+
+## Source
+
+| Field | Value |
+| --- | --- |
+| Repo | `PaddlePaddle/Paddle` |
+| PR | [79035](https://github.com/PaddlePaddle/Paddle/pull/79035) |
+| PR title | `[API Compatibility] Add aliases for apis in paddle.optimizer.lr` |
+| Base commit | `e55b609b31d6a00ab35d8fd6e651b2106319ba0d` |
+| Merged at | `2026-05-22` |
+| Task type | `feature_enhancement` |
+| Resource | CPU |
+
+## Summary
+
+为 `paddle.optim` 补齐 `lr_scheduler` 兼容命名空间，使用户可以使用与常见 scheduler 命名一致的公开别名，同时保持原有 `paddle.optimizer.lr` 行为不变。
+
+## Why This Is A Good SWE-Paddle Candidate
+
+- 用户可观察契约明确：兼容 namespace 与公开 scheduler 名称能否正常导入和使用。
+- production change 范围小且边界清楚，仅涉及 `paddle.optim` 的公开 Python API 暴露。
+- 可通过 CPU-only source overlay 稳定验证，无需编译 Paddle、GPU、网络或外部数据集。
+- Base 上缺失兼容 namespace，可构造直接相关且确定性的 F2P；原有 namespace 可作为 P2P。
+
+## Files
+
+- `proposal.md`: candidate proposal for maintainer triage.
+- `instruction.md`: self-contained problem statement for the coding agent.
+- `solution/code.patch`: gold patch for the production files from the merged PR.
+- `tests/test.patch`: independent test patch exposing the target behavior.
+- `tests/test.sh`: minimal target test command.
+- `environment/README.md`: environment notes for reproduction.
+- `README.md`: task overview and verification entrypoint.
+
+## Verification
+
+```bash
+bash tests/test.sh
+```
+
+Expected behavior: applying `tests/test.patch` to `base_commit` should fail on the target behavior; applying both `tests/test.patch` and `solution/code.patch` should pass the target tests.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79035/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79035/environment/README.md
@@ -1,0 +1,27 @@
+# Environment Notes
+
+This candidate is part of the SWE-Paddle community task set.
+
+## Expected Environment
+
+- Repository: `PaddlePaddle/Paddle`
+- Base commit: `e55b609b31d6a00ab35d8fd6e651b2106319ba0d`
+- Resource: CPU
+- GPU required: no
+- Build path: no Paddle source build is required; use an installed Paddle wheel for canonical `paddle.optimizer.lr` runtime dependencies, execute the checkout production Python files through a controlled source overlay, and isolate unrelated sibling optimizer imports with deterministic module doubles.
+
+## Run Order
+
+1. Check out `PaddlePaddle/Paddle` at the base commit.
+2. Apply `tests/test.patch`.
+3. Run `bash tests/test.sh`; the target behavior should fail before the fix.
+4. Apply `solution/code.patch`.
+5. Run `bash tests/test.sh` again; the target behavior should pass after the gold patch.
+
+## Minimal Test Command
+
+```bash
+bash tests/test.sh
+```
+
+The verifier is responsible for deriving stable F2P and P2P node IDs from repeated runs.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79035/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79035/instruction.md
@@ -2,19 +2,17 @@
 
 ## 详细描述
 
-目前 Paddle 的学习率调度器主要通过 `paddle.optimizer.lr` 提供。
+目前 Paddle 的学习率调度器主要通过 `paddle.optimizer.lr` 提供，例如 `StepDecay`、`MultiStepDecay`、`LambdaDecay` 和 `ReduceOnPlateau` 等。
 
-在将其他框架的训练代码迁移到 Paddle 时，一些代码会使用 `paddle.optim.lr_scheduler` 下的 `StepLR`、`MultiStepLR`、`LambdaLR` 等 API。Paddle 当前缺少这些兼容 API，导致相关代码不能直接运行，需要用户手动修改导入路径和部分 API 名称。
+在迁移其他框架的训练代码到 Paddle 时，学习率调度器的导入方式和 API 名称存在差异。例如，一些代码会使用 `lr_scheduler.StepLR`、`lr_scheduler.MultiStepLR`、`lr_scheduler.LambdaLR` 等 API，而 Paddle 中对应的学习率调度器位于 `paddle.optimizer.lr` 下，部分名称也有所不同，因此迁移时需要额外修改相关代码。
 
-需要在 `paddle.optim.lr_scheduler` 下补充对应的学习率调度器 API，使常见的训练代码能够更方便地迁移到 Paddle。
-
-这些新增 API 应复用 Paddle 已有的学习率调度器实现，并保持原有 `paddle.optimizer.lr` API 的行为不变。
+为了减少迁移成本，需要为 `paddle.optim` 补充 `lr_scheduler` API，并为 Paddle 已有的学习率调度器提供对应的兼容 API 名称。新增的 API 要复用 Paddle 现有的学习率调度器实现，不改变原有计算逻辑，同时保证 `paddle.optimizer.lr` 下已有的其他 API 的使用方式和行为保持不变。
 
 ## 验收说明
 
-* `paddle.optim.lr_scheduler` 应提供 `LambdaLR`、`MultiplicativeLR`、`StepLR`、`MultiStepLR`、`ConstantLR`、`LinearLR`、`ExponentialLR`、`CosineAnnealingLR`、`ReduceLROnPlateau`、`CyclicLR`、`CosineAnnealingWarmRestarts`、`OneCycleLR` 和 `LRScheduler`。
-* 新增的兼容 API 要对应 Paddle 已有的学习率调度器能力，不能重新实现一套不同的调度逻辑。
-* 原有 `paddle.optimizer.lr` API 以及已有学习率调度器行为应保持不变。
+* 支持通过 `paddle.optim.lr_scheduler` 使用 `LambdaLR`、`MultiplicativeLR`、`StepLR`、`MultiStepLR`、`ConstantLR`、`LinearLR`、`ExponentialLR`、`CosineAnnealingLR`、`ReduceLROnPlateau`、`CyclicLR`、`CosineAnnealingWarmRestarts`、`OneCycleLR` 和 `LRScheduler`。
+* `paddle.optim.lr_scheduler` 下新增的 API 应复用 `paddle.optimizer.lr` 中已有的学习率调度器功能。
+* 原有 `paddle.optimizer.lr` API 及已有学习率调度器行为保持不变。
 
 ## 技术要求
 

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79035/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79035/instruction.md
@@ -1,29 +1,22 @@
-# 为 `paddle.optim` 提供 `lr_scheduler` API compatibility namespace
+# 为 `paddle.optim` 补充 `lr_scheduler` API
 
 ## 详细描述
 
-当前 `paddle.optimizer.lr` 已提供学习率 scheduler，但用户无法通过 `paddle.optim.lr_scheduler` 使用对应的兼容命名。这会使采用另一套常见 scheduler 命名方式的代码在迁移到 Paddle 时因 namespace 或符号缺失而失败。
+目前 Paddle 的学习率调度器主要通过 `paddle.optimizer.lr` 提供。
 
-任务需要让 `paddle.optim.lr_scheduler` 成为可用的公开兼容入口，并提供与现有 Paddle scheduler 对应的兼容名称；同时不得改变原有 `paddle.optimizer.lr` 的有效行为。
+在将其他框架的训练代码迁移到 Paddle 时，一些代码会使用 `paddle.optim.lr_scheduler` 下的 `StepLR`、`MultiStepLR`、`LambdaLR` 等 API。Paddle 当前缺少这些兼容 API，导致相关代码不能直接运行，需要用户手动修改导入路径和部分 API 名称。
+
+需要在 `paddle.optim.lr_scheduler` 下补充对应的学习率调度器 API，使常见的训练代码能够更方便地迁移到 Paddle。
+
+这些新增 API 应复用 Paddle 已有的学习率调度器实现，并保持原有 `paddle.optimizer.lr` API 的行为不变。
 
 ## 验收说明
 
-- `paddle.optim.lr_scheduler` 应可用，并公开 `LambdaLR`、`MultiplicativeLR`、`StepLR`、`MultiStepLR`、`ConstantLR`、`LinearLR`、`ExponentialLR`、`CosineAnnealingLR`、`ReduceLROnPlateau`、`CyclicLR`、`CosineAnnealingWarmRestarts`、`OneCycleLR` 和 `LRScheduler`。
-- 这些兼容名称应对应现有 `paddle.optimizer.lr` scheduler 的既有行为，而不是形成不同的 scheduler 实现。
-- 原有 `paddle.optimizer.lr` namespace 和有效 scheduler 行为必须保持不变。
+* `paddle.optim.lr_scheduler` 应提供 `LambdaLR`、`MultiplicativeLR`、`StepLR`、`MultiStepLR`、`ConstantLR`、`LinearLR`、`ExponentialLR`、`CosineAnnealingLR`、`ReduceLROnPlateau`、`CyclicLR`、`CosineAnnealingWarmRestarts`、`OneCycleLR` 和 `LRScheduler`。
+* 新增的兼容 API 要对应 Paddle 已有的学习率调度器能力，不能重新实现一套不同的调度逻辑。
+* 原有 `paddle.optimizer.lr` API 以及已有学习率调度器行为应保持不变。
 
 ## 技术要求
 
-- Python package / module import 机制
-- PaddlePaddle optimizer 与 learning-rate scheduler API
-- API compatibility 与 regression testing
-
-## 参考资料
-
-- https://github.com/PaddlePaddle/Paddle/pull/79035
-
-## Acceptance Criteria
-
-- The behavior described above should be fixed.
-- Existing valid behavior should remain unchanged.
-- Do not satisfy the task by deleting tests, weakening assertions, or bypassing validation broadly.
+* 熟悉 Python 模块导入机制
+* 熟悉 Paddle optimizer 和学习率调度器相关 API

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79035/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79035/instruction.md
@@ -1,0 +1,29 @@
+# 为 `paddle.optim` 提供 `lr_scheduler` API compatibility namespace
+
+## 详细描述
+
+当前 `paddle.optimizer.lr` 已提供学习率 scheduler，但用户无法通过 `paddle.optim.lr_scheduler` 使用对应的兼容命名。这会使采用另一套常见 scheduler 命名方式的代码在迁移到 Paddle 时因 namespace 或符号缺失而失败。
+
+任务需要让 `paddle.optim.lr_scheduler` 成为可用的公开兼容入口，并提供与现有 Paddle scheduler 对应的兼容名称；同时不得改变原有 `paddle.optimizer.lr` 的有效行为。
+
+## 验收说明
+
+- `paddle.optim.lr_scheduler` 应可用，并公开 `LambdaLR`、`MultiplicativeLR`、`StepLR`、`MultiStepLR`、`ConstantLR`、`LinearLR`、`ExponentialLR`、`CosineAnnealingLR`、`ReduceLROnPlateau`、`CyclicLR`、`CosineAnnealingWarmRestarts`、`OneCycleLR` 和 `LRScheduler`。
+- 这些兼容名称应对应现有 `paddle.optimizer.lr` scheduler 的既有行为，而不是形成不同的 scheduler 实现。
+- 原有 `paddle.optimizer.lr` namespace 和有效 scheduler 行为必须保持不变。
+
+## 技术要求
+
+- Python package / module import 机制
+- PaddlePaddle optimizer 与 learning-rate scheduler API
+- API compatibility 与 regression testing
+
+## 参考资料
+
+- https://github.com/PaddlePaddle/Paddle/pull/79035
+
+## Acceptance Criteria
+
+- The behavior described above should be fixed.
+- Existing valid behavior should remain unchanged.
+- Do not satisfy the task by deleting tests, weakening assertions, or bypassing validation broadly.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79035/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79035/proposal.md
@@ -1,0 +1,56 @@
+# Task Proposal: PaddlePaddle__Paddle-79035
+
+## 1. 来源信息
+
+- Instance ID：`PaddlePaddle__Paddle-79035`
+- Issue 链接：无独立关联 issue；目标行为由 PR 描述和 review discussion 定义
+- PR 链接：https://github.com/PaddlePaddle/Paddle/pull/79035
+- PR 标题：`[API Compatibility] Add aliases for apis in paddle.optimizer.lr`
+- `base_commit`：`e55b609b31d6a00ab35d8fd6e651b2106319ba0d`
+- merged 时间：`2026-05-22`
+- 你的身份：熟悉该模块的 contributor
+- 后续联系人：TBD
+
+## 2. 问题一句话
+
+`paddle.optim` 缺少 `lr_scheduler` 兼容 namespace，导致使用常见 scheduler 名称的代码无法直接通过该入口访问 Paddle 已有的 learning-rate scheduler。
+
+## 3. 为什么适合作为 SWE-Paddle 样本
+
+- **真实性**：来源于已合入 PaddlePaddle 的 API Compatibility PR，目标是用户直接可见的公开 Python API。
+- **代表性**：覆盖 framework API namespace 兼容、公开符号映射和 package import 暴露，这类兼容工作具有明确工程价值。
+- **边界清楚**：production change 仅涉及 `python/paddle/optim/__init__.py` 与 `python/paddle/optim/lr_scheduler.py`；Gold commit 另更新一处上游 alias test。
+- **非平凡性**：不仅要求模块存在，还要验证完整 alias contract 以及 `paddle.optim` package 初始化后 namespace 的可见性。
+- **环境友好性**：可以用 installed Paddle wheel 提供依赖，并对 checkout production Python files 做 source overlay，无需 source build。
+
+## 4. 任务类型和标签
+
+- 任务类型：`feature_enhancement`
+- 执行后端：`cpu`
+- 设备范围：`cpu_only`
+- 模块标签：`[optimizer, lr_scheduler, api_compatibility, python]`
+
+## 5. 验证思路
+
+- 目标测试命令：`bash tests/test.sh`
+- 目标测试文件：`test/swe_paddle/test_pr79035_lr_scheduler_alias.py`
+- 修复前预期：P2P 验证 legacy `paddle.optimizer.lr.StepDecay` 仍可构造并返回初始 learning rate；两个 F2P 分别因兼容模块缺失、`paddle.optim` 初始化后无 `lr_scheduler` namespace 而失败。
+- 修复后预期：P2P 保持通过；兼容模块能加载，13 个公开兼容名称与 canonical scheduler 对象一致；`paddle.optim` package 初始化后可见 `lr_scheduler` namespace。
+- P2P 候选：`test_p2p_legacy_step_decay_keeps_initial_learning_rate`
+
+## 6. 环境与资源
+
+- 资源需求：CPU
+- Paddle 来源：`PaddlePaddle/Paddle` source checkout at `base_commit`
+- 是否能提供 Docker：暂无
+- patch 类型：Python-only
+- 环境建议：使用已安装的 Paddle wheel 提供 `paddle.optimizer.lr` runtime 依赖；测试通过 source overlay 执行 checkout 中目标 Python module/package 初始化逻辑，并用 controlled module doubles 隔离与目标无关的 sibling optimizer imports，避免依赖 wheel 是否已提供 `paddle.optim`，也无需编译 Paddle。
+- 最小测试命令：`bash tests/test.sh`
+- 是否有 oracle 日志：由 SWE-Paddle verifier 结果另行维护
+
+## 7. 风险自查
+
+- 泄露风险：instruction 仅描述公开 namespace、公开兼容名称和期望行为，不描述 Gold patch 的具体 import 写法。
+- 环境风险：测试依赖可 import 的 Paddle wheel 与 pytest，但不依赖 GPU、NCCL、网络或 source build。
+- flaky 风险：无并发、随机时序、训练或外部数据依赖，测试为确定性 import/API contract 检查。
+- 拆分风险：Gold 同时新增兼容 module 并从 `paddle.optim` 暴露它；两项共同构成完整用户可观察 API，适合作为一个 task。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79035/solution/code.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79035/solution/code.patch
@@ -1,0 +1,63 @@
+diff --git a/python/paddle/optim/__init__.py b/python/paddle/optim/__init__.py
+index de2c898e9d3e78229fcc0f50be64f5927eb8d0ed..8df8547f4981879ef34253c24a67e2f2c42a0035 100644
+--- a/python/paddle/optim/__init__.py
++++ b/python/paddle/optim/__init__.py
+@@ -12,6 +12,7 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ 
++from . import lr_scheduler  # noqa: F401
+ from .adadelta import Adadelta
+ from .adagrad import Adagrad
+ from .adam import Adam
+diff --git a/python/paddle/optim/lr_scheduler.py b/python/paddle/optim/lr_scheduler.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..957ac076df00d6477f2e05a80a39c0fc749fbd6b
+--- /dev/null
++++ b/python/paddle/optim/lr_scheduler.py
+@@ -0,0 +1,45 @@
++# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#     http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++
++from paddle.optimizer.lr import (
++    CosineAnnealingDecay as CosineAnnealingLR,
++    CosineAnnealingWarmRestarts as CosineAnnealingWarmRestarts,
++    CyclicLR as CyclicLR,
++    ExponentialDecay as ExponentialLR,
++    LambdaDecay as LambdaLR,
++    LinearLR as LinearLR,
++    LRScheduler as LRScheduler,
++    MultiplicativeDecay as MultiplicativeLR,
++    MultiStepDecay as MultiStepLR,
++    OneCycleLR as OneCycleLR,
++    PiecewiseDecay as ConstantLR,
++    ReduceOnPlateau as ReduceLROnPlateau,
++    StepDecay as StepLR,
++)
++
++__all__ = [
++    "LambdaLR",
++    "MultiplicativeLR",
++    "StepLR",
++    "MultiStepLR",
++    "ConstantLR",
++    "LinearLR",
++    "ExponentialLR",
++    "CosineAnnealingLR",
++    "ReduceLROnPlateau",
++    "CyclicLR",
++    "CosineAnnealingWarmRestarts",
++    "OneCycleLR",
++    "LRScheduler",
++]

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79035/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79035/tests/test.patch
@@ -1,0 +1,134 @@
+diff --git a/test/swe_paddle/test_pr79035_lr_scheduler_alias.py b/test/swe_paddle/test_pr79035_lr_scheduler_alias.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..1d51c4c73f8e278b05338b259e4db53bf12d6ff8
+--- /dev/null
++++ b/test/swe_paddle/test_pr79035_lr_scheduler_alias.py
+@@ -0,0 +1,128 @@
++import ast
++import importlib
++import importlib.util
++import sys
++import types
++import uuid
++from contextlib import contextmanager
++from pathlib import Path
++
++import pytest
++
++
++REPO_ROOT = Path(__file__).resolve().parents[2]
++OPTIM_DIR = REPO_ROOT / "python" / "paddle" / "optim"
++ALIAS_FILE = OPTIM_DIR / "lr_scheduler.py"
++OPTIM_INIT = OPTIM_DIR / "__init__.py"
++
++ALIAS_TO_CANONICAL = {
++    "LambdaLR": "LambdaDecay",
++    "MultiplicativeLR": "MultiplicativeDecay",
++    "StepLR": "StepDecay",
++    "MultiStepLR": "MultiStepDecay",
++    "ConstantLR": "PiecewiseDecay",
++    "LinearLR": "LinearLR",
++    "ExponentialLR": "ExponentialDecay",
++    "CosineAnnealingLR": "CosineAnnealingDecay",
++    "ReduceLROnPlateau": "ReduceOnPlateau",
++    "CyclicLR": "CyclicLR",
++    "CosineAnnealingWarmRestarts": "CosineAnnealingWarmRestarts",
++    "OneCycleLR": "OneCycleLR",
++    "LRScheduler": "LRScheduler",
++}
++
++
++def test_p2p_legacy_step_decay_keeps_initial_learning_rate():
++    from paddle.optimizer.lr import StepDecay
++
++    scheduler = StepDecay(learning_rate=1.0, step_size=2, gamma=0.5)
++    assert scheduler.get_lr() == pytest.approx(1.0)
++
++
++def _load_checkout_alias_module():
++    if not ALIAS_FILE.is_file():
++        pytest.fail(
++            "paddle.optim.lr_scheduler is unavailable in this checkout; "
++            "the compatibility namespace cannot be imported"
++        )
++
++    module_name = f"_swe_pr79035_lr_scheduler_{uuid.uuid4().hex}"
++    spec = importlib.util.spec_from_file_location(module_name, ALIAS_FILE)
++    assert spec is not None and spec.loader is not None
++    module = importlib.util.module_from_spec(spec)
++    spec.loader.exec_module(module)
++    return module
++
++
++def test_f2p_lr_scheduler_aliases_match_existing_schedulers():
++    canonical = importlib.import_module("paddle.optimizer.lr")
++    compat = _load_checkout_alias_module()
++
++    assert set(compat.__all__) == set(ALIAS_TO_CANONICAL)
++    for alias_name, canonical_name in ALIAS_TO_CANONICAL.items():
++        assert getattr(compat, alias_name) is getattr(canonical, canonical_name)
++
++
++def _stub_preexisting_relative_imports(package_name, tree):
++    """Stub only sibling modules that are unrelated to the target namespace."""
++    for node in tree.body:
++        if not isinstance(node, ast.ImportFrom) or node.level != 1:
++            continue
++
++        if node.module is None:
++            module_names = [alias.name for alias in node.names]
++        else:
++            module_names = [node.module]
++
++        for module_name in module_names:
++            if not module_name or module_name == "lr_scheduler":
++                continue
++
++            full_name = f"{package_name}.{module_name}"
++            stub = sys.modules.get(full_name)
++            if stub is None:
++                stub = types.ModuleType(full_name)
++                sys.modules[full_name] = stub
++
++            if node.module == module_name:
++                for alias in node.names:
++                    if alias.name != "*" and not hasattr(stub, alias.name):
++                        setattr(stub, alias.name, object())
++
++
++@contextmanager
++def _load_checkout_optim_package():
++    package_name = f"_swe_pr79035_optim_{uuid.uuid4().hex}"
++    source = OPTIM_INIT.read_text(encoding="utf-8")
++    tree = ast.parse(source, filename=str(OPTIM_INIT))
++    spec = importlib.util.spec_from_file_location(
++        package_name,
++        OPTIM_INIT,
++        submodule_search_locations=[str(OPTIM_DIR)],
++    )
++    assert spec is not None and spec.loader is not None
++    package = importlib.util.module_from_spec(spec)
++    sys.modules[package_name] = package
++
++    # Execute the checkout package initializer itself, but isolate unrelated
++    # historical optimizer implementations from the installed wheel. The target
++    # lr_scheduler module is deliberately not stubbed and must be loaded from
++    # the checkout package path when the initializer imports it.
++    _stub_preexisting_relative_imports(package_name, tree)
++
++    try:
++        spec.loader.exec_module(package)
++        yield package
++    finally:
++        for key in list(sys.modules):
++            if key == package_name or key.startswith(package_name + "."):
++                sys.modules.pop(key, None)
++
++
++def test_f2p_paddle_optim_initialization_exposes_lr_scheduler_namespace():
++    canonical = importlib.import_module("paddle.optimizer.lr")
++    with _load_checkout_optim_package() as optim_package:
++        assert hasattr(optim_package, "lr_scheduler"), (
++            "importing paddle.optim should expose the lr_scheduler compatibility namespace"
++        )
++        assert optim_package.lr_scheduler.StepLR is canonical.StepDecay

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79035/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79035/tests/test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+python -m pytest test/swe_paddle/test_pr79035_lr_scheduler_alias.py -q


### PR DESCRIPTION
# 关联

* SWE-Paddle 共建 issue: https://github.com/PaddlePaddle/Paddle/issues/79447
* 来源 PR: https://github.com/PaddlePaddle/Paddle/pull/79035

## 说明

* 新增 SWE-Paddle 任务 `PaddlePaddle__Paddle-79035`

该任务覆盖 `paddle.optim.lr_scheduler` API Compatibility：验证新的 compatibility namespace 能正确暴露已有 learning-rate schedulers，同时保持原有 `paddle.optimizer.lr` 行为不变。

## 验证结果

| 状态                                        | Legacy StepDecay P2P | lr_scheduler aliases F2P | paddle.optim namespace F2P |
| ----------------------------------------- | -------------------- | ------------------------ | -------------------------- |
| Base + `tests/test.patch`                 | PASS                 | FAIL，符合预期                | FAIL，符合预期                  |
| Base + test patch + `solution/code.patch` | PASS                 | PASS                     | PASS                       |

#### Base P2P：`test_p2p_legacy_step_decay_keeps_initial_learning_rate`

```text
.                                                                        [100%]
1 passed in 0.70s
[exit code] 0
```

#### Base F2P：`test_f2p_lr_scheduler_aliases_match_existing_schedulers`

```text
E   Failed: paddle.optim.lr_scheduler is unavailable in this checkout; the compatibility namespace cannot be imported

FAILED test/swe_paddle/test_pr79035_lr_scheduler_alias.py::test_f2p_lr_scheduler_aliases_match_existing_schedulers
1 failed in 0.84s
[exit code] 1
```

#### Base F2P：`test_f2p_paddle_optim_initialization_exposes_lr_scheduler_namespace`

```text
E   AssertionError: importing paddle.optim should expose the lr_scheduler compatibility namespace
E   assert False

FAILED test/swe_paddle/test_pr79035_lr_scheduler_alias.py::test_f2p_paddle_optim_initialization_exposes_lr_scheduler_namespace
1 failed in 0.96s
[exit code] 1
```

#### Solution 测试

```text
test_p2p_legacy_step_decay_keeps_initial_learning_rate
1 passed in 0.66s
[exit code] 0

test_f2p_lr_scheduler_aliases_match_existing_schedulers
1 passed in 0.72s
[exit code] 0

test_f2p_paddle_optim_initialization_exposes_lr_scheduler_namespace
1 passed in 0.70s
[exit code] 0
```

#### `tests/test.sh`

```text
...                                                                      [100%]
3 passed in 1.35s
[exit code] 0
```