### PR TITLE
[SWE-Paddle] Add task PaddlePaddle__Paddle_78048

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78048/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78048/README.md
@@ -1,18 +1,44 @@
 # PaddlePaddle__Paddle-78048
 
-Source PR: https://github.com/PaddlePaddle/Paddle/pull/78048
+This directory converts Paddle PR #78048 into a SWE-Paddle community task candidate.
 
-This task covers parameter-alias compatibility for `paddle.hsplit`, `paddle.dsplit`, and `paddle.vsplit`.
+## Source
 
-- Base: `3f270c40db7776481d69176ee09222b3437d92bb`
-- Gold: `e9f4d5fd4a0893b99b358b100383799ed52a0e7e`
-- Production file: `python/paddle/tensor/manipulation.py`
-- Upstream test file: `test/legacy_test/test_api_compatibility.py`
+| Field       | Value                                                        |
+| ----------- | ------------------------------------------------------------ |
+| Repo        | `PaddlePaddle/Paddle`                                        |
+| PR          | [78048](https://github.com/PaddlePaddle/Paddle/pull/78048)   |
+| PR title    | `[API Compatibility No.62、73、234] Add parameter alias support for dsplit、hsplit、vsplit - part` |
+| Base commit | `3f270c40db7776481d69176ee09222b3437d92bb`                   |
+| Merged at   | `2026-03-05T10:11:27+08:00`                                  |
+| Task type   | `feature_enhancement`                                        |
+| Resource    | CPU                                                          |
 
-The task is Python-only and does not require rebuilding Paddle.
+## Summary
 
-The F2P oracle uses the real tests added by the source PR:
+Allow `paddle.hsplit`, `paddle.dsplit`, and `paddle.vsplit` to accept commonly used parameter aliases while preserving their existing positional and Paddle-native keyword forms.
 
-- `TestHsplitAPI::test_dygraph_Compatibility`
-- `TestDsplitAPI::test_dygraph_Compatibility`
-- `TestVsplitAPI::test_dygraph_Compatibility`
+## Why This Is A Good SWE-Paddle Candidate
+
+- The task comes from a real API compatibility gap with clear trigger conditions and expected results.
+- The change covers three related public APIs through shared parameter-handling behavior rather than isolated special cases.
+- The source PR provides real Tensor-based tests for the original names, the new aliases, Tensor methods, and NumPy reference results.
+- The tests run deterministically on CPU without external datasets, network access, or distributed devices.
+
+## Files
+
+- `proposal.md`: candidate proposal for maintainer triage.
+- `instruction.md`: self-contained problem statement for the coding agent.
+- `solution/code.patch`: gold patch from the merged PR.
+- `tests/test.patch`: test patch exposing the target behavior.
+- `tests/test.sh`: minimal target test command.
+- `environment/README.md`: environment notes for reproduction.
+- `README.md`: task overview and verification entrypoint.
+
+## Verification
+
+```bash
+bash tests/test.sh
+```
+
+Expected behavior: applying `tests/test.patch` to `base_commit` should fail on the unsupported parameter aliases; applying both `tests/test.patch` and `solution/code.patch` should pass the target tests.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78048/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78048/README.md
@@ -1,0 +1,18 @@
+# PaddlePaddle__Paddle-78048
+
+Source PR: https://github.com/PaddlePaddle/Paddle/pull/78048
+
+This task covers parameter-alias compatibility for `paddle.hsplit`, `paddle.dsplit`, and `paddle.vsplit`.
+
+- Base: `3f270c40db7776481d69176ee09222b3437d92bb`
+- Gold: `e9f4d5fd4a0893b99b358b100383799ed52a0e7e`
+- Production file: `python/paddle/tensor/manipulation.py`
+- Upstream test file: `test/legacy_test/test_api_compatibility.py`
+
+The task is Python-only and does not require rebuilding Paddle.
+
+The F2P oracle uses the real tests added by the source PR:
+
+- `TestHsplitAPI::test_dygraph_Compatibility`
+- `TestDsplitAPI::test_dygraph_Compatibility`
+- `TestVsplitAPI::test_dygraph_Compatibility`

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78048/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78048/environment/README.md
@@ -1,0 +1,13 @@
+# Environment
+
+This task is Python-only and does not require a Paddle source rebuild.
+
+Recommended verification environment:
+
+- Windows or Linux
+- Python 3.11
+- pytest
+- NumPy
+- an installed Paddle wheel providing the native CPU runtime
+
+The verifier loads the target Python module from the Base/Solution worktree, so the behavior under test comes from the checked-out source rather than from the installed wheel's copy of `manipulation.py`.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78048/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78048/instruction.md
@@ -1,32 +1,21 @@
-# 为 dsplit、hsplit 和 vsplit 补充参数别名兼容
+# 完善 hsplit、dsplit 和 vsplit 的参数名兼容
 
 ## 详细描述
 
-在迁移使用 PyTorch 参数命名方式的代码时，`paddle.hsplit`、`paddle.dsplit` 和 `paddle.vsplit` 仍只接受 Paddle 原有的 `x` 与 `num_or_indices` 参数名。使用 `input` 传入待切分 Tensor，或使用 `indices` / `sections` 指定切分位置或份数时，会因为参数名不被识别而调用失败。
+目前 `paddle.hsplit`、`paddle.dsplit` 和 `paddle.vsplit` 可以使用 Paddle 原有的参数名调用，但在使用一些常见的兼容参数名时会直接报参数错误。
 
-需要让这三个 API 在保持现有调用方式不变的同时，接受对应的兼容参数名，并保证通过别名调用得到的切分结果与现有参数名调用一致。
+例如使用 `input` 传入待切分的 Tensor，或者使用 `indices`、`sections` 指定切分方式时，这三个 API 目前无法正常调用。
+
+希望补充这些参数名的兼容支持，使用户能够使用不同的参数写法完成相同的切分操作，同时不影响现有调用方式。
 
 ## 验收说明
 
-验证 `hsplit`、`dsplit` 和 `vsplit` 均支持：
-
-- `input` 作为 `x` 的兼容参数名；
-- `indices` 和 `sections` 作为 `num_or_indices` 的兼容参数名；
-- 原有位置参数以及 `x` / `num_or_indices` 关键字调用继续正常工作。
+- `paddle.hsplit`、`paddle.dsplit` 和 `paddle.vsplit` 应支持使用 `input` 代替 `x`。
+- 三个 API 应支持使用 `indices` 或 `sections` 代替 `num_or_indices`，并得到与原参数名相同的切分结果。
+- 原有的位置参数以及 `x`、`num_or_indices` 参数名必须继续正常工作，已有行为不能发生变化。
 
 ## 技术要求
 
-- 不改变三个 API 现有切分语义和返回结果。
-- 不要求修改底层 C++/CUDA kernel。
-- 不应通过放宽全局参数校验或绕过调用检查来实现兼容。
-
-## 参考资料
-
-- 来源 issue: https://github.com/PaddlePaddle/Paddle/issues/76301
-- 来源 PR: https://github.com/PaddlePaddle/Paddle/pull/78048
-
-## Acceptance Criteria
-
-- The behavior described above should be fixed.
-- Existing valid behavior should remain unchanged.
-- Do not satisfy the task by deleting tests, weakening assertions, or bypassing validation broadly.
+- 熟悉 Paddle Python API 的参数定义和关键字参数调用方式。
+- 理解 `hsplit`、`dsplit`、`vsplit` 的基本切分行为以及参数含义。
+- 能够使用现有 API compatibility 单测验证新旧参数写法的兼容性。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78048/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78048/instruction.md
@@ -1,0 +1,32 @@
+# 为 dsplit、hsplit 和 vsplit 补充参数别名兼容
+
+## 详细描述
+
+在迁移使用 PyTorch 参数命名方式的代码时，`paddle.hsplit`、`paddle.dsplit` 和 `paddle.vsplit` 仍只接受 Paddle 原有的 `x` 与 `num_or_indices` 参数名。使用 `input` 传入待切分 Tensor，或使用 `indices` / `sections` 指定切分位置或份数时，会因为参数名不被识别而调用失败。
+
+需要让这三个 API 在保持现有调用方式不变的同时，接受对应的兼容参数名，并保证通过别名调用得到的切分结果与现有参数名调用一致。
+
+## 验收说明
+
+验证 `hsplit`、`dsplit` 和 `vsplit` 均支持：
+
+- `input` 作为 `x` 的兼容参数名；
+- `indices` 和 `sections` 作为 `num_or_indices` 的兼容参数名；
+- 原有位置参数以及 `x` / `num_or_indices` 关键字调用继续正常工作。
+
+## 技术要求
+
+- 不改变三个 API 现有切分语义和返回结果。
+- 不要求修改底层 C++/CUDA kernel。
+- 不应通过放宽全局参数校验或绕过调用检查来实现兼容。
+
+## 参考资料
+
+- 来源 issue: https://github.com/PaddlePaddle/Paddle/issues/76301
+- 来源 PR: https://github.com/PaddlePaddle/Paddle/pull/78048
+
+## Acceptance Criteria
+
+- The behavior described above should be fixed.
+- Existing valid behavior should remain unchanged.
+- Do not satisfy the task by deleting tests, weakening assertions, or bypassing validation broadly.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78048/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78048/proposal.md
@@ -1,0 +1,22 @@
+# Proposal
+
+## Problem
+
+`paddle.hsplit`, `paddle.dsplit`, and `paddle.vsplit` expose Paddle-native argument names `x` and `num_or_indices`. Code written with PyTorch-style keyword names such as `input`, `indices`, and `sections` cannot call these APIs directly even though the underlying split semantics already match.
+
+## Expected behavior
+
+Each API should accept the following equivalent parameter names:
+
+- `x` / `input`
+- `num_or_indices` / `indices` / `sections`
+
+Existing positional calls and Paddle-native keyword calls must continue to produce identical results.
+
+## Verification
+
+The task uses the real compatibility tests added by the source PR in `test/legacy_test/test_api_compatibility.py`.
+
+F2P coverage runs the PR's `TestHsplitAPI`, `TestDsplitAPI`, and `TestVsplitAPI` dynamic-mode compatibility methods. These tests exercise real Paddle Tensor inputs, the original parameter names, the new aliases, Tensor methods, and NumPy reference results.
+
+P2P coverage separately verifies that the existing positional and Paddle-native keyword forms remain unchanged.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78048/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78048/proposal.md
@@ -1,22 +1,54 @@
-# Proposal
+# Task Proposal: PaddlePaddle__Paddle-78048
 
-## Problem
+## 1. 来源信息
 
-`paddle.hsplit`, `paddle.dsplit`, and `paddle.vsplit` expose Paddle-native argument names `x` and `num_or_indices`. Code written with PyTorch-style keyword names such as `input`, `indices`, and `sections` cannot call these APIs directly even though the underlying split semantics already match.
+- Instance ID：`PaddlePaddle__Paddle-78048`
+- PR 链接：https://github.com/PaddlePaddle/Paddle/pull/78048
+- PR 标题：`[API Compatibility No.62、73、234] Add parameter alias support for dsplit、hsplit、vsplit - part`
+- `base_commit`：`3f270c40db7776481d69176ee09222b3437d92bb`
+- merged 时间：`2026-03-05T10:11:27+08:00`
+- 你的身份：熟悉该模块的 contributor
+- 后续联系人：TBD
 
-## Expected behavior
+## 2. 问题一句话
 
-Each API should accept the following equivalent parameter names:
+`paddle.hsplit`、`paddle.dsplit` 和 `paddle.vsplit` 无法使用 `input`、`indices` 或 `sections` 这些常见参数名调用，与已有代码的兼容性不足。
 
-- `x` / `input`
-- `num_or_indices` / `indices` / `sections`
+## 3. 为什么适合作为 SWE-Paddle 样本
 
-Existing positional calls and Paddle-native keyword calls must continue to produce identical results.
+- **真实性**：来自真实的 Paddle API 兼容性改进，用户在迁移或复用切分代码时可直接遇到。
+- **代表性**：要求在多个相关公开 API 中统一处理参数别名，同时保留原有调用方式。
+- **边界清楚**：生产修改集中在单个 Python 文件，目标行为可由三组 API compatibility 测试直接验证。
+- **非平凡性**：修复不能只针对某一个函数或某一个参数特判，还要保证新旧参数名返回一致的切分结果。
+- **环境友好性**：可在 CPU 环境使用小型 Tensor 稳定复现，不依赖外部资源。
 
-## Verification
+## 4. 任务类型和标签
 
-The task uses the real compatibility tests added by the source PR in `test/legacy_test/test_api_compatibility.py`.
+- 任务类型：`feature_enhancement`
+- 执行后端：`cpu`
+- 设备范围：`cpu_only`
+- 模块标签：`[tensor, split-api, api-compatibility]`
 
-F2P coverage runs the PR's `TestHsplitAPI`, `TestDsplitAPI`, and `TestVsplitAPI` dynamic-mode compatibility methods. These tests exercise real Paddle Tensor inputs, the original parameter names, the new aliases, Tensor methods, and NumPy reference results.
+## 5. 验证思路
 
-P2P coverage separately verifies that the existing positional and Paddle-native keyword forms remain unchanged.
+- 目标测试命令：`bash tests/test.sh`
+- 目标测试文件：`test/legacy_test/test_api_compatibility.py`
+- 修复前预期：`input`、`indices` 和 `sections` 别名调用失败，目标测试不通过。
+- 修复后预期：三个 API 的原参数名、新别名和 Tensor method 调用均返回与 NumPy 参考结果一致的切分结果。
+- P2P 候选：位置参数调用、`x`/`num_or_indices` 关键字参数调用以及已有 Tensor method 调用。
+
+## 6. 环境与资源
+
+- 资源需求：CPU
+- Paddle 来源：`PaddlePaddle/Paddle` source checkout at `base_commit`
+- 是否能提供 Docker：暂无
+- patch 类型：Python-only
+- 最小测试命令：`bash tests/test.sh`
+- 是否有 oracle 日志：由 SWE-Paddle verifier 结果另行维护
+
+## 7. 风险自查
+
+- 泄露风险：任务描述只说明对外行为和兼容性要求，未给出 Gold patch 的具体修改方式。
+- 环境风险：历史 checkout 与已安装 wheel 可能存在 Python 层差异，因此需要按 environment 说明加载 checkout 中的目标模块。
+- flaky 风险：测试使用固定随机种子和小型 CPU Tensor，不依赖时序、网络或外部数据。
+- 拆分风险：三个 API 共享同一类参数别名兼容问题，且修改位于同一生产文件，无需拆成多个任务。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78048/solution/code.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78048/solution/code.patch
@@ -1,0 +1,76 @@
+diff --git a/python/paddle/tensor/manipulation.py b/python/paddle/tensor/manipulation.py
+index 33d9e2702a7d19b1cc16b94541df265a953f6cf8..12495d5dee3fca2ed0af721c190b95e392fadb32 100644
+--- a/python/paddle/tensor/manipulation.py
++++ b/python/paddle/tensor/manipulation.py
+@@ -3101,6 +3101,12 @@ def tensor_split(
+         )
+ 
+ 
++@ParamAliasDecorator(
++    {
++        "x": ["input"],
++        "num_or_indices": ["indices", "sections"],
++    }
++)
+ def hsplit(
+     x: Tensor, num_or_indices: int | Sequence[int], name: str | None = None
+ ) -> list[Tensor]:
+@@ -3119,8 +3125,10 @@ def hsplit(
+ 
+     Args:
+         x (Tensor): A Tensor whose dimension must be greater than 0. The data type is bool, bfloat16, float16, float32, float64, uint8, int32 or int64.
++            Alias: ``input``.
+         num_or_indices (int|list|tuple): If ``num_or_indices`` is an int ``n``, ``x`` is split into ``n`` sections.
+             If ``num_or_indices`` is a list or tuple of integer indices, ``x`` is split at each of the indices.
++            Alias: ``indices``、``sections``.
+         name (str|None, optional): The default value is None.  Normally there is no need for user to set this property.
+             For more information, please refer to :ref:`api_guide_Name` .
+     Returns:
+@@ -3166,6 +3174,12 @@ def hsplit(
+         return tensor_split(x, num_or_indices, axis=0, name=name)
+ 
+ 
++@ParamAliasDecorator(
++    {
++        "x": ["input"],
++        "num_or_indices": ["indices", "sections"],
++    }
++)
+ def dsplit(
+     x: Tensor, num_or_indices: int | Sequence[int], name: str | None = None
+ ) -> list[Tensor]:
+@@ -3183,8 +3197,10 @@ def dsplit(
+ 
+     Args:
+         x (Tensor): A Tensor whose dimension must be greater than 2. The data type is bool, bfloat16, float16, float32, float64, uint8, int32 or int64.
++            Alias: ``input``.
+         num_or_indices (int|list|tuple): If ``num_or_indices`` is an int ``n``, ``x`` is split into ``n`` sections.
+             If ``num_or_indices`` is a list or tuple of integer indices, ``x`` is split at each of the indices.
++            Alias: ``indices``、``sections``.
+         name (str|None, optional): The default value is None.  Normally there is no need for user to set this property.
+             For more information, please refer to :ref:`api_guide_Name` .
+     Returns:
+@@ -3219,6 +3235,12 @@ def dsplit(
+     return tensor_split(x, num_or_indices, axis=2, name=name)
+ 
+ 
++@ParamAliasDecorator(
++    {
++        "x": ["input"],
++        "num_or_indices": ["indices", "sections"],
++    }
++)
+ def vsplit(
+     x: Tensor, num_or_indices: int | Sequence[int], name: str | None = None
+ ) -> list[Tensor]:
+@@ -3240,8 +3262,10 @@ def vsplit(
+ 
+     Args:
+         x (Tensor): A Tensor whose dimension must be greater than 1. The data type is bool, bfloat16, float16, float32, float64, uint8, int32 or int64.
++            Alias: ``input``.
+         num_or_indices (int|list|tuple): If ``num_or_indices`` is an int ``n``, ``x`` is split into ``n`` sections.
+             If ``num_or_indices`` is a list or tuple of integer indices, ``x`` is split at each of the indices.
++            Alias: ``indices``、``sections``.
+         name (str, optional): The default value is None.  Normally there is no need for user to set this property.
+             For more information, please refer to :ref:`api_guide_Name` .
+ 

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78048/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78048/tests/test.patch
@@ -1,0 +1,208 @@
+diff --git a/test/legacy_test/test_api_compatibility.py b/test/legacy_test/test_api_compatibility.py
+index d3f0eb4a448932a04ef6d2bd7b2d55cd731e199f..e6e8fb3b294b287b6392c612996f2325016a1849 100644
+--- a/test/legacy_test/test_api_compatibility.py
++++ b/test/legacy_test/test_api_compatibility.py
+@@ -2997,5 +2997,203 @@ class TestCloneAPI(unittest.TestCase):
+                 np.testing.assert_allclose(out, self.np_x)
+ 
+ 
++class TestHsplitAPI(unittest.TestCase):
++    def setUp(self):
++        np.random.seed(2025)
++        self.shape2d = [7, 8]
++        self.dtype = 'float32'
++        self.init_data()
++
++    def init_data(self):
++        self.np_x_2d = np.random.rand(*self.shape2d).astype(self.dtype)
++
++    def test_dygraph_Compatibility(self):
++        paddle.disable_static()
++        x_2d = paddle.to_tensor(self.np_x_2d)
++
++        out1 = paddle.hsplit(x_2d, 2)
++        out2 = paddle.hsplit(x=x_2d, num_or_indices=2)
++        out3 = paddle.hsplit(input=x_2d, indices=2)
++        out4 = paddle.hsplit(input=x_2d, sections=2)
++        out5 = paddle.hsplit(x_2d, num_or_indices=2)
++        out6 = x_2d.hsplit(2)
++        out7 = x_2d.hsplit(num_or_indices=2)
++
++        ref_out = np.array_split(self.np_x_2d, 2, axis=1)
++        for out in [out1, out2, out3, out4, out5, out6, out7]:
++            self.assertEqual(len(out), 2)
++            np.testing.assert_allclose(ref_out[0], out[0].numpy())
++            np.testing.assert_allclose(ref_out[1], out[1].numpy())
++
++        paddle.enable_static()
++
++    def test_static_Compatibility(self):
++        paddle.enable_static()
++        main = paddle.static.Program()
++        startup = paddle.static.Program()
++        with paddle.base.program_guard(main, startup):
++            x_2d = paddle.static.data(
++                name="x_2d", shape=self.shape2d, dtype=self.dtype
++            )
++
++            out1 = paddle.hsplit(x_2d, 2)
++            out2 = paddle.hsplit(x=x_2d, num_or_indices=2)
++            out3 = paddle.hsplit(input=x_2d, indices=2)
++            out4 = paddle.hsplit(input=x_2d, sections=2)
++
++            exe = paddle.base.Executor()
++            fetches = exe.run(
++                main,
++                feed={"x_2d": self.np_x_2d},
++                fetch_list=[
++                    out1[0],
++                    out1[1],
++                    out2[0],
++                    out2[1],
++                    out3[0],
++                    out3[1],
++                    out4[0],
++                    out4[1],
++                ],
++            )
++
++            ref_out = np.array_split(self.np_x_2d, 2, axis=1)
++            for i in range(0, 8, 2):
++                np.testing.assert_allclose(fetches[i], ref_out[0])
++                np.testing.assert_allclose(fetches[i + 1], ref_out[1])
++
++
++class TestDsplitAPI(unittest.TestCase):
++    def setUp(self):
++        np.random.seed(2025)
++        self.shape3d = [7, 6, 8]
++        self.dtype = 'float32'
++        self.init_data()
++
++    def init_data(self):
++        self.np_x_3d = np.random.rand(*self.shape3d).astype(self.dtype)
++
++    def test_dygraph_Compatibility(self):
++        paddle.disable_static()
++        x_3d = paddle.to_tensor(self.np_x_3d)
++
++        out1 = paddle.dsplit(x_3d, 2)
++        out2 = paddle.dsplit(x=x_3d, num_or_indices=2)
++        out3 = paddle.dsplit(input=x_3d, indices=2)
++        out4 = paddle.dsplit(input=x_3d, sections=2)
++        out5 = paddle.dsplit(x_3d, num_or_indices=2)
++        out6 = x_3d.dsplit(2)
++        out7 = x_3d.dsplit(num_or_indices=2)
++
++        ref_out = np.array_split(self.np_x_3d, 2, axis=2)
++        for out in [out1, out2, out3, out4, out5, out6, out7]:
++            self.assertEqual(len(out), 2)
++            np.testing.assert_allclose(ref_out[0], out[0].numpy())
++            np.testing.assert_allclose(ref_out[1], out[1].numpy())
++
++        paddle.enable_static()
++
++    def test_static_Compatibility(self):
++        paddle.enable_static()
++        main = paddle.static.Program()
++        startup = paddle.static.Program()
++        with paddle.base.program_guard(main, startup):
++            x_3d = paddle.static.data(
++                name="x_3d", shape=self.shape3d, dtype=self.dtype
++            )
++
++            out1 = paddle.dsplit(x_3d, 2)
++            out2 = paddle.dsplit(x=x_3d, num_or_indices=2)
++            out3 = paddle.dsplit(input=x_3d, indices=2)
++            out4 = paddle.dsplit(input=x_3d, sections=2)
++
++            exe = paddle.base.Executor()
++            fetches = exe.run(
++                main,
++                feed={"x_3d": self.np_x_3d},
++                fetch_list=[
++                    out1[0],
++                    out1[1],
++                    out2[0],
++                    out2[1],
++                    out3[0],
++                    out3[1],
++                    out4[0],
++                    out4[1],
++                ],
++            )
++
++            ref_out = np.array_split(self.np_x_3d, 2, axis=2)
++            for i in range(0, 8, 2):
++                np.testing.assert_allclose(fetches[i], ref_out[0])
++                np.testing.assert_allclose(fetches[i + 1], ref_out[1])
++
++
++class TestVsplitAPI(unittest.TestCase):
++    def setUp(self):
++        np.random.seed(2025)
++        self.shape2d = [8, 6]
++        self.dtype = 'float32'
++        self.init_data()
++
++    def init_data(self):
++        self.np_x_2d = np.random.rand(*self.shape2d).astype(self.dtype)
++
++    def test_dygraph_Compatibility(self):
++        paddle.disable_static()
++        x_2d = paddle.to_tensor(self.np_x_2d)
++
++        out1 = paddle.vsplit(x_2d, 2)
++        out2 = paddle.vsplit(x=x_2d, num_or_indices=2)
++        out3 = paddle.vsplit(input=x_2d, indices=2)
++        out4 = paddle.vsplit(input=x_2d, sections=2)
++        out5 = paddle.vsplit(x_2d, num_or_indices=2)
++        out6 = x_2d.vsplit(2)
++        out7 = x_2d.vsplit(num_or_indices=2)
++
++        ref_out = np.array_split(self.np_x_2d, 2, axis=0)
++        for out in [out1, out2, out3, out4, out5, out6, out7]:
++            self.assertEqual(len(out), 2)
++            np.testing.assert_allclose(ref_out[0], out[0].numpy())
++            np.testing.assert_allclose(ref_out[1], out[1].numpy())
++
++        paddle.enable_static()
++
++    def test_static_Compatibility(self):
++        paddle.enable_static()
++        main = paddle.static.Program()
++        startup = paddle.static.Program()
++        with paddle.base.program_guard(main, startup):
++            x_2d = paddle.static.data(
++                name="x_2d", shape=self.shape2d, dtype=self.dtype
++            )
++
++            out1 = paddle.vsplit(x_2d, 2)
++            out2 = paddle.vsplit(x=x_2d, num_or_indices=2)
++            out3 = paddle.vsplit(input=x_2d, indices=2)
++            out4 = paddle.vsplit(input=x_2d, sections=2)
++
++            exe = paddle.base.Executor()
++            fetches = exe.run(
++                main,
++                feed={"x_2d": self.np_x_2d},
++                fetch_list=[
++                    out1[0],
++                    out1[1],
++                    out2[0],
++                    out2[1],
++                    out3[0],
++                    out3[1],
++                    out4[0],
++                    out4[1],
++                ],
++            )
++
++            ref_out = np.array_split(self.np_x_2d, 2, axis=0)
++            for i in range(0, 8, 2):
++                np.testing.assert_allclose(fetches[i], ref_out[0])
++                np.testing.assert_allclose(fetches[i + 1], ref_out[1])
++
++
+ if __name__ == '__main__':
+     unittest.main()

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78048/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78048/tests/test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python -m pytest \
+  test/legacy_test/test_api_compatibility.py::TestHsplitAPI::test_dygraph_Compatibility \
+  test/legacy_test/test_api_compatibility.py::TestDsplitAPI::test_dygraph_Compatibility \
+  test/legacy_test/test_api_compatibility.py::TestVsplitAPI::test_dygraph_Compatibility \
+  -q


### PR DESCRIPTION
## 关联

* SWE-Paddle 共建 issue: https://github.com/PaddlePaddle/Paddle/issues/79447
* 来源 PR:https://github.com/PaddlePaddle/Paddle/pull/78048

## 说明

新增 SWE-Paddle 任务 `PaddlePaddle__Paddle-78048`。

该任务覆盖 `paddle.hsplit`、`paddle.dsplit` 和 `paddle.vsplit` 的参数名兼容，支持使用 `input` 代替 `x`，以及使用 `indices`、`sections` 代替 `num_or_indices`。测试使用来源 PR 中新增的 API compatibility 单测，同时包含原有参数写法的 regression case，可在 CPU 环境运行，无需重新编译 Paddle。

## 验证结果

| 状态                                        | P2P  | hsplit F2P | dsplit F2P | vsplit F2P |
| ----------------------------------------- | ---- | ---------- | ---------- | ---------- |
| Base + `tests/test.patch`                 | PASS | FAIL       | FAIL       | FAIL       |
| Base + test patch + `solution/code.patch` | PASS | PASS       | PASS       | PASS       |

#### Base P2P

```text
P2P existing parameter forms: PASS
```

#### Base F2P：hsplit

```text
FAILED test/legacy_test/test_api_compatibility.py::TestHsplitAPI::test_dygraph_Compatibility
TypeError: hsplit() got an unexpected keyword argument 'input'

1 failed in 1.15s
```

#### Base F2P：dsplit

```text
FAILED test/legacy_test/test_api_compatibility.py::TestDsplitAPI::test_dygraph_Compatibility
TypeError: dsplit() got an unexpected keyword argument 'input'

1 failed in 1.29s
```

#### Base F2P：vsplit

```text
FAILED test/legacy_test/test_api_compatibility.py::TestVsplitAPI::test_dygraph_Compatibility
TypeError: vsplit() got an unexpected keyword argument 'input'

1 failed in 1.11s
```

#### Solution P2P

```text
P2P existing parameter forms: PASS
```

#### Solution F2P：hsplit

```text
1 passed in 0.92s
```

#### Solution F2P：dsplit

```text
1 passed in 0.93s
```

#### Solution F2P：vsplit

```text
1 passed in 0.92s
```

#### Solution `tests/test.sh`

```text
3 passed in 1.03s
```
