### PR TITLE
[SWE-Paddle] Add task PaddlePaddle__Paddle-73776

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73776/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73776/README.md
@@ -1,0 +1,51 @@
+# PaddlePaddle__Paddle-73776
+
+This directory converts Paddle PR #73776 into a SWE-Paddle community task candidate.
+
+## Source
+
+| Field | Value |
+| --- | --- |
+| Repo | `PaddlePaddle/Paddle` |
+| PR | [73776](https://github.com/PaddlePaddle/Paddle/pull/73776) |
+| PR title | `[0-size Tensor No.117] Add 0-size Tensor support for paddle.linalg.svd_lowrank` |
+| Base commit | `24392e6ecbec3fea89e5ea5cdf9cbc8dd01aeafc` |
+| Gold commit | `49a9bb516f9d29350490bcc5287ac7acb9e52f73` |
+| Merged at | `2025-07-03` |
+| Task type | `bug_fix` |
+| Resource | CPU |
+| Scope | Python Tensor API |
+
+## Summary
+
+Fix `paddle.linalg.svd_lowrank` to correctly handle 0-size tensors in dynamic mode.
+
+## Why This Is A Good SWE-Paddle Candidate
+
+- It is derived from a merged Paddle bug-fix PR rather than a synthetic issue.
+- The target behavior is isolated to the Python Tensor API and does not require rebuilding C++ kernels.
+- The failure is deterministic: the base revision fails when processing 0-size tensors in dynamic mode.
+- The task has clear regression coverage for existing non-zero-size behavior.
+- The task runs on CPU and does not require distributed execution, external services, or additional datasets.
+
+## Files
+
+- `proposal.md`: candidate proposal for maintainer triage.
+- `instruction.md`: self-contained problem statement for the coding agent.
+- `solution/code.patch`: gold implementation patch.
+- `tests/test.patch`: tests exposing the target behavior.
+- `tests/test.sh`: minimal target test command.
+- `environment/README.md`: environment and reproduction notes.
+
+## Verification
+
+```bash
+bash tests/test.sh
+```
+
+Expected behavior:
+
+| Revision state | Existing behavior (P2P) | svd_lowrank F2P |
+| --- | ---: | ---: |
+| Base + `tests/test.patch` | PASS | FAIL |
+| Base + `tests/test.patch` + `solution/code.patch` | PASS | PASS |

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73776/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73776/environment/README.md
@@ -1,0 +1,37 @@
+# Environment Notes
+
+## Expected Environment
+
+- Repository: `PaddlePaddle/Paddle`
+- Base commit: `24392e6ecbec3fea89e5ea5cdf9cbc8dd01aeafc`
+- Gold commit: `49a9bb516f9d29350490bcc5287ac7acb9e52f73`
+- Resource: CPU
+- GPU required: no
+- Patch type: Python-only
+- Python dependencies: PaddlePaddle, NumPy, pytest
+
+The verifier should execute against the Paddle source revision represented by the selected patch state. A source build is not required when an equivalent Python overlay is available and the underlying runtime remains API-compatible.
+
+## Run Order
+
+1. Check out `PaddlePaddle/Paddle` at the base commit.
+2. Apply `tests/test.patch`.
+3. Run the P2P tests; existing non-zero-size behavior should pass.
+4. Run the 0-size tensor tests; the target case should fail before the fix.
+5. Apply `solution/code.patch`.
+6. Run `bash tests/test.sh`; all target tests should pass.
+
+## Minimal Test Command
+
+```bash
+bash tests/test.sh
+```
+
+## Expected Matrix
+
+| Revision state | P2P | svd_lowrank F2P |
+| --- | ---: | ---: |
+| Base + test patch | PASS | FAIL |
+| Base + test patch + solution patch | PASS | PASS |
+
+No GPU, distributed runtime, external service, or additional dataset is required.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73776/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73776/instruction.md
@@ -2,11 +2,11 @@
 
 ## 详细描述
 
-当 `paddle.linalg.svd_lowrank(x)` 的输入 `x` 中存在大小为 `0` 的 dimension，即 `m` 和 `n` 中有一项为 0 时，当前实现在动态图模式下会因为参数校验和中间断言失败而报错。
+当 `paddle.linalg.svd_lowrank(x)` 的输入 `x` 中存在大小为 `0` 的 dimension，即 `m` 和 `n` 中有一项为 0 时，当前实现在动态图模式下会报错。
 
 典型表现包括：
 
-- 参数校验阶段，当 `min(m, n) == 0` 时，`q >= 0 and q <= min(m, n)` 条件不满足，抛出 `ValueError`
+- 参数校验阶段，当 `min(m, n) == 0` 时，条件不满足，抛出 `ValueError`
 - 中间计算阶段的 assert 检查在 0-size 维度上失败
 
 例如：

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73776/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73776/instruction.md
@@ -1,0 +1,39 @@
+# 修复 `paddle.linalg.svd_lowrank` 对 0-size Tensor 的处理
+
+## 详细描述
+
+当 `paddle.linalg.svd_lowrank(x)` 的输入 `x` 中存在大小为 `0` 的 dimension，即 `m` 和 `n` 中有一项为 0 时，当前实现在动态图模式下会因为参数校验和中间断言失败而报错。
+
+典型表现包括：
+
+- 参数校验阶段，当 `min(m, n) == 0` 时，`q >= 0 and q <= min(m, n)` 条件不满足，抛出 `ValueError`
+- 中间计算阶段的 assert 检查在 0-size 维度上失败
+
+例如：
+
+```python
+import numpy as np
+import paddle
+
+paddle.disable_static()
+x = paddle.to_tensor(np.random.random((1, 4, 0)).astype("float64"))
+x.stop_gradient = False
+out = paddle.linalg.svd_lowrank(x, q=4)
+```
+
+上述调用中 `x` 的 shape 为 `[1, 4, 0]`，`m=4, n=0`，`min(m, n)=0`。按照 API semantics，当输入 tensor 的某个维度为 0 时，SVD 分解应正常完成并返回正确 shape 的空 tensor。
+
+当前实现层在进入参数校验和中间计算时，会失败而报错。
+
+## 验收说明
+
+- 当输入 tensor 的最后两个维度中有一个为 0 时，`paddle.linalg.svd_lowrank` 应正常完成，返回正确 shape 的空 tensor（U, S, V）
+- 返回的 U、S、V 的 shape 应与非 0-size 输入时的 shape 推断一致
+- 非 0-size tensor 输入下的 svd_lowrank 行为不得退化
+
+## 技术要求
+
+- 熟悉 Python 和 Paddle Tensor API
+- 了解 Tensor shape、0-size Tensor 和动态图执行路径
+- 了解 SVD 分解和多返回值语义
+- 了解 Paddle 动态图和静态图执行路径的区别

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73776/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73776/proposal.md
@@ -1,0 +1,58 @@
+# Task Proposal: PaddlePaddle__Paddle-73776
+
+## 1. 来源信息
+
+- Instance ID：`PaddlePaddle__Paddle-73776`
+- PR 链接：https://github.com/PaddlePaddle/Paddle/pull/73776
+- PR 标题：`[0-size Tensor No.117] Add 0-size Tensor support for paddle.linalg.svd_lowrank`
+- `base_commit`：`24392e6ecbec3fea89e5ea5cdf9cbc8dd01aeafc`
+- merged 时间：`2025-07-03`
+- 你的身份：contributor
+
+## 2. 问题一句话
+
+`paddle.linalg.svd_lowrank` 在动态图模式下对 0-size tensor（最后两个维度中含有 0）的输入缺少显式处理，导致参数校验和中间断言失败，需要补齐 0-size tensor 支持。
+
+## 3. 为什么适合作为 SWE-Paddle 样本
+
+- **真实性**：该问题来自 Paddle 的「0-size Tensor 机制建设」系列任务，是真实研发需求，目标是为 `svd_lowrank` 算子补齐 0-size tensor 支持。
+- **代表性**：覆盖 Python API 层面的算子边界处理，涉及 dynamic mode 下的 tensor 维度判断和参数校验逻辑，是 Paddle API 算子机制增强的典型样本。
+- **边界清楚**：目标仅限 0-size tensor 输入的参数校验跳过和中间 assert 保护，返回值为空 tensor 且保持 shape 一致；正向非零尺寸输入不应受影响。
+- **非平凡性**：修复需要在 `linalg.py` 中为 `svd_lowrank` 函数修改参数校验逻辑（`min(m, n) != 0` 条件保护）以及两处中间 assert 的 0-size 保护，涉及矩阵分解的维度语义，不是简单机械修改。
+- **回归护栏明确**：目标 F2P 可覆盖 0-size tensor 输入的 `paddle.linalg.svd_lowrank` 动态图调用；同文件已有的标准 svd_lowrank 测试用例可作为 P2P 护栏。
+
+## 4. 任务类型和标签
+
+- 任务类型：`bug_fix`
+- 执行后端：`cpu`
+- 设备范围：`cpu_only`
+- 模块标签：`[python_api, linalg, 0-size_tensor, svd_lowrank, dynamic_mode]`
+
+## 5. 验证思路
+
+- 目标测试命令：`bash tests/test.sh`
+- 目标测试文件：
+  - `test/legacy_test/test_svd_lowrank.py`（`TestSvdLowRankAPI_ZeroSize`）
+- P2P 候选：同文件中已有的 `TestSvdLowrankAPI` 等标准 svd_lowrank 测试用例。
+- 修复前预期：`base_commit` + `tests/test.patch` 后，0-size tensor 输入在 `paddle.linalg.svd_lowrank` 的动态图调用中失败（参数校验或 assert 报错）。
+- 修复后预期：继续应用 `solution/code.patch` 后，0-size tensor 输入返回正确的空 tensor（shape 与预期一致），P2P 存量测试仍然通过。
+
+## 6. 环境与资源
+
+- 是否能提供 Docker：无
+- Dockerfile 或镜像地址：暂无
+- Paddle 来源：`PaddlePaddle/Paddle` source checkout at `base_commit`，纯 Python 修改可直接 patch。
+- 如果使用 wheel，请填写 wheel URL、Python 版本和平台标签：可由 verifier 选择与 base 兼容的 CPU wheel 或本地源码环境；proposal 阶段不固定 wheel URL。
+- OS / Python / CUDA / cuDNN / 其他关键依赖：Linux CPU + Python + numpy + pytest；不要求 CUDA/cuDNN。
+- 硬件：CPU 即可。
+- patch 类型：纯 Python 修改 + Python legacy test，无需 C++ rebuild。
+- 最小测试命令：`bash tests/test.sh`
+- 是否有 oracle 日志：无；由 SWE-Paddle verifier 记录 Run/Test/Fix 结果。
+
+## 7. 风险自查
+
+- 泄露风险：正式 `instruction.md` 只描述「动态图下 svd_lowrank 对 0-size tensor 输入的行为异常」，不指出具体 `min(m, n) != 0` 条件保护逻辑或具体代码位置。
+- 环境风险：低。任务为 Python-only，无需特殊镜像、外部服务或不可固定下载。
+- flaky 风险：低。测试使用固定的 0-size tensor 构造，不依赖随机数差异或多设备同步。
+- 拆分风险：低。该 PR 目标集中在 `linalg.py` 中 `svd_lowrank` 函数的 0-size 保护，测试也明确指向 svd_lowrank 的零尺寸分支，适合作为一个独立样本。
+- 其他不确定点：完整任务包阶段应确认新增 F2P（`TestSvdLowRankAPI_ZeroSize`）在 `base_commit` 上确实失败，并选择同文件中已有的 `TestSvdLowrankAPI` 等标准测试用例作为在 base 与修复后都稳定通过的 P2P nodeid。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73776/solution/code.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73776/solution/code.patch
@@ -1,0 +1,33 @@
+diff --git a/python/paddle/tensor/linalg.py b/python/paddle/tensor/linalg.py
+index ecc345c250..d54005f508 100644
+--- a/python/paddle/tensor/linalg.py
++++ b/python/paddle/tensor/linalg.py
+@@ -3170,7 +3170,7 @@ def svd_lowrank(
+     m, n = x.shape[-2:]
+     if q is None:
+         q = min(6, m, n)
+-    elif not (q >= 0 and q <= min(m, n)):
++    elif min(m, n) != 0 and not (q >= 0 and q <= min(m, n)):
+         raise ValueError(
+             f'q(={q}) must be non-negative integer'
+             f' and not greater than min(m, n)={min(m, n)}'
+@@ -3194,7 +3194,8 @@ def svd_lowrank(
+         else:
+             B_t = paddle.matmul(x, Q_c) - paddle.matmul(M, Q_c)
+         assert B_t.shape[-2] == m, (B_t.shape, m)
+-        assert B_t.shape[-1] == q, (B_t.shape, q)
++        if B_t.shape[-1] != 0:
++            assert B_t.shape[-1] == q, (B_t.shape, q)
+         assert B_t.shape[-1] <= B_t.shape[-2], B_t.shape
+         U, S, Vh = paddle.linalg.svd(B_t, full_matrices=False)
+         V = _transjugate(Vh)
+@@ -3207,7 +3208,8 @@ def svd_lowrank(
+         else:
+             B = paddle.matmul(A_t, Q_c) - paddle.matmul(M_t, Q_c)
+         B_t = _transpose(B)
+-        assert B_t.shape[-2] == q, (B_t.shape, q)
++        if B_t.shape[-2] != 0:
++            assert B_t.shape[-2] == q, (B_t.shape, q)
+         assert B_t.shape[-1] == n, (B_t.shape, n)
+         assert B_t.shape[-1] <= B_t.shape[-2], B_t.shape
+         U, S, Vh = paddle.linalg.svd(B_t, full_matrices=False)

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73776/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73776/tests/test.patch
@@ -1,0 +1,33 @@
+diff --git a/test/legacy_test/test_svd_lowrank.py b/test/legacy_test/test_svd_lowrank.py
+index 9ecedfb15e..d731c17487 100644
+--- a/test/legacy_test/test_svd_lowrank.py
++++ b/test/legacy_test/test_svd_lowrank.py
+@@ -235,5 +235,28 @@ class TestStaticSvdLowrankAPI(unittest.TestCase):
+                             )
+ 
+ 
++class TestSvdLowRankAPI_ZeroSize(unittest.TestCase):
++    def generate_input(self):
++        self._input_shape = (1, 4, 0)
++        self._input_data = np.random.random(self._input_shape).astype("float64")
++
++    def generate_output(self):
++        self._output_data = [
++            np.random.random((1, 4, 0)).astype("float64"),
++            np.random.random((1, 0)).astype("float64"),
++            np.random.random((1, 0, 0)).astype("float64"),
++        ]
++
++    def test_dygraph_api(self):
++        self.generate_input()
++        self.generate_output()
++        x = paddle.to_tensor(self._input_data)
++        x.stop_gradient = False
++        out = paddle.linalg.svd_lowrank(x, q=4)
++        np.testing.assert_allclose(out[0].numpy(), self._output_data[0])
++        np.testing.assert_allclose(out[1].numpy(), self._output_data[1])
++        np.testing.assert_allclose(out[2].numpy(), self._output_data[2])
++
++
+ if __name__ == "__main__":
+     unittest.main()

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73776/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73776/tests/test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# P2P tests (pass-to-pass)
+python -m pytest test/legacy_test/test_svd_lowrank.py::TestSvdLowrankAPI -q
+
+# F2P tests (fail-to-pass)
+python -m pytest test/legacy_test/test_svd_lowrank.py::TestSvdLowRankAPI_ZeroSize -q


### PR DESCRIPTION
### 关联

- SWE-Paddle 共建 issue: [[0-size Tensor] Paddle API 0-size 机制建设 #72637](https://github.com/PaddlePaddle/Paddle/issues/72637)
- 来源 PR: [[0-size Tensor No.117] Add 0-size Tensor support for paddle.linalg.svd_lowrank](https://github.com/PaddlePaddle/Paddle/pull/73776)

### 说明

新增 SWE-Paddle 任务 `PaddlePaddle__Paddle-73776`。

该任务覆盖 `paddle.linalg.svd_lowrank` 对 0-size Tensor 的处理。测试包含非 0-size Tensor regression case，以及 `svd_lowrank` 的目标场景，可在 CPU 环境运行。

### 验证结果

| 状态 | P2P | svd_lowrank F2P |
| --- | --- | --- |
| Base + `tests/test.patch` | PASS | FAIL |
| Base + test patch + `solution/code.patch` | PASS | PASS |

#### Base P2P

```
========================================================= 2 passed, 1 warning in 1.49s =========================================================
```

#### Base F2P：svd_lowrank

```
        m, n = x.shape[-2:]
        if q is None:
            q = min(6, m, n)
        elif not (q >= 0 and q <= min(m, n)):
>           raise ValueError(
                f'q(={q}) must be non-negative integer'
                f' and not greater than min(m, n)={min(m, n)}'
            )
E           ValueError: q(=4) must be non-negative integer and not greater than min(m, n)=0

test/legacy_test/test_svd_lowrank.py:255: ValueError
======================================================== 1 failed, 1 warning in 1.33s ========================================================
```

#### Solution P2P

```
========================================================= 2 passed, 1 warning in 1.53s =========================================================
```

#### Solution F2P：svd_lowrank

```
========================================================= 1 passed, 1 warning in 1.19s =========================================================
```