### PR TITLE
[SWE-Paddle] Add task PaddlePaddle__Paddle-73582

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73582/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73582/README.md
@@ -1,0 +1,53 @@
+# PaddlePaddle__Paddle-73582
+
+This directory converts Paddle PR #73582 into a SWE-Paddle community task candidate.
+
+## Source
+
+| Field | Value |
+| --- | --- |
+| Repo | `PaddlePaddle/Paddle` |
+| PR | [73582](https://github.com/PaddlePaddle/Paddle/pull/73582) |
+| PR title | `[0-size Tensor Job2 No.12、77] Add 0-size Tensor support for paddle.squeeze/full` |
+| Base commit | `ecd685afb0ffc1f509771cd1820254c8b42020ad` |
+| Gold commit | `f69b42e57712ab1c68edc071bee41758c27612f7` |
+| Merged at | `2025-06-30` |
+| Task type | `bug_fix` |
+| Resource | CPU |
+| Scope | Python API (squeeze/full 0-size Tensor support) |
+
+## Summary
+
+Fix `paddle.squeeze` and `paddle.full` to correctly handle 0-size Tensor inputs:
+- `paddle.squeeze`: When `axis` is a 0-size Tensor, return `x` unchanged
+- `paddle.full`: When `shape` contains 0-size Tensor elements, skip them in conversion
+
+## Why This Is A Good SWE-Paddle Candidate
+
+- It is derived from a merged Paddle bug-fix PR rather than a synthetic issue.
+- The target behavior is isolated to the Python API layer and does not require C++ kernel changes.
+- The failure is deterministic: the base revision fails when `squeeze` receives a 0-size axis tensor or when `full` receives a shape containing 0-size tensors.
+- The task has clear regression coverage for existing squeeze/full behavior.
+- The task runs on CPU and does not require distributed execution, external services, or additional datasets.
+
+## Files
+
+- `proposal.md`: candidate proposal for maintainer triage.
+- `instruction.md`: self-contained problem statement for the coding agent.
+- `solution/code.patch`: gold implementation patch (Python API changes).
+- `tests/test.patch`: tests exposing the target behavior.
+- `tests/test.sh`: minimal target test command.
+- `environment/README.md`: environment and reproduction notes.
+
+## Verification
+
+```bash
+bash tests/test.sh
+```
+
+Expected behavior:
+
+| Revision state | Existing behavior (P2P) | squeeze/full F2P |
+| --- | ---: | ---: |
+| Base + `tests/test.patch` | PASS | FAIL |
+| Base + `tests/test.patch` + `solution/code.patch` | PASS | PASS |

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73582/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73582/environment/README.md
@@ -1,0 +1,56 @@
+# Environment Notes
+
+## Expected Environment
+
+- Repository: `PaddlePaddle/Paddle`
+- Base commit: `ecd685afb0ffc1f509771cd1820254c8b42020ad`
+- Gold commit: `f69b42e57712ab1c68edc071bee41758c27612f7`
+- Resource: CPU
+- GPU required: no
+- Patch type: Python API (no C++ kernel changes)
+- Python dependencies: PaddlePaddle (source build or pre-built), NumPy
+
+The verifier should execute against the Paddle source revision represented by the selected patch state. Since the patch only modifies Python code, no recompilation is needed — only the Python files change.
+
+## Build Instructions
+
+1. Check out `PaddlePaddle/Paddle` at the base commit.
+2. Apply `tests/test.patch`.
+3. Build Paddle from source (CPU-only build is sufficient):
+```bash
+mkdir build && cd build
+cmake .. -DWITH_GPU=OFF -DWITH_TESTING=ON -DCMAKE_BUILD_TYPE=Release
+make -j$(nproc)
+```
+4. Install the built Paddle package.
+
+## Run Order
+
+1. Check out `PaddlePaddle/Paddle` at the base commit.
+2. Build and install Paddle from source.
+3. Apply `tests/test.patch`.
+4. Run the P2P tests; existing squeeze/full behavior should pass.
+5. Run the 0-size tensor tests; the target cases should fail before the fix.
+6. Apply `solution/code.patch`.
+7. Reinstall the Python package to apply the changes:
+```bash
+cd build/python
+python setup.py bdist_wheel
+pip install --force-reinstall dist/*.whl
+```
+8. Run `bash tests/test.sh`; all target tests should pass.
+
+## Minimal Test Command
+
+```bash
+bash tests/test.sh
+```
+
+## Expected Matrix
+
+| Revision state | P2P | squeeze/full F2P |
+| --- | ---: | ---: |
+| Base + test patch | PASS | FAIL |
+| Base + test patch + solution patch | PASS | PASS |
+
+No GPU, distributed runtime, external service, or additional dataset is required.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73582/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73582/instruction.md
@@ -6,7 +6,7 @@
 
 当 `paddle.squeeze(x, axis)` 的 `axis` 参数是一个 0-size Tensor 时，当前实现会对输入无法正确处理、调用报错。
 
-按照 API semantics 和 PyTorch 的参考行为，当 `axis` 为空 tensor 时，应该不进行任何 squeeze 操作，直接返回原始输入 `x`。
+按照 API semantics 和 PyTorch 的参考行为，当 `axis` 为空 Tensor 时，不应改变输入的 shape 和数据，输出应与输入保持一致。
 
 例如：
 

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73582/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73582/instruction.md
@@ -1,0 +1,57 @@
+# 修复 `paddle.squeeze` 和 `paddle.full` 对 0-size Tensor 的支持
+
+## 详细描述
+
+### 1. paddle.squeeze 问题
+
+当 `paddle.squeeze(x, axis)` 的 `axis` 参数是一个 0-size Tensor 时，当前实现会对输入无法正确处理、调用报错。
+
+按照 API semantics 和 PyTorch 的参考行为，当 `axis` 为空 tensor 时，应该不进行任何 squeeze 操作，直接返回原始输入 `x`。
+
+例如：
+
+```python
+import paddle
+
+x = paddle.ones([3, 2, 1])
+axis = paddle.to_tensor([], dtype=paddle.int32)  # 0-size tensor
+out = paddle.squeeze(x, axis=axis)
+# 期望: out.shape == [3, 2, 1]，与 x 相同
+```
+
+### 2. paddle.full 问题
+
+当 `paddle.full(shape, fill_value)` 的 `shape` 参数是一个包含 Tensor 的列表，且其中某些 Tensor 是 0-size 的，当前实现会对输入无法正确处理、调用报错。
+
+按照 API semantics，当 shape 列表中包含 0-size tensor 时，应该跳过该元素（相当于该维度大小为 1 或被忽略）。
+
+例如：
+
+```python
+import paddle
+
+out = paddle.full(
+    shape=[
+        paddle.to_tensor([1]),
+        paddle.to_tensor([1]),
+        paddle.to_tensor([]),  # 0-size tensor，应该被跳过
+    ],
+    fill_value=1.0,
+)
+# 期望: out.shape == [1, 1]
+```
+
+## 验收说明
+
+- 当 `paddle.squeeze` 的 `axis` 为 0-size Tensor 时，应返回原始输入 `x`，不改变 shape
+- 当 `paddle.full` 的 `shape` 列表中包含 0-size Tensor 时，应跳过该元素
+- 输出的 shape 应与预期一致
+- 非 0-size Tensor 输入下的 squeeze/full 行为不得退化
+- 梯度计算也应正常工作
+
+## 技术要求
+
+- 熟悉 Python 和 Paddle 动态图 API 开发
+- 了解 Tensor 的 size 属性和 0-size Tensor 的概念
+- 了解 squeeze 和 full API 的实现逻辑
+- 不需要修改 C++ kernel，仅需修改 Python 层代码

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73582/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73582/instruction.md
@@ -54,4 +54,3 @@ out = paddle.full(
 - 熟悉 Python 和 Paddle 动态图 API 开发
 - 了解 Tensor 的 size 属性和 0-size Tensor 的概念
 - 了解 squeeze 和 full API 的实现逻辑
-- 不需要修改 C++ kernel，仅需修改 Python 层代码

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73582/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73582/proposal.md
@@ -1,0 +1,59 @@
+# SWE-Paddle Task Proposal: PaddlePaddle__Paddle-73582
+
+## 1. 来源信息
+
+- Instance ID: `PaddlePaddle__Paddle-73582`
+- PR 链接: https://github.com/PaddlePaddle/Paddle/pull/73582
+- PR 标题: `[0-size Tensor Job2 No.12、77] Add 0-size Tensor support for paddle.squeeze/full`
+- Base commit: `ecd685afb0ffc1f509771cd1820254c8b42020ad`
+- Gold commit: `f69b42e57712ab1c68edc071bee41758c27612f7`
+- Merged at: 2025-06-30
+- 你的身份: contributor
+
+## 2. 问题一句话
+
+`paddle.squeeze` 在 axis 为 0-size Tensor 时行为异常，`paddle.full` 在 shape 包含 0-size Tensor 时报错，需要在 Python 层添加 0-size 处理逻辑。
+
+## 3. 为什么适合作为 SWE-Paddle 样本
+
+- **真实性**: 来自 Paddle「0-size Tensor 机制建设」系列任务，是真实研发需求。
+- **代表性**: 覆盖 Python API 层的 0-size Tensor 边界处理，涉及 squeeze 和 full 两个 API。
+- **边界清楚**: 目标仅限 0-size Tensor 输入的特殊处理；正向非零尺寸输入不应受影响。
+- **非平凡性**: 修复需要理解 squeeze 的 axis 处理流程和 full 的 shape 转换逻辑，在正确位置添加 0-size 检查。
+- **回归护栏明确**: 目标 F2P 可覆盖 0-size Tensor 输入的 squeeze/full 测试；同文件中已有的标准测试用例可作为 P2P 护栏。
+
+## 4. 任务类型和标签
+
+- 任务类型: `bug_fix`
+- 执行后端: `cpu`
+- 设备范围: `cpu_only`
+- 模块标签: `[python_api, squeeze, full, 0-size_tensor, tensor_manipulation]`
+
+## 5. 验证思路
+
+- 目标测试命令: `bash tests/test.sh`
+- 目标测试文件:
+  - `test/legacy_test/test_fill_constant_op.py`（`TestFillConstantOp_ZeroSize`）
+  - `test/legacy_test/test_squeeze2_op.py`（`TestSqueezeAPI_ZeroSize`）
+- P2P 候选: 同文件中已有的 `TestFillConstantOp`、`TestSqueezeAPI` 等标准测试用例。
+- 修复前预期: `base_commit` + `tests/test.patch` 后，0-size Tensor 输入的 squeeze/full 测试失败。
+- 修复后预期: 继续应用 `solution/code.patch` 后，0-size Tensor 输入正常处理，P2P 存量测试仍然通过。
+
+## 6. 环境与资源
+
+- 是否能提供 Docker: 无
+- Dockerfile 或镜像地址: 暂无
+- Paddle 来源: `PaddlePaddle/Paddle` source checkout at `base_commit`，需要源码编译（或安装对应版本的 Paddle）。
+- OS / Python / CUDA / cuDNN / 其他关键依赖: Linux CPU + Python + numpy；编译需要 CMake、GCC；不要求 CUDA/cuDNN（CPU 编译即可验证）。
+- 硬件: CPU 即可（编译和测试均不需要 GPU）。
+- patch 类型: 仅 Python 代码修改（`python/paddle/tensor/manipulation.py` 和 `python/paddle/utils/layers_utils.py`），无需重新编译。
+- 最小测试命令: `bash tests/test.sh`
+- 是否有 oracle 日志: 无
+
+## 7. 风险自查
+
+- 泄露风险: 正式 `instruction.md` 只描述「squeeze/full 对 0-size Tensor 输入的行为异常」，不指出具体的代码位置或实现细节。
+- 环境风险: 中。任务需要 Paddle 源码环境，但 patch 仅涉及 Python 文件，无需重新编译。
+- flaky 风险: 低。测试使用固定的 tensor 构造，不依赖随机数差异或多设备同步。
+- 拆分风险: 低。该 PR 目标集中在两个 API 的 0-size Tensor 处理，测试明确指向新增的 ZeroSize 测试类，适合作为一个独立样本。
+- 其他不确定点: 完整任务包阶段应确认新增 F2P 在 `base_commit` 上确实失败。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73582/solution/code.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73582/solution/code.patch
@@ -1,0 +1,35 @@
+diff --git a/python/paddle/tensor/manipulation.py b/python/paddle/tensor/manipulation.py
+index b57098cddc..bebeb087f3 100644
+--- a/python/paddle/tensor/manipulation.py
++++ b/python/paddle/tensor/manipulation.py
+@@ -3336,6 +3336,9 @@ def squeeze(
+         axis = [axis]
+     elif isinstance(axis, tuple):
+         axis = list(axis)
++    elif isinstance(axis, (paddle.Tensor, Variable)):
++        if axis.size == 0:
++            return x
+ 
+     input = x
+     axes = axis
+diff --git a/python/paddle/utils/layers_utils.py b/python/paddle/utils/layers_utils.py
+index 767f4afe80..9f97b00ca3 100644
+--- a/python/paddle/utils/layers_utils.py
++++ b/python/paddle/utils/layers_utils.py
+@@ -483,7 +483,15 @@ def convert_shape_to_list(shape):
+     Convert shape(list, tuple, variable) to list in imperative mode
+     """
+     if isinstance(shape, (list, tuple)):
+-        shape = [x.item(0) if isinstance(x, Variable) else x for x in shape]
++        shape_out = []
++        for x in shape:
++            if isinstance(x, Variable):
++                # skip item if size = 0
++                if x.size > 0:
++                    shape_out.append(x.item(0))
++            else:
++                shape_out.append(x)
++        shape = shape_out
+     else:
+         if in_dygraph_mode():
+             shape = shape.astype(int).tolist()

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73582/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73582/tests/test.patch
@@ -1,0 +1,57 @@
+diff --git a/test/legacy_test/test_fill_constant_op.py b/test/legacy_test/test_fill_constant_op.py
+index 5dc8cd23f2..aa6a082c46 100644
+--- a/test/legacy_test/test_fill_constant_op.py
++++ b/test/legacy_test/test_fill_constant_op.py
+@@ -553,6 +553,21 @@ class TestFillConstantOp_ValueTensorBf16(OpTest):
+         )
+ 
+ 
++class TestFillConstantOp_ZeroSize(unittest.TestCase):
++
++    def test_shape(self):
++        out = paddle.full(
++            shape=[
++                paddle.to_tensor([1]),
++                paddle.to_tensor([1]),
++                paddle.to_tensor([]),
++            ],
++            fill_value=1.0,
++        )
++        out_np = out.numpy()
++        np.testing.assert_allclose(out_np, np.ones([1, 1]).astype(out_np.dtype))
++
++
+ if __name__ == "__main__":
+     paddle.enable_static()
+     unittest.main()
+diff --git a/test/legacy_test/test_squeeze2_op.py b/test/legacy_test/test_squeeze2_op.py
+index 068414d688..acab7a2ed0 100755
+--- a/test/legacy_test/test_squeeze2_op.py
++++ b/test/legacy_test/test_squeeze2_op.py
+@@ -230,5 +230,26 @@ class TestSqueezeInplaceAPI(TestSqueezeAPI):
+         self.squeeze = paddle.squeeze_
+ 
+ 
++class TestSqueezeAPI_ZeroSize(unittest.TestCase):
++    def setUp(self):
++        self.executed_api()
++
++    def executed_api(self):
++        self.squeeze = paddle.squeeze
++
++    def test_api(self):
++        paddle.disable_static()
++        input_data = np.random.random([3, 2, 1]).astype("float32")
++        x = paddle.to_tensor(input_data)
++        x.stop_gradient = False
++        # axis set to 0-size
++        out = self.squeeze(x, axis=paddle.to_tensor([], dtype=paddle.int32))
++        np.testing.assert_allclose(out.numpy(), x.numpy())
++
++        out.backward()
++        np.testing.assert_allclose(x.grad.shape, x.shape)
++        paddle.enable_static()
++
++
+ if __name__ == "__main__":
+     unittest.main()

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73582/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73582/tests/test.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# P2P tests (pass-to-pass)
+python -m pytest test/legacy_test/test_fill_constant_op.py::TestFillConstantOp -q
+python -m pytest test/legacy_test/test_squeeze2_op.py::TestSqueezeAPI -q
+
+# F2P tests (fail-to-pass)
+python -m pytest test/legacy_test/test_fill_constant_op.py::TestFillConstantOp_ZeroSize -q
+python -m pytest test/legacy_test/test_squeeze2_op.py::TestSqueezeAPI_ZeroSize -q


### PR DESCRIPTION
### 关联

- SWE-Paddle 共建 issue: [[Call for Bench] SWE-Paddle 社区共建 Paddle#79447](https://github.com/PaddlePaddle/Paddle/issues/79447)
- 来源 PR: [[0-size Tensor Job2 No.12、77] Add 0-size Tensor support for paddle.squeeze/full PaddlePaddle/Paddle#73582](https://github.com/PaddlePaddle/Paddle/pull/73582)

### 说明

新增 SWE-Paddle 任务 `PaddlePaddle__Paddle-73582`。

该任务覆盖 `paddle.squeeze` 和 `paddle.full` 对 0-size Tensor 的处理。测试包含已有 regression case，以及 0-size Tensor 的目标场景，可在 CPU 环境运行。

### 验证结果

| 状态 | P2P | squeeze/full F2P |
| --- | --- | --- |
| Base + `tests/test.patch` | PASS | FAIL |
| Base + test patch + `solution/code.patch` | PASS | PASS |

#### Base P2P

```
1 passed, 1 warning in 1.26s
2 passed, 1 warning in 1.24s
```

#### Base F2P：full

```
FAILED test/legacy_test/test_fill_constant_op.py::TestFillConstantOp_ZeroSize::test_shape - ValueError: (InvalidArgument) index 0 is out of bounds for size 0
1 failed, 1 warning in 1.42s
```

#### Base F2P：squeeze

```
FAILED test/legacy_test/test_squeeze2_op.py::TestSqueezeAPI_ZeroSize::test_api - AssertionError: 
1 failed, 1 warning in 1.33s
```

#### Solution P2P

```
1 passed, 1 warning in 1.28s
2 passed, 1 warning in 1.22s
```

#### Solution F2P：full + squeeze

```
1 passed, 1 warning in 1.20s
1 passed, 1 warning in 1.23s
```