### PR TITLE
[SWE-Paddle] Add task PaddlePaddle__Paddle-73702

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73702/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73702/README.md
@@ -1,0 +1,51 @@
+# PaddlePaddle__Paddle-73702
+
+This directory converts Paddle PR #73702 into a SWE-Paddle community task candidate.
+
+## Source
+
+| Field | Value |
+| --- | --- |
+| Repo | `PaddlePaddle/Paddle` |
+| PR | [73702](https://github.com/PaddlePaddle/Paddle/pull/73702) |
+| PR title | `[0-size Tensor Job2 No.16、85] Add 0-size Tensor support for paddle.gather_nd` |
+| Base commit | `a311cbc2ea18cadd6cde71de661091c60fcd9ce5` |
+| Gold commit | `8b69643bc063fb36e8be4d7df265a8b3082e32f5` |
+| Merged at | `2025-07-04` |
+| Task type | `bug_fix` |
+| Resource | CPU |
+| Scope | C++ Operator Kernel |
+
+## Summary
+
+Fix `paddle.gather_nd` to correctly handle 0-size tensors in CPU/GPU/XPU kernels by adding special handling when the last dimension of index is 0, using tile kernel to broadcast the input tensor.
+
+## Why This Is A Good SWE-Paddle Candidate
+
+- It is derived from a merged Paddle bug-fix PR rather than a synthetic issue.
+- The target behavior is isolated to the C++ operator kernel level and requires rebuilding Paddle from source.
+- The failure is deterministic: the base revision fails when processing 0-size index tensors due to missing special handling in gather_nd kernels.
+- The task has clear regression coverage for existing non-zero-size behavior.
+- The task runs on CPU and does not require distributed execution, external services, or additional datasets.
+
+## Files
+
+- `proposal.md`: candidate proposal for maintainer triage.
+- `instruction.md`: self-contained problem statement for the coding agent.
+- `solution/code.patch`: gold implementation patch (C++ kernel changes).
+- `tests/test.patch`: tests exposing the target behavior.
+- `tests/test.sh`: minimal target test command.
+- `environment/README.md`: environment and reproduction notes.
+
+## Verification
+
+```bash
+bash tests/test.sh
+```
+
+Expected behavior:
+
+| Revision state | Existing behavior (P2P) | gather_nd F2P |
+| --- | ---: | ---: |
+| Base + `tests/test.patch` | PASS | FAIL |
+| Base + `tests/test.patch` + `solution/code.patch` | PASS | PASS |

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73702/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73702/environment/README.md
@@ -1,0 +1,52 @@
+# Environment Notes
+
+## Expected Environment
+
+- Repository: `PaddlePaddle/Paddle`
+- Base commit: `a311cbc2ea18cadd6cde71de661091c60fcd9ce5`
+- Gold commit: `8b69643bc063fb36e8be4d7df265a8b3082e32f5`
+- Resource: CPU
+- GPU required: no
+- Patch type: C++ kernel (CPU/GPU/XPU backends) + tile kernel data type extension
+- Python dependencies: PaddlePaddle (source build), NumPy
+
+The verifier should execute against the Paddle source revision represented by the selected patch state. A source build is required since the patch modifies C++ kernel code.
+
+## Build Instructions
+
+1. Check out `PaddlePaddle/Paddle` at the base commit.
+2. Apply `tests/test.patch`.
+3. Build Paddle from source (CPU-only build is sufficient):
+   ```bash
+   mkdir build && cd build
+   cmake .. -DWITH_GPU=OFF -DWITH_TESTING=ON -DCMAKE_BUILD_TYPE=Release
+   make -j$(nproc)
+   ```
+4. Install the built Paddle package.
+
+## Run Order
+
+1. Check out `PaddlePaddle/Paddle` at the base commit.
+2. Build and install Paddle from source.
+3. Apply `tests/test.patch`.
+4. Run the P2P tests; existing non-zero-size behavior should pass.
+5. Run the 0-size tensor tests; the target case should fail before the fix.
+6. Apply `solution/code.patch`.
+7. Rebuild Paddle from source.
+8. Reinstall Paddle package.
+9. Run `bash tests/test.sh`; all target tests should pass.
+
+## Minimal Test Command
+
+```bash
+bash tests/test.sh
+```
+
+## Expected Matrix
+
+| Revision state | P2P | gather_nd F2P |
+| --- | ---: | ---: |
+| Base + test patch | PASS | FAIL |
+| Base + test patch + solution patch | PASS | PASS |
+
+No GPU, distributed runtime, external service, or additional dataset is required.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73702/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73702/instruction.md
@@ -1,0 +1,46 @@
+# 修复 `paddle.gather_nd` 对 0-size Tensor 的处理
+
+## 详细描述
+
+当 `paddle.gather_nd(x, index)` 的 `index` 张量的最后一维为 0 时，当前 CPU/GPU/XPU kernel 实现无法正确处理这种特殊情况。根据 gather_nd 的语义，当 index 的最后一维为 0 时，输出应该是 x 的 tile 操作结果。
+
+典型表现包括：
+
+- kernel 在处理 0-size index 时崩溃或报错
+- 0-size index 输入无法通过 `gather_nd` 算子
+
+例如：
+
+```python
+import numpy as np
+import paddle
+
+paddle.disable_static()
+
+# gather_nd 0-size index 输入
+x = paddle.to_tensor(np.random.random([10, 20]).astype('float32'))
+index = paddle.to_tensor(np.random.random([2, 0]).astype('int32'))
+out = paddle.gather_nd(x, index)
+# 期望返回 shape 为 (2, 10, 20) 的 Tensor
+```
+
+上述调用中 `index` 的 shape 为 `[2, 0]`，最后一维为 0。按照 gather_nd 的语义：
+- 输出 shape = Index.shape[:-1] + X.shape[Index.shape[-1]:]
+- 即 [2] + [10, 20] = [2, 10, 20]
+
+需要修复 CPU/GPU/XPU kernel 对这种 0-size index 输入的支持，使 `paddle.gather_nd` 能正确处理 index 最后一维为 0 的情况，返回符合 gather_nd 语义的输出 shape 和数值。
+
+## 验收说明
+
+- 当 index 的最后一维为 0 时，`paddle.gather_nd` 应正常完成，返回正确 shape 的 Tensor
+- 输出的 shape 应符合 gather_nd 的语义规则
+- 非 0-size index 输入下的 gather_nd 行为不得退化
+- 梯度计算也应正常工作
+
+## 技术要求
+
+- 熟悉 C++ 和 Paddle PHI kernel 开发
+- 了解 Tensor shape、0-size Tensor 和 kernel 执行路径
+- 了解 gather_nd 算子的输入输出语义
+- 了解 Paddle CPU/GPU/XPU kernel 的实现模式
+- 需要从源码编译 Paddle 以验证修改

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73702/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73702/proposal.md
@@ -1,0 +1,58 @@
+# SWE-Paddle Task Proposal: PaddlePaddle__Paddle-73702
+
+## 1. 来源信息
+
+- Instance ID: `PaddlePaddle__Paddle-73702`
+- PR 链接: https://github.com/PaddlePaddle/Paddle/pull/73702
+- PR 标题: `[0-size Tensor Job2 No.16、85] Add 0-size Tensor support for paddle.gather_nd`
+- Base commit: `a311cbc2ea18cadd6cde71de661091c60fcd9ce5`
+- Gold commit: `8b69643bc063fb36e8be4d7df265a8b3082e32f5`
+- Merged at: 2025-07-04
+- 你的身份: contributor
+
+## 2. 问题一句话
+
+`paddle.gather_nd` 在 index 的最后一维为 0 时，CPU/GPU/XPU kernel 未正确处理这种特殊情况导致崩溃或报错，需要在 kernel 中添加特殊处理逻辑，使用 tile kernel 来广播输入张量。
+
+## 3. 为什么适合作为 SWE-Paddle 样本
+
+- **真实性**: 来自 Paddle「0-size Tensor 机制建设」系列任务，是真实研发需求。
+- **代表性**: 覆盖 C++ kernel 层面的 0-size Tensor 边界处理，涉及 CPU/GPU/XPU 三端 kernel 和 tile kernel 的数据类型扩展。
+- **边界清楚**: 目标仅限 index 最后一维为 0 时的特殊处理；正向非零尺寸输入不应受影响。
+- **非平凡性**: 修复需要在 `GatherNdKernel` 中添加对 index 最后一维为 0 的检查，并使用 `TileKernel` 进行广播，同时需要扩展 tile kernel 支持更多数据类型，涉及对 gather_nd 语义和 kernel 执行流程的理解。
+- **回归护栏明确**: 目标 F2P 可覆盖 0-size index 输入的 `gather_nd` 算子测试；同文件中已有的标准测试用例可作为 P2P 护栏。
+
+## 4. 任务类型和标签
+
+- 任务类型: `bug_fix`
+- 执行后端: `cpu`
+- 设备范围: `cpu_only`
+- 模块标签: `[operator_kernel, gather_nd, 0-size_tensor, cpu_kernel, gpu_kernel, xpu_kernel, tile_kernel]`
+
+## 5. 验证思路
+
+- 目标测试命令: `bash tests/test.sh`
+- 目标测试文件:
+  - `test/legacy_test/test_gather_nd_op.py`（`TestGatherNdOp_ZeroSize`）
+- P2P 候选: 同文件中已有的 `TestGatherND` 等标准算子测试用例。
+- 修复前预期: `base_commit` + `tests/test.patch` 后，0-size index 输入的算子测试失败（kernel 崩溃或报错）。
+- 修复后预期: 继续应用 `solution/code.patch` 并重新编译后，0-size index 输入正常返回正确结果，P2P 存量测试仍然通过。
+
+## 6. 环境与资源
+
+- 是否能提供 Docker: 无
+- Dockerfile 或镜像地址: 暂无
+- Paddle 来源: `PaddlePaddle/Paddle` source checkout at `base_commit`，需要源码编译。
+- OS / Python / CUDA / cuDNN / 其他关键依赖: Linux CPU + Python + numpy；编译需要 CMake、GCC；不要求 CUDA/cuDNN（CPU 编译即可验证）。
+- 硬件: CPU 即可（编译和测试均不需要 GPU）。
+- patch 类型: 含 C++ kernel 修改（CPU/GPU/XPU 三端）+ tile kernel 数据类型扩展，需要重新编译 Paddle。
+- 最小测试命令: `bash tests/test.sh`
+- 是否有 oracle 日志: 无
+
+## 7. 风险自查
+
+- 泄露风险: 正式 `instruction.md` 只描述「gather_nd 对 0-size index 输入的行为异常」，不指出具体使用 tile kernel 进行广播的实现细节。
+- 环境风险: 中。任务涉及 C++ kernel 修改，需要源码编译 Paddle，编译时间较长。
+- flaky 风险: 低。测试使用固定的 0-size Tensor 构造，不依赖随机数差异或多设备同步。
+- 拆分风险: 低。该 PR 目标集中在 `gather_nd` 的 CPU/GPU/XPU kernel 0-size 特殊处理，测试明确指向新增的 ZeroSize 测试类，适合作为一个独立样本。
+- 其他不确定点: 完整任务包阶段应确认新增 F2P 在 `base_commit` 编译后确实失败。注意该 PR 同时修改了 tile kernel 和 broadcast.cu 以支持更多数据类型。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73702/solution/code.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73702/solution/code.patch
@@ -1,0 +1,192 @@
+diff --git a/paddle/phi/kernels/cpu/gather_nd_kernel.cc b/paddle/phi/kernels/cpu/gather_nd_kernel.cc
+index 44cc22966c60ab..39f5b3c3a17cec 100644
+--- a/paddle/phi/kernels/cpu/gather_nd_kernel.cc
++++ b/paddle/phi/kernels/cpu/gather_nd_kernel.cc
+@@ -17,6 +17,7 @@
+ #include "paddle/phi/backends/cpu/cpu_context.h"
+ #include "paddle/phi/core/kernel_registry.h"
+ #include "paddle/phi/kernels/funcs/gather.h"
++#include "paddle/phi/kernels/tile_kernel.h"
+ 
+ namespace phi {
+ 
+@@ -27,6 +28,21 @@ void GatherNdKernel(const Context &dev_ctx,
+                     DenseTensor *out) {
+   dev_ctx.template Alloc<T>(out);
+   if (x.numel() == 0 || out->numel() == 0) return;
++  // The result dims is
++  //   Index.shape[:-1] + X.shape[Index.shape[-1]:]
++  // If the last dimension of index is 0, set it to 1 and tile x.
++  auto index_dims = index.dims();
++  std::vector<int64_t> out_dims;
++  if (index_dims[index_dims.size() - 1] == 0) {
++    for (int i = 0; i < index_dims.size() - 1; ++i) {
++      out_dims.emplace_back(index_dims[i]);
++    }
++    for (int i = 0; i < x.dims().size(); ++i) {
++      out_dims.emplace_back(1);
++    }
++    phi::TileKernel<T, Context>(dev_ctx, x, phi::IntArray(out_dims), out);
++    return;
++  }
+   if (index.dims()[0] == 0 && index.numel() == 0) return;
+   auto index_type = index.dtype();
+   bool index_type_match =
+diff --git a/paddle/phi/kernels/cpu/tile_kernel.cc b/paddle/phi/kernels/cpu/tile_kernel.cc
+index 30eb1d5cd6c47b..01645f3db1cd56 100644
+--- a/paddle/phi/kernels/cpu/tile_kernel.cc
++++ b/paddle/phi/kernels/cpu/tile_kernel.cc
+@@ -27,6 +27,9 @@ PD_REGISTER_KERNEL(tile,
+                    double,
+                    int,
+                    int64_t,
++                   int8_t,
++                   int16_t,
++                   uint8_t,
+                    phi::dtype::float16,
+                    phi::dtype::complex<float>,
+                    phi::dtype::complex<double>) {}
+diff --git a/paddle/phi/kernels/cpu/tile_grad_kernel.cc b/paddle/phi/kernels/cpu/tile_grad_kernel.cc
+index ed6bc49ed8..cda32f1a3c 100644
+--- a/paddle/phi/kernels/cpu/tile_grad_kernel.cc
++++ b/paddle/phi/kernels/cpu/tile_grad_kernel.cc
+@@ -26,6 +26,9 @@ PD_REGISTER_KERNEL(tile_grad,
+                    float,
+                    double,
+                    int,
++                   int64_t,
++                   int8_t,
++                   int16_t,
++                   uint8_t,
+                    phi::dtype::complex<float>,
+-                   phi::dtype::complex<double>,
+-                   int64_t) {}
++                   phi::dtype::complex<double>) {}
+diff --git a/paddle/phi/kernels/funcs/eigen/broadcast.cu b/paddle/phi/kernels/funcs/eigen/broadcast.cu
+index fe16588c9b..e883faa550 100644
+--- a/paddle/phi/kernels/funcs/eigen/broadcast.cu
++++ b/paddle/phi/kernels/funcs/eigen/broadcast.cu
+@@ -14,8 +14,9 @@ limitations under the License. */
+ #include "paddle/phi/common/bfloat16.h"
+ #include "paddle/phi/common/complex.h"
+ #include "paddle/phi/common/float16.h"
++#include "paddle/phi/common/float8_e4m3fn.h"
++#include "paddle/phi/common/float8_e5m2.h"
+ #include "paddle/phi/kernels/funcs/eigen/eigen_function.h"
+-
+ namespace phi {
+ namespace funcs {
+ 
+@@ -93,6 +94,11 @@ INSTANTIATION(EigenBroadcastGrad, dtype::complex<float>);
+ INSTANTIATION(EigenBroadcastGrad, dtype::complex<double>);
+ INSTANTIATION(EigenBroadcastGrad, int);
+ INSTANTIATION(EigenBroadcastGrad, int64_t);
++INSTANTIATION(EigenBroadcastGrad, int8_t);
++INSTANTIATION(EigenBroadcastGrad, uint8_t);
++INSTANTIATION(EigenBroadcastGrad, int16_t);
++INSTANTIATION(EigenBroadcastGrad, phi::dtype::float8_e4m3fn);
++INSTANTIATION(EigenBroadcastGrad, phi::dtype::float8_e5m2);
+ template struct EigenBroadcastGrad<Eigen::GpuDevice, float, 0>;
+ template struct EigenBroadcastGrad<Eigen::GpuDevice, dtype::float16, 0>;
+ template struct EigenBroadcastGrad<Eigen::GpuDevice, double, 0>;
+diff --git a/paddle/phi/kernels/gpu/gather_nd_kernel.cu b/paddle/phi/kernels/gpu/gather_nd_kernel.cu
+index dd18f192e275d5..2fc8cb0c3b754c 100644
+--- a/paddle/phi/kernels/gpu/gather_nd_kernel.cu
++++ b/paddle/phi/kernels/gpu/gather_nd_kernel.cu
+@@ -18,6 +18,7 @@
+ #include "paddle/phi/common/bfloat16.h"
+ #include "paddle/phi/core/kernel_registry.h"
+ #include "paddle/phi/kernels/funcs/gather.cu.h"
++#include "paddle/phi/kernels/tile_kernel.h"
+ 
+ namespace phi {
+ 
+@@ -28,6 +29,21 @@ void GatherNdKernel(const Context &dev_ctx,
+                     DenseTensor *out) {
+   dev_ctx.template Alloc<T>(out);
+   if (x.numel() == 0 || out->numel() == 0) return;
++  // The result dims is
++  //   Index.shape[:-1] + X.shape[Index.shape[-1]:]
++  // If the last dimension of index is 0, set it to 1 and tile x.
++  auto index_dims = index.dims();
++  std::vector<int64_t> out_dims;
++  if (index_dims[index_dims.size() - 1] == 0) {
++    for (int i = 0; i < index_dims.size() - 1; ++i) {
++      out_dims.emplace_back(index_dims[i]);
++    }
++    for (int i = 0; i < x.dims().size(); ++i) {
++      out_dims.emplace_back(1);
++    }
++    phi::TileKernel<T, Context>(dev_ctx, x, phi::IntArray(out_dims), out);
++    return;
++  }
+   if (index.dims()[0] == 0 && index.numel() == 0) return;
+   const auto &index_type = index.dtype();
+   bool index_type_match =
+diff --git a/paddle/phi/kernels/gpu/tile_kernel.cu b/paddle/phi/kernels/gpu/tile_kernel.cu
+index fa378da418c4e6..d1b9fd6a37220c 100644
+--- a/paddle/phi/kernels/gpu/tile_kernel.cu
++++ b/paddle/phi/kernels/gpu/tile_kernel.cu
+@@ -107,6 +107,9 @@ PD_REGISTER_KERNEL(tile,
+                    double,
+                    int,
+                    int64_t,
++                   int8_t,
++                   int16_t,
++                   uint8_t,
+                    phi::dtype::float16,
+                    phi::dtype::bfloat16,
+                    phi::dtype::float8_e4m3fn,
+diff --git a/paddle/phi/kernels/gpu/tile_grad_kernel.cu b/paddle/phi/kernels/gpu/tile_grad_kernel.cu
+index 7817d42d03..6e89d88dff 100644
+--- a/paddle/phi/kernels/gpu/tile_grad_kernel.cu
++++ b/paddle/phi/kernels/gpu/tile_grad_kernel.cu
+@@ -27,7 +27,12 @@ PD_REGISTER_KERNEL(tile_grad,
+                    double,
+                    int,
+                    int64_t,
++                   int8_t,
++                   int16_t,
++                   uint8_t,
+                    phi::dtype::float16,
++                   phi::dtype::bfloat16,
++                   phi::dtype::float8_e4m3fn,
++                   phi::dtype::float8_e5m2,
+                    phi::dtype::complex<float>,
+-                   phi::dtype::complex<double>,
+-                   phi::dtype::bfloat16) {}
++                   phi::dtype::complex<double>) {}
+diff --git a/paddle/phi/kernels/xpu/gather_nd_kernel.cc b/paddle/phi/kernels/xpu/gather_nd_kernel.cc
+index 82740ae4819218..ec2261c3ed3ea1 100644
+--- a/paddle/phi/kernels/xpu/gather_nd_kernel.cc
++++ b/paddle/phi/kernels/xpu/gather_nd_kernel.cc
+@@ -16,6 +16,7 @@
+ 
+ #include "paddle/phi/backends/xpu/enforce_xpu.h"
+ #include "paddle/phi/core/kernel_registry.h"
++#include "paddle/phi/kernels/tile_kernel.h"
+ 
+ namespace phi {
+ 
+@@ -28,6 +29,21 @@ void GatherNdKernel(const Context &dev_ctx,
+   dev_ctx.template Alloc<T>(out);
+ 
+   if (x.numel() == 0 || out->numel() == 0) return;
++  // The result dims is
++  //   Index.shape[:-1] + X.shape[Index.shape[-1]:]
++  // If the last dimension of index is 0, set it to 1 and tile x.
++  auto index_dims = index.dims();
++  std::vector<int64_t> out_dims;
++  if (index_dims[index_dims.size() - 1] == 0) {
++    for (int i = 0; i < index_dims.size() - 1; ++i) {
++      out_dims.emplace_back(index_dims[i]);
++    }
++    for (int i = 0; i < x.dims().size(); ++i) {
++      out_dims.emplace_back(1);
++    }
++    phi::TileKernel<T, Context>(dev_ctx, x, phi::IntArray(out_dims), out);
++    return;
++  }
+   if (index.dims()[0] == 0 && index.numel() == 0) return;
+ 
+   if (index.numel() == 0) {

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73702/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73702/tests/test.patch
@@ -1,0 +1,28 @@
+diff --git a/test/legacy_test/test_gather_nd_op.py b/test/legacy_test/test_gather_nd_op.py
+index 914b460c36..b1d5ccaed9 100644
+--- a/test/legacy_test/test_gather_nd_op.py
++++ b/test/legacy_test/test_gather_nd_op.py
+@@ -721,6 +721,23 @@ class TestGatherNdAPI2(unittest.TestCase):
+         paddle.enable_static()
+ 
+ 
++class TestGatherNdOp_ZeroSize(OpTest):
++    def setUp(self):
++        self.op_type = "gather_nd"
++        self.python_api = paddle.gather_nd
++        self.public_python_api = paddle.gather_nd
++        xnp = np.random.random([10, 20])
++        index = np.random.random([0]).astype("int32")
++        output = xnp[tuple(index.T)]
++
++        self.inputs = {'X': xnp, 'Index': index}
++        self.outputs = {'Out': output}
++        self.__class__.no_need_check_grad = True
++
++    def test_check_output(self):
++        self.check_output(check_pir=True)
++
++
+ if __name__ == "__main__":
+     paddle.enable_static()
+     unittest.main()

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73702/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73702/tests/test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+# P2P tests (pass-to-pass)
+python -m pytest test/legacy_test/test_gather_nd_op.py::TestGatherNdOpWithEmptyIndex -q
+
+# F2P tests (fail-to-pass)
+python -m pytest test/legacy_test/test_gather_nd_op.py::TestGatherNdOp_ZeroSize -q


### PR DESCRIPTION
### 关联

- SWE-Paddle 共建 issue: [[Call for Bench] SWE-Paddle 社区共建 Paddle#79447](https://github.com/PaddlePaddle/Paddle/issues/79447)
- 来源 PR: [[0-size Tensor Job2 No.16、85] Add 0-size Tensor support for paddle.gather_nd Paddle#73702](https://github.com/PaddlePaddle/Paddle/pull/73702)

### 说明

新增 SWE-Paddle 任务 `PaddlePaddle__Paddle-73702`。

该任务覆盖 `paddle.gather_nd` 对 0-size Tensor 的处理。测试包含非 0-size Tensor regression case，以及 gather_nd 的目标场景，可在 CPU 环境运行。

### 验证结果

| 状态 | P2P | gather_nd F2P |
|---|---|---|
| Base + `tests/test.patch` | PASS | FAIL |
| Base + test patch + `solution/code.patch` | PASS | PASS |

#### Base P2P
```
2 passed, 2 warnings in 1.53s
```
    
#### Base F2P：gather_nd
```
FAILED test/legacy_test/test_gather_nd_op.py::TestGatherNdOp_ZeroSize::test_check_output - AssertionError: 
1 failed, 1 warning in 1.57s
```
    

#### Solution P2P
```
2 passed, 2 warnings in 1.53s

```
   
#### Solution F2P：gather_nd
```
1 passed, 1 warning in 1.28s
```
    