### PR TITLE
[SWE-Paddle] Add task PaddlePaddle__Paddle-73821

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73821/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73821/README.md
@@ -1,0 +1,51 @@
+# PaddlePaddle__Paddle-73821
+
+This directory converts Paddle PR #73821 into a SWE-Paddle community task candidate.
+
+## Source
+
+| Field | Value |
+| --- | --- |
+| Repo | `PaddlePaddle/Paddle` |
+| PR | [73821](https://github.com/PaddlePaddle/Paddle/pull/73821) |
+| PR title | `[0-size Tensor No.205] Add 0-size Tensor support for pad` |
+| Base commit | `4c0a9e966c763e900222ee8457060b845b7e1664` |
+| Gold commit | `2489cc099daafe0d75907e9c1be5a9cd0dbfbdfa` |
+| Merged at | `2025-07-09` |
+| Task type | `bug_fix` |
+| Resource | CPU |
+| Scope | C++ Operator Kernel + Python API |
+
+## Summary
+
+Fix `paddle.nn.functional.pad` and related pad kernels (CPU/GPU/XPU) to correctly handle 0-size tensors by adding early return with `pad_value` fill for forward and zero-fill for backward, and handling 0-size pad tensor input in the Python API.
+
+## Why This Is A Good SWE-Paddle Candidate
+
+- It is derived from a merged Paddle bug-fix PR rather than a synthetic issue.
+- The target behavior spans C++ operator kernels (CPU/GPU/XPU) and the Python API layer.
+- The failure is deterministic: the base revision fails when processing 0-size tensors in pad operations.
+- The task has clear regression coverage for existing non-zero-size behavior.
+- The task runs on CPU and does not require distributed execution, external services, or additional datasets.
+
+## Files
+
+- `proposal.md`: candidate proposal for maintainer triage.
+- `instruction.md`: self-contained problem statement for the coding agent.
+- `solution/code.patch`: gold implementation patch (C++ kernel + Python API changes).
+- `tests/test.patch`: tests exposing the target behavior (F2P: `TestPadOp_ZeroSize2`, `TestPad3dOp_ZeroSize_Circular`, `TestPad3dOp_ZeroSize_Replicate`; P2P: `TestPadOp`).
+- `tests/test.sh`: minimal target test command.
+- `environment/README.md`: environment and reproduction notes.
+
+## Verification
+
+```bash
+bash tests/test.sh
+```
+
+Expected behavior:
+
+| Revision state | Existing behavior (P2P) | pad F2P |
+| --- | ---: | ---: |
+| Base + `tests/test.patch` | PASS | FAIL |
+| Base + `tests/test.patch` + `solution/code.patch` | PASS | PASS |

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73821/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73821/environment/README.md
@@ -1,0 +1,52 @@
+# Environment Notes
+
+## Expected Environment
+
+- Repository: `PaddlePaddle/Paddle`
+- Base commit: `4c0a9e966c763e900222ee8457060b845b7e1664`
+- Gold commit: `2489cc099daafe0d75907e9c1be5a9cd0dbfbdfa`
+- Resource: CPU
+- GPU required: no
+- Patch type: C++ kernel (CPU/GPU/XPU backends) + Python API
+- Python dependencies: PaddlePaddle (source build), NumPy
+
+The verifier should execute against the Paddle source revision represented by the selected patch state. A source build is required since the patch modifies C++ kernel code.
+
+## Build Instructions
+
+1. Check out `PaddlePaddle/Paddle` at the base commit.
+2. Apply `tests/test.patch`.
+3. Build Paddle from source (CPU-only build is sufficient):
+   ```bash
+   mkdir build && cd build
+   cmake .. -DWITH_GPU=OFF -DWITH_TESTING=ON -DCMAKE_BUILD_TYPE=Release
+   make -j$(nproc)
+   ```
+4. Install the built Paddle package.
+
+## Run Order
+
+1. Check out `PaddlePaddle/Paddle` at the base commit.
+2. Build and install Paddle from source.
+3. Apply `tests/test.patch`.
+4. Run the P2P tests; existing non-zero-size behavior should pass.
+5. Run the 0-size tensor tests; the target case should fail before the fix.
+6. Apply `solution/code.patch`.
+7. Rebuild Paddle from source.
+8. Reinstall Paddle package.
+9. Run `bash tests/test.sh`; all target tests should pass.
+
+## Minimal Test Command
+
+```bash
+bash tests/test.sh
+```
+
+## Expected Matrix
+
+| Revision state | P2P | pad F2P |
+| --- | ---: | ---: |
+| Base + test patch | PASS | FAIL |
+| Base + test patch + solution patch | PASS | PASS |
+
+No GPU, distributed runtime, external service, or additional dataset is required.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73821/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73821/instruction.md
@@ -1,0 +1,57 @@
+# 修复 `paddle.nn.functional.pad` 对 0-size Tensor 的处理
+
+## 详细描述
+
+当 `paddle.nn.functional.pad(x, pad, ...)` 的输入 `x` 或 `pad` 参数为 0-size Tensor 时，当前实现无法正确处理这些情况。
+
+典型表现包括：
+
+- 底层 C++ kernel 在处理 0-size tensor 时崩溃或产生错误结果
+- 前向 pad 操作在 0-size 输入时未使用 `pad_value` 填充输出
+- 反向 pad 操作在 0-size 输入时未正确处理梯度
+
+例如：
+
+```python
+import numpy as np
+import paddle
+
+paddle.disable_static()
+
+# pad 0-size tensor 输入
+x = paddle.to_tensor(np.random.random([0, 16]).astype('float32'))
+x.stop_gradient = False
+out = paddle.nn.functional.pad(
+    x,
+    [0, 1, 2, 3],
+    mode='constant',
+    value=0.5,
+    pad_from_left_axis=True,
+)
+# 期望: out shape 为 [0, 22]，值由 pad_value 填充
+out.sum().backward()
+# 期望: x.grad shape 为 [0, 16]，值为 1
+```
+
+上述调用中 `x` 的 shape 为 `[0, 16]`，numel 为 0。按照 pad 的语义：
+- 前向输出应保持正确的输出 shape，所有元素填充为 `pad_value`
+- 反向梯度应正确传回，梯度值为 1
+
+当前实现会导致 0-size 输入无法正确处理、调用报错。
+
+## 验收说明
+
+- 当输入 tensor 的 numel 为 0 时，`paddle.nn.functional.pad` 应正常完成，返回正确 shape 的 Tensor
+- 前向输出的所有元素应填充为 `pad_value`
+- 反向梯度应正确传回
+- 当 `pad` 参数为 0-size Tensor 时，应返回 `x.clone()`
+- 非 0-size tensor 输入下的 pad 行为不得退化
+
+## 技术要求
+
+- 熟悉 C++ 和 Paddle PHI kernel 开发
+- 了解 Tensor shape、0-size Tensor 和 kernel 执行路径
+- 了解 pad 算子的前向和反向语义
+- 了解 Paddle CPU/GPU/XPU kernel 的实现模式
+- 了解 `phi::Full` kernel 的使用
+- 需要从源码编译 Paddle 以验证修改

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73821/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73821/instruction.md
@@ -28,7 +28,7 @@ out = paddle.nn.functional.pad(
     value=0.5,
     pad_from_left_axis=True,
 )
-# 期望: out shape 为 [0, 22]，值由 pad_value 填充
+# 期望: out shape 为 [1, 21]，值由 pad_value 填充
 out.sum().backward()
 # 期望: x.grad shape 为 [0, 16]，值为 1
 ```
@@ -53,5 +53,4 @@ out.sum().backward()
 - 了解 Tensor shape、0-size Tensor 和 kernel 执行路径
 - 了解 pad 算子的前向和反向语义
 - 了解 Paddle CPU/GPU/XPU kernel 的实现模式
-- 了解 `phi::Full` kernel 的使用
 - 需要从源码编译 Paddle 以验证修改

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73821/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73821/proposal.md
@@ -1,0 +1,59 @@
+# SWE-Paddle Task Proposal: PaddlePaddle__Paddle-73821
+
+## 1. 来源信息
+
+- Instance ID: `PaddlePaddle__Paddle-73821`
+- PR 链接: https://github.com/PaddlePaddle/Paddle/pull/73821
+- PR 标题: `[0-size Tensor No.205] Add 0-size Tensor support for pad`
+- Base commit: `4c0a9e966c763e900222ee8457060b845b7e1664`
+- Gold commit: `2489cc099daafe0d75907e9c1be5a9cd0dbfbdfa`
+- Merged at: 2025-07-09
+- 你的身份: contributor
+
+## 2. 问题一句话
+
+`paddle.nn.functional.pad` 及其底层 C++ kernel（CPU/GPU/XPU 的 pad 和 pad3d）对 0-size tensor 输入缺少显式处理，导致前向无法正确填充 `pad_value`、反向梯度计算异常，需要在 kernel 中添加 0-size 早期返回逻辑，并在 Python API 层处理 0-size pad Tensor 输入。
+
+## 3. 为什么适合作为 SWE-Paddle 样本
+
+- **真实性**: 来自 Paddle「0-size Tensor 机制建设」系列任务，是真实研发需求。
+- **代表性**: 覆盖 C++ kernel 层面（CPU/GPU/XPU 三端 pad/pad3d kernel）和 Python API 层的 0-size Tensor 边界处理，涉及前向填充和反向梯度的完整链路。
+- **边界清楚**: 目标仅限 0-size tensor 输入的 pad 操作和 0-size pad Tensor 的 Python API 处理；正向非零尺寸输入不应受影响。
+- **非平凡性**: 修复需要在多个 kernel 文件（pad_kernel_impl.h、pad3d_kernel.cc/cu、pad_grad_kernel_impl.h、pad3d_grad_kernel.cc/cu 以及 XPU 对应文件）中分别添加 0-size 检查，前向使用 `phi::Full` 填充 `pad_value`，反向直接返回，Python 层处理 0-size pad Tensor，涉及对 pad 算子语义和 kernel 执行流程的理解。
+- **回归护栏明确**: 目标 F2P 可覆盖 0-size tensor 输入的 pad 算子测试；同文件中已有的标准 pad 测试用例可作为 P2P 护栏。
+
+## 4. 任务类型和标签
+
+- 任务类型: `bug_fix`
+- 执行后端: `cpu`
+- 设备范围: `cpu_only`
+- 模块标签: `[operator_kernel, pad, pad3d, 0-size_tensor, cpu_kernel, gpu_kernel, xpu_kernel, python_api]`
+
+## 5. 验证思路
+
+- 目标测试命令: `bash tests/test.sh`
+- 目标测试文件:
+  - `test/legacy_test/test_pad_op.py`（`TestPadOp_ZeroSize2`）
+  - `test/legacy_test/test_pad3d_op.py`（`TestPad3dOp_ZeroSize_Circular`、`TestPad3dOp_ZeroSize_Replicate`）
+- P2P 候选: 同文件中已有的 `TestPadOp` 等标准 pad 算子测试用例。
+- 修复前预期: `base_commit` + `tests/test.patch` 后，0-size tensor 输入的 pad 算子测试失败（kernel 崩溃或结果异常）。
+- 修复后预期: 继续应用 `solution/code.patch` 并重新编译后，0-size tensor 输入正常返回正确结果（前向填充 `pad_value`，反向梯度正确），P2P 存量测试仍然通过。
+
+## 6. 环境与资源
+
+- 是否能提供 Docker: 无
+- Dockerfile 或镜像地址: 暂无
+- Paddle 来源: `PaddlePaddle/Paddle` source checkout at `base_commit`，需要源码编译。
+- OS / Python / CUDA / cuDNN / 其他关键依赖: Linux CPU + Python + numpy；编译需要 CMake、GCC；不要求 CUDA/cuDNN（CPU 编译即可验证）。
+- 硬件: CPU 即可（编译和测试均不需要 GPU）。
+- patch 类型: 含 C++ kernel 修改（CPU/GPU/XPU 三端 pad/pad3d kernel）+ Python API 修改，需要重新编译 Paddle。
+- 最小测试命令: `bash tests/test.sh`
+- 是否有 oracle 日志: 无
+
+## 7. 风险自查
+
+- 泄露风险: 正式 `instruction.md` 只描述「pad 对 0-size tensor 输入的行为异常」，不指出具体使用 `phi::Full` 填充或各 kernel 文件的修改细节。
+- 环境风险: 中。任务涉及 C++ kernel 修改，需要源码编译 Paddle，编译时间较长。
+- flaky 风险: 低。测试使用固定的 0-size Tensor 构造，不依赖随机数差异或多设备同步。
+- 拆分风险: 低。该 PR 目标集中在 pad/pad3d 的 CPU/GPU/XPU kernel 0-size 特殊处理和 Python API 层 0-size pad Tensor 处理，测试明确指向新增的 ZeroSize 测试类（`TestPadOp_ZeroSize2`、`TestPad3dOp_ZeroSize_Circular`、`TestPad3dOp_ZeroSize_Replicate`），适合作为一个独立样本。
+- 其他不确定点: 完整任务包阶段应确认新增 F2P 在 `base_commit` 编译后确实失败。该 PR 同时修改了 `test_pad3d_op.py` 中注释掉了部分 `assertRaises` 测试（因为 pad3d 现在支持 0-size）。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73821/solution/code.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73821/solution/code.patch
@@ -1,0 +1,212 @@
+diff --git a/paddle/phi/kernels/cpu/pad3d_grad_kernel.cc b/paddle/phi/kernels/cpu/pad3d_grad_kernel.cc
+index ecfec05dda..c6112fbca9 100644
+--- a/paddle/phi/kernels/cpu/pad3d_grad_kernel.cc
++++ b/paddle/phi/kernels/cpu/pad3d_grad_kernel.cc
+@@ -375,6 +375,7 @@ void Pad3dGradKernel(const Context& dev_ctx,
+   auto d_out_dims = d_out->dims();
+   const T* d_out_data = d_out->data<T>();
+   T* d_in_data = dev_ctx.template Alloc<T>(d_in);
++  if (x.numel() == 0) return;
+   phi::funcs::SetConstant<Context, T>()(dev_ctx, d_in, static_cast<T>(0));
+ 
+   const int pad_left = static_cast<int>(pads[0]);
+diff --git a/paddle/phi/kernels/cpu/pad3d_kernel.cc b/paddle/phi/kernels/cpu/pad3d_kernel.cc
+index f99a5582ec..cb24764048 100644
+--- a/paddle/phi/kernels/cpu/pad3d_kernel.cc
++++ b/paddle/phi/kernels/cpu/pad3d_kernel.cc
+@@ -17,6 +17,7 @@
+ #include "paddle/phi/backends/cpu/cpu_context.h"
+ #include "paddle/phi/common/complex.h"
+ #include "paddle/phi/core/kernel_registry.h"
++#include "paddle/phi/kernels/full_kernel.h"
+ 
+ namespace phi {
+ 
+@@ -406,6 +407,11 @@ void Pad3dKernel(const Context& dev_ctx,
+ 
+   auto out_dims = out->dims();
+   T* out_data = dev_ctx.template Alloc<T>(out);
++  if (x.numel() == 0) {
++    phi::Full<T, Context>(
++        dev_ctx, phi::IntArray(common::vectorize(out->dims())), pad_value, out);
++    return;
++  }
+ 
+   int channels = static_cast<int>(in_dims[1]);
+   int in_depth = static_cast<int>(in_dims[2]);
+diff --git a/paddle/phi/kernels/gpu/pad3d_grad_kernel.cu b/paddle/phi/kernels/gpu/pad3d_grad_kernel.cu
+index c3492c5560..b749454902 100644
+--- a/paddle/phi/kernels/gpu/pad3d_grad_kernel.cu
++++ b/paddle/phi/kernels/gpu/pad3d_grad_kernel.cu
+@@ -347,6 +347,7 @@ void Pad3dGradKernel(const Context& dev_ctx,
+   auto d_out_dims = d_out->dims();
+   const T* d_out_data = d_out->data<T>();
+   T* d_in_data = dev_ctx.template Alloc<T>(d_in);
++  if (x.numel() == 0) return;
+ 
+   phi::funcs::SetConstant<Context, T>()(dev_ctx, d_in, static_cast<T>(0));
+ 
+diff --git a/paddle/phi/kernels/gpu/pad3d_kernel.cu b/paddle/phi/kernels/gpu/pad3d_kernel.cu
+index 30cc5bcb4d..556548ada5 100644
+--- a/paddle/phi/kernels/gpu/pad3d_kernel.cu
++++ b/paddle/phi/kernels/gpu/pad3d_kernel.cu
+@@ -20,7 +20,7 @@
+ #include "paddle/phi/backends/gpu/gpu_primitives.h"
+ #include "paddle/phi/common/complex.h"
+ #include "paddle/phi/core/kernel_registry.h"
+-
++#include "paddle/phi/kernels/full_kernel.h"
+ namespace phi {
+ 
+ using phi::PADDLE_CUDA_NUM_THREADS;
+@@ -359,6 +359,11 @@ void Pad3dKernel(const Context& dev_ctx,
+   }
+   out->Resize(out_dims);
+   T* out_data = dev_ctx.template Alloc<T>(out);
++  if (x.numel() == 0) {
++    phi::Full<T, Context>(
++        dev_ctx, phi::IntArray(common::vectorize(out->dims())), pad_value, out);
++    return;
++  }
+ 
+   int64_t channels = in_dims[1];
+   int64_t in_depth = in_dims[2];
+diff --git a/paddle/phi/kernels/impl/pad_grad_kernel_impl.h b/paddle/phi/kernels/impl/pad_grad_kernel_impl.h
+index 875045f8c8..eb6352aaea 100644
+--- a/paddle/phi/kernels/impl/pad_grad_kernel_impl.h
++++ b/paddle/phi/kernels/impl/pad_grad_kernel_impl.h
+@@ -28,6 +28,7 @@ void PadGradKernel(const Context& dev_ctx,
+     return;
+   }
+   dev_ctx.template Alloc<T>(d_x);
++  if (d_x->numel() == 0) return;
+   int rank = d_out.dims().size();
+   phi::funcs::PaddingGradFunctor<Context, T>(
+       rank, dev_ctx, paddings, d_out, d_x);
+diff --git a/paddle/phi/kernels/impl/pad_kernel_impl.h b/paddle/phi/kernels/impl/pad_kernel_impl.h
+index 7737882c42..217ff8fff7 100644
+--- a/paddle/phi/kernels/impl/pad_kernel_impl.h
++++ b/paddle/phi/kernels/impl/pad_kernel_impl.h
+@@ -18,6 +18,7 @@
+ 
+ #include "paddle/phi/common/scalar.h"
+ #include "paddle/phi/core/dense_tensor.h"
++#include "paddle/phi/kernels/full_kernel.h"
+ #include "paddle/phi/kernels/funcs/padding.h"
+ namespace phi {
+ template <typename T, typename Context>
+@@ -27,6 +28,15 @@ void PadKernel(const Context& dev_ctx,
+                const Scalar& pad_value,
+                DenseTensor* out) {
+   dev_ctx.template Alloc<T>(out);
++  if (x.numel() == 0) {
++    if (out) {
++      phi::Full<T, Context>(dev_ctx,
++                            phi::IntArray(common::vectorize(out->dims())),
++                            pad_value,
++                            out);
++    }
++    return;
++  }
+   int rank = x.dims().size();
+   funcs::PaddingFunctor<Context, T>(
+       rank, dev_ctx, paddings, pad_value.to<T>(), x, out);
+diff --git a/paddle/phi/kernels/xpu/pad3d_grad_kernel.cc b/paddle/phi/kernels/xpu/pad3d_grad_kernel.cc
+index b42a3180dc..c0ec47b722 100644
+--- a/paddle/phi/kernels/xpu/pad3d_grad_kernel.cc
++++ b/paddle/phi/kernels/xpu/pad3d_grad_kernel.cc
+@@ -37,6 +37,7 @@ void Pad3dGradKernel(const Context& dev_ctx,
+   auto d_in_dims = common::vectorize<int64_t>(d_in->dims());
+   const T* d_out_data = d_out->data<T>();
+   T* d_in_data = dev_ctx.template Alloc<T>(d_in);
++  if (x.numel() == 0) return;
+ 
+   bool is_ncdhw = true;
+   if (data_format == "NDHWC") {
+diff --git a/paddle/phi/kernels/xpu/pad3d_kernel.cc b/paddle/phi/kernels/xpu/pad3d_kernel.cc
+index a74d101830..b01bfa974a 100644
+--- a/paddle/phi/kernels/xpu/pad3d_kernel.cc
++++ b/paddle/phi/kernels/xpu/pad3d_kernel.cc
+@@ -17,6 +17,7 @@
+ #include "paddle/phi/backends/xpu/enforce_xpu.h"
+ #include "paddle/phi/backends/xpu/xpu_context.h"
+ #include "paddle/phi/core/kernel_registry.h"
++#include "paddle/phi/kernels/full_kernel.h"
+ 
+ namespace phi {
+ 
+@@ -51,6 +52,11 @@ void Pad3dKernel(const Context& dev_ctx,
+   }
+ 
+   T* out_data = dev_ctx.template Alloc<T>(out);
++  if (x.numel() == 0) {
++    phi::Full<T, Context>(
++        dev_ctx, phi::IntArray(common::vectorize(out->dims())), pad_value, out);
++    return;
++  }
+ 
+   const int64_t num = in_dims[0];  // n
+   int64_t channels = in_dims[1];   // c
+diff --git a/paddle/phi/kernels/xpu/pad_grad_kernel.cc b/paddle/phi/kernels/xpu/pad_grad_kernel.cc
+index fb84a2f094..2d7a0db907 100644
+--- a/paddle/phi/kernels/xpu/pad_grad_kernel.cc
++++ b/paddle/phi/kernels/xpu/pad_grad_kernel.cc
+@@ -29,6 +29,7 @@ void PadGradKernel(const Context& dev_ctx,
+   std::vector<int64_t> pad_left, pad_right;
+   std::vector<int64_t> out_shape = common::vectorize<int64_t>(d_out.dims());
+   dev_ctx.template Alloc<T>(d_x);
++  if (d_x && d_x->numel() == 0) return;
+ 
+   for (size_t i = 0; i < paddings.size() / 2; ++i) {
+     pad_left.push_back(-paddings[i * 2]);
+@@ -58,6 +59,7 @@ void PadGradKernel<phi::dtype::complex<float>, XPUContext>(
+   std::vector<int64_t> pad_left, pad_right;
+   std::vector<int64_t> out_shape = common::vectorize<int64_t>(d_out.dims());
+   dev_ctx.template Alloc<T>(d_x);
++  if (d_x && d_x->numel() == 0) return;
+ 
+   for (size_t i = 0; i < paddings.size() / 2; ++i) {
+     pad_left.push_back(-paddings[i * 2]);
+diff --git a/paddle/phi/kernels/xpu/pad_kernel.cc b/paddle/phi/kernels/xpu/pad_kernel.cc
+index b7353d4d67..eb86c0a05f 100644
+--- a/paddle/phi/kernels/xpu/pad_kernel.cc
++++ b/paddle/phi/kernels/xpu/pad_kernel.cc
+@@ -17,6 +17,7 @@
+ #include "paddle/phi/backends/xpu/enforce_xpu.h"
+ #include "paddle/phi/core/kernel_registry.h"
+ #include "paddle/phi/kernels/complex_kernel.h"
++#include "paddle/phi/kernels/full_kernel.h"
+ 
+ namespace phi {
+ template <typename T, typename Context>
+@@ -27,6 +28,15 @@ void PadKernel(const Context& dev_ctx,
+                DenseTensor* out) {
+   using XPUType = typename XPUTypeTrait<T>::Type;
+   dev_ctx.template Alloc<T>(out);
++  if (x.numel() == 0) {
++    if (out) {
++      phi::Full<T, Context>(dev_ctx,
++                            phi::IntArray(common::vectorize(out->dims())),
++                            pad_value,
++                            out);
++      return;
++    }
++  }
+   std::vector<int64_t> pad_left, pad_right;
+   std::vector<int64_t> xshape = common::vectorize<int64_t>(x.dims());
+ 
+diff --git a/python/paddle/nn/functional/common.py b/python/paddle/nn/functional/common.py
+index 15b1587635..432be87fa4 100644
+--- a/python/paddle/nn/functional/common.py
++++ b/python/paddle/nn/functional/common.py
+@@ -1959,7 +1959,9 @@ def pad(
+     ], f"mode should be one of constant, reflect, replicate, circular, but got {mode}."
+ 
+     x_dim = len(x.shape)
+-
++    if in_dynamic_mode():
++        if isinstance(pad, (Variable, paddle.Tensor)) and pad.size == 0:
++            return x.clone()
+     if (
+         mode == "constant"
+         and isinstance(pad, (list, tuple))

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73821/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73821/tests/test.patch
@@ -1,0 +1,155 @@
+diff --git a/test/legacy_test/test_pad3d_op.py b/test/legacy_test/test_pad3d_op.py
+index c6402fab17..0579f33e61 100644
+--- a/test/legacy_test/test_pad3d_op.py
++++ b/test/legacy_test/test_pad3d_op.py
+@@ -1196,8 +1196,9 @@ class TestPad3dOpError(unittest.TestCase):
+             self.assertRaises(Exception, test_reflect_1)
+             self.assertRaises(Exception, test_reflect_2)
+             self.assertRaises(Exception, test_reflect_3)
+-            self.assertRaises(Exception, test_circular_1)
+-            self.assertRaises(Exception, test_replicate_1)
++            # comment out because pad3d support 0-size now.
++            # self.assertRaises(Exception, test_circular_1)
++            # self.assertRaises(Exception, test_replicate_1)
+         paddle.enable_static()
+ 
+ 
+@@ -1261,5 +1262,57 @@ class TestPadDataformatError(unittest.TestCase):
+         self.assertRaises(AssertionError, test_ncdhw)
+ 
+ 
++class TestPad3dOp_ZeroSize_Circular(unittest.TestCase):
++    """F2P test: pad3d with circular mode on 0-size tensor should work after fix."""
++
++    def test_circular_0size(self):
++        paddle.disable_static()
++        for place in get_places():
++            with paddle.base.dygraph.guard(place):
++                input_shape = (1, 2, 0, 4, 5)
++                data = np.random.rand(*input_shape).astype(np.float32)
++                x = paddle.to_tensor(data)
++                # pad order for NCDHW: [W_left, W_right, H_top, H_bottom, D_front, D_back]
++                y = F.pad(
++                    x,
++                    pad=[1, 1, 1, 1, 2, 3],
++                    mode='circular',
++                    data_format="NCDHW",
++                )
++                # Expected shape:
++                # D (dim 2): 0 + 2 + 3 = 5
++                # H (dim 3): 4 + 1 + 1 = 6
++                # W (dim 4): 5 + 1 + 1 = 7
++                expected_shape = [1, 2, 5, 6, 7]
++                self.assertEqual(list(y.shape), expected_shape)
++        paddle.enable_static()
++
++
++class TestPad3dOp_ZeroSize_Replicate(unittest.TestCase):
++    """F2P test: pad3d with replicate mode on 0-size tensor should work after fix."""
++
++    def test_replicate_0size(self):
++        paddle.disable_static()
++        for place in get_places():
++            with paddle.base.dygraph.guard(place):
++                input_shape = (1, 2, 0, 4, 5)
++                data = np.random.rand(*input_shape).astype(np.float32)
++                x = paddle.to_tensor(data)
++                # pad order for NCDHW: [W_left, W_right, H_top, H_bottom, D_front, D_back]
++                y = F.pad(
++                    x,
++                    pad=[1, 1, 1, 1, 2, 3],
++                    mode='replicate',
++                    data_format="NCDHW",
++                )
++                # Expected shape:
++                # D (dim 2): 0 + 2 + 3 = 5
++                # H (dim 3): 4 + 1 + 1 = 6
++                # W (dim 4): 5 + 1 + 1 = 7
++                expected_shape = [1, 2, 5, 6, 7]
++                self.assertEqual(list(y.shape), expected_shape)
++        paddle.enable_static()
++
++
+ if __name__ == '__main__':
+     unittest.main()
+diff --git a/test/legacy_test/test_pad_op.py b/test/legacy_test/test_pad_op.py
+index 1c000d7ac7..05b9efe14b 100644
+--- a/test/legacy_test/test_pad_op.py
++++ b/test/legacy_test/test_pad_op.py
+@@ -17,7 +17,7 @@ import sys
+ import unittest
+ 
+ import numpy as np
+-from op_test import OpTest, convert_float_to_uint16
++from op_test import OpTest, convert_float_to_uint16, get_places
+ 
+ sys.path.append("../deprecated/legacy_test")
+ from test_attribute_var import UnittestBase
+@@ -561,6 +561,53 @@ class TestPadOrder3(TestPadOrder):
+         self.pad_value = 0.5
+ 
+ 
++class TestPadOp_ZeroSize(unittest.TestCase):
++    def init_case(self):
++        self.shape = [0, 16]
++        self.paddings = [(0, 1), (2, 3)]
++        self.paddings_empty_tensor = False
++        self.pad_value = 0.5
++
++    def test_dygraph(self):
++        self.init_case()
++        for place in get_places():
++            paddle.disable_static(place)
++            x_np = np.random.random(self.shape).astype('float32')
++            paddings_np = self.paddings.copy()
++            x = paddle.to_tensor(x_np)
++            x.stop_gradient = False
++            paddings = list(np.array(self.paddings).flatten())
++            if self.paddings_empty_tensor:
++                paddings = paddle.to_tensor(paddings)
++                # output the same as x
++                out_np = x_np
++            else:
++                out_np = np.pad(
++                    x_np,
++                    paddings_np,
++                    mode="constant",
++                    constant_values=self.pad_value,
++                )
++            out = paddle.nn.functional.pad(
++                x,
++                paddings,
++                mode='constant',
++                value=self.pad_value,
++                pad_from_left_axis=True,
++            )
++            np.testing.assert_array_equal(out, out_np)
++            out.sum().backward()
++            np.testing.assert_allclose(x.grad.numpy(), np.ones(self.shape))
++
++
++class TestPadOp_ZeroSize2(TestPadOp_ZeroSize):
++    def init_case(self):
++        self.shape = [4, 6, 6]
++        self.paddings = []
++        self.paddings_empty_tensor = True
++        self.pad_value = 0.5
++
++
+ if __name__ == "__main__":
+     # paddle.enable_static()
+     unittest.main()
+diff --git a/test/xpu/test_pad3d_op_xpu.py b/test/xpu/test_pad3d_op_xpu.py
+index 4e98f554e1..59dd708f06 100644
+--- a/test/xpu/test_pad3d_op_xpu.py
++++ b/test/xpu/test_pad3d_op_xpu.py
+@@ -836,7 +836,8 @@ class XPUTestPad3dOp(XPUOpTestWrapper):
+                 self.assertRaises(Exception, test_reflect_1)
+                 self.assertRaises(Exception, test_reflect_2)
+                 self.assertRaises(Exception, test_reflect_3)
+-                self.assertRaises(Exception, test_replicate_1)
++                # comment out because pad3d support 0-size now.
++                # self.assertRaises(Exception, test_replicate_1)
+             paddle.enable_static()
+ 
+     class TestPadDataformatError(unittest.TestCase):

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73821/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73821/tests/test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+# P2P tests (pass-to-pass)
+python -m pytest test/legacy_test/test_pad_op.py::TestPadOp -q
+
+# F2P tests (fail-to-pass)
+python -m pytest test/legacy_test/test_pad_op.py::TestPadOp_ZeroSize2 -q
+python -m pytest test/legacy_test/test_pad3d_op.py::TestPad3dOp_ZeroSize_Circular -q
+python -m pytest test/legacy_test/test_pad3d_op.py::TestPad3dOp_ZeroSize_Replicate -q


### PR DESCRIPTION
### 关联

* SWE-Paddle 共建 issue: [[Call for Bench] SWE-Paddle 社区共建 Paddle#79447](https://github.com/PaddlePaddle/Paddle/issues/79447)
* 来源 PR: [[0-size Tensor No.205] Add 0-size Tensor support for pad](https://github.com/PaddlePaddle/Paddle/pull/73821)

### 说明

新增 SWE-Paddle 任务 `PaddlePaddle__Paddle-73821`。

该任务覆盖 `paddle.nn.functional.pad` 及其底层 C++ kernel（CPU/GPU/XPU）对 0-size Tensor 的处理。测试包含已有 pad regression case，以及 0-size tensor 的目标场景，可在 CPU 环境运行。

### 验证结果

| 状态 | P2P | pad F2P |
| --- | ---: | ---: |
| Base + `tests/test.patch` | PASS | FAIL |
| Base + test patch + `solution/code.patch` | PASS | PASS |


#### Base P2P
```
2 passed, 2 warnings in 1.53s
```
#### Base F2P
```
FAILED test/legacy_test/test_pad_op.py::TestPadOp_ZeroSize2::test_dygraph - ValueError: (InvalidArgument) The data_type of input tensor in list isn't consistent, the first tensor is i...
1 failed, 1 warning in 1.45s
FAILED test/legacy_test/test_pad3d_op.py::TestPad3dOp_ZeroSize_Circular::test_circular_0size - ValueError: (InvalidArgument) The input tensor size can not be 0 for circular or replicate padding mode.
1 failed, 1 warning in 1.43s
FAILED test/legacy_test/test_pad3d_op.py::TestPad3dOp_ZeroSize_Replicate::test_replicate_0size - ValueError: (InvalidArgument) The input tensor size can not be 0 for circular or replicate padding mode.
1 failed, 1 warning in 1.39s
```
#### Solution P2P
```
2 passed, 2 warnings in 1.55s
```
#### Solution F2P
```
1 passed, 1 warning in 1.21s
1 passed, 1 warning in 1.23s
1 passed, 1 warning in 1.23s
```
