### PR TITLE
[SWE-Paddle] Add task PaddlePaddle__Paddle-73854

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73854/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73854/README.md
@@ -1,0 +1,51 @@
+# PaddlePaddle__Paddle-73854
+
+This directory converts Paddle PR #73854 into a SWE-Paddle community task candidate.
+
+## Source
+
+| Field | Value |
+| --- | --- |
+| Repo | `PaddlePaddle/Paddle` |
+| PR | [73854](https://github.com/PaddlePaddle/Paddle/pull/73854) |
+| PR title | `[0-size Tensor Job2 No.60] Add 0-size Tensor support for paddle.nn.functional.instance_norm` |
+| Base commit | `6ad407d1aaf34c41e193361d22f10c39946b715f` |
+| Gold commit | `81a61590467551723341382599b950b4e92a6e1e` |
+| Merged at | `2025-07-22` |
+| Task type | `bug_fix` |
+| Resource | CPU |
+| Scope | C++ phi kernel + Python test |
+
+## Summary
+
+Fix `paddle.nn.functional.instance_norm` to correctly handle 0-size tensors in both forward and backward passes. The forward kernel adds an early return when `x.numel() == 0`, and the backward kernel fills gradients with 0. InferMeta is modified to remove the 0-size check and correctly handle dimension inference when C=0.
+
+## Why This Is A Good SWE-Paddle Candidate
+
+- It is derived from a merged Paddle bug-fix PR rather than a synthetic issue.
+- The target behavior is isolated to the instance_norm phi kernels (CPU/GPU/XPU) and InferMeta functions.
+- The failure is deterministic: the base revision fails when processing 0-size tensors in instance_norm.
+- The task has clear regression coverage for existing non-zero-size behavior.
+- The task runs on CPU and does not require distributed execution, external services, or additional datasets.
+
+## Files
+
+- `proposal.md`: candidate proposal for maintainer triage.
+- `instruction.md`: self-contained problem statement for the coding agent.
+- `solution/code.patch`: gold implementation patch.
+- `tests/test.patch`: tests exposing the target behavior.
+- `tests/test.sh`: minimal target test command.
+- `environment/README.md`: environment and reproduction notes.
+
+## Verification
+
+```bash
+bash tests/test.sh
+```
+
+Expected behavior:
+
+| Revision state | Existing behavior (P2P) | instance_norm F2P |
+| --- | ---: | ---: |
+| Base + `tests/test.patch` | PASS | FAIL |
+| Base + `tests/test.patch` + `solution/code.patch` | PASS | PASS |

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73854/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73854/environment/README.md
@@ -1,0 +1,56 @@
+# Environment Notes
+
+## Expected Environment
+
+- Repository: `PaddlePaddle/Paddle`
+- Base commit: `6ad407d1aaf34c41e193361d22f10c39946b715f`
+- Gold commit: `81a61590467551723341382599b950b4e92a6e1e`
+- Resource: CPU
+- GPU required: no
+- Patch type: C++ kernel (phi kernels) + Python test
+- Python dependencies: PaddlePaddle (source build), NumPy, pytest
+
+The verifier should execute against the Paddle source revision represented by the selected patch state. Since the patch modifies C++ kernel files, a source rebuild is required after applying the solution patch.
+
+## Build Instructions
+
+1. Check out `PaddlePaddle/Paddle` at the base commit.
+2. Build Paddle from source (CPU-only build is sufficient):
+```bash
+mkdir build && cd build
+cmake .. -DWITH_GPU=OFF -DWITH_TESTING=ON -DCMAKE_BUILD_TYPE=Release
+make -j$(nproc)
+```
+3. Install the built Paddle package.
+
+## Run Order
+
+1. Check out `PaddlePaddle/Paddle` at the base commit.
+2. Build and install Paddle from source.
+3. Apply `tests/test.patch`.
+4. Run the P2P tests; existing non-zero-size behavior should pass.
+5. Run the 0-size tensor tests; the target cases should fail before the fix.
+6. Apply `solution/code.patch`.
+7. Rebuild Paddle from source so the modified C++ kernels take effect:
+```bash
+cd build
+make -j$(nproc)
+pip install --force-reinstall python/dist/paddlepaddle-*.whl
+cd ..
+```
+8. Run `bash tests/test.sh`; all target tests should pass.
+
+## Minimal Test Command
+
+```bash
+bash tests/test.sh
+```
+
+## Expected Matrix
+
+| Revision state | P2P | instance_norm F2P |
+| --- | ---: | ---: |
+| Base + test patch | PASS | FAIL |
+| Base + test patch + solution patch | PASS | PASS |
+
+No GPU, distributed runtime, external service, or additional dataset is required.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73854/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73854/instruction.md
@@ -1,0 +1,46 @@
+# 修复 `paddle.nn.functional.instance_norm` 对 0-size Tensor 的处理
+
+## 详细描述
+
+当 `paddle.nn.functional.instance_norm(x, ...)` 的输入 `x` 为 0-size 输入时无法正确处理、调用报错。
+
+典型表现包括：
+
+- `InstanceNormInferMeta` 中的 `PADDLE_ENFORCE_NE(common::product(x_dims), 0, ...)` 检查会抛出异常
+- 底层 kernel 在处理 0-size tensor 时出现计算错误或崩溃
+- 反向传播时 scale_grad 和 bias_grad 的维度推断错误
+
+例如：
+
+```python
+import numpy as np
+import paddle
+
+paddle.disable_static()
+x = paddle.to_tensor(np.random.random([2, 0, 4, 5]).astype('float32'))
+scale = paddle.to_tensor(np.random.random([100]).astype('float32'))
+bias = paddle.to_tensor(np.random.random([100]).astype('float32'))
+out = paddle.nn.functional.instance_norm(x, scale, bias)
+# 期望: out shape 为 [2, 0, 4, 5]，正常返回空 tensor
+```
+
+上述调用中 `x` 的 shape 为 `[2, 0, 4, 5]`，通道数 C=0，不包含任何元素。按照 API semantics，当输入 tensor 的 numel 为 0 时，不存在需要归一化的数据，因此该调用应正常完成并返回正确 shape 的空 tensor。
+
+当前实现会导致 0-size 输入无法正确处理、调用报错。
+
+此外，反向传播也需要正确处理 0-size tensor 的情况。当 `x` 为 0-size 时，`d_scale` 和 `d_bias` 应被填充为 0。
+
+## 验收说明
+
+- 当输入 tensor 的 numel 为 0 时，`paddle.nn.functional.instance_norm` 前向应正常完成，返回正确 shape 的空 tensor
+- 返回的 out tensor 应保持与输入相同的 dtype
+- 反向传播时，当 `x.numel() == 0`，`d_scale` 和 `d_bias` 应被正确填充为 0
+- 非 0-size tensor 输入下的 instance_norm 行为不得退化
+
+## 技术要求
+
+- 熟悉 C++ 和 Paddle phi kernel 开发
+- 了解 Tensor shape、0-size Tensor 和 kernel 执行路径
+- 了解 instance_norm 算子的前向和反向语义
+- 了解 Paddle phi kernel 的 CPU/GPU/XPU 实现结构
+- 了解 InferMeta 函数的维度推断机制

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73854/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73854/proposal.md
@@ -1,0 +1,58 @@
+# SWE-Paddle Task Proposal: PaddlePaddle__Paddle-73854
+
+## 1. 来源信息
+
+- Instance ID: `PaddlePaddle__Paddle-73854`
+- PR 链接: https://github.com/PaddlePaddle/Paddle/pull/73854
+- PR 标题: `[0-size Tensor Job2 No.60] Add 0-size Tensor support for paddle.nn.functional.instance_norm`
+- Base commit: `6ad407d1aaf34c41e193361d22f10c39946b715f`
+- Gold commit: `81a61590467551723341382599b950b4e92a6e1e`
+- Merged at: 2025-07-22
+- 你的身份: contributor
+
+## 2. 问题一句话
+
+`paddle.nn.functional.instance_norm` 在动态图模式下对 0-size tensor（任意维度含有 0）的输入缺少显式处理，前向进入底层算子时出错，反向未正确填充梯度为 0，需要补齐 0-size tensor 支持。
+
+## 3. 为什么适合作为 SWE-Paddle 样本
+
+- **真实性**：该问题来自 Paddle 的「0-size Tensor 机制建设」系列任务，是真实研发需求，目标是为 `instance_norm` 算子补齐 0-size tensor 支持。
+- **代表性**：覆盖 C++ phi kernel 层面的算子边界处理，涉及 forward kernel 的早期返回、backward kernel 的梯度填充和 InferMeta 的维度推断，是 Paddle 算子机制增强的典型样本。
+- **边界清楚**：目标仅限 0-size tensor 输入的 forward/backward 早期返回逻辑；正向非零尺寸输入不应受影响。
+- **非平凡性**：修复需要在 CPU kernel、GPU kernel、XPU kernel 和 InferMeta 多处分别添加 0-size 判断逻辑，涉及 `numel() == 0` 检查、输出分配、梯度填充（使用 `phi::Full` 或 `SetConstant`）和维度推断，不是简单机械修改。
+- **回归护栏明确**：目标 F2P 可覆盖 0-size tensor 输入的 `instance_norm` 前向和反向调用；同文件已有的 `TestInstanceNormOp` 等标准算子测试用例可作为 P2P 护栏。
+
+## 4. 任务类型和标签
+
+- 任务类型：`bug_fix`
+- 执行后端：`cpu`
+- 设备范围：`cpu_only`
+- 模块标签：`[phi_kernel, instance_norm, 0-size_tensor, forward, backward, cpu, gpu, xpu]`
+
+## 5. 验证思路
+
+- 目标测试命令：`bash tests/test.sh`
+- 目标测试文件：
+  - `test/legacy_test/test_instance_norm_op_v2.py`（`TestInstanceNormOp_ZeroSize`）
+- P2P 候选：同文件中已有的 `TestInstanceNormOp` 等标准 instance_norm 算子测试用例。
+- 修复前预期：`base_commit` + `tests/test.patch` 后，0-size tensor 输入在 `instance_norm` 的前向/反向调用中失败（进入底层算子时出错）。
+- 修复后预期：继续应用 `solution/code.patch` 后，0-size tensor 输入返回正确的空 tensor（shape 与预期一致），反向梯度填充为 0，P2P 存量测试仍然通过。
+
+## 6. 环境与资源
+
+- 是否能提供 Docker: 无
+- Dockerfile 或镜像地址: 暂无
+- Paddle 来源: `PaddlePaddle/Paddle` source checkout at `base_commit`，需要源码编译。
+- OS / Python / CUDA / cuDNN / 其他关键依赖: Linux CPU + Python + numpy；编译需要 CMake、GCC；不要求 CUDA/cuDNN（CPU 编译即可验证）。
+- 硬件: CPU 即可（编译和测试均不需要 GPU）。
+- patch 类型: C++ kernel 修改（`paddle/phi/kernels/cpu/instance_norm_kernel.cc`、`paddle/phi/kernels/gpu/instance_norm_kernel.cu`、`paddle/phi/kernels/xpu/instance_norm_kernel.cc` 等），需要重新编译。
+- 最小测试命令: `bash tests/test.sh`
+- 是否有 oracle 日志: 无
+
+## 7. 风险自查
+
+- 泄露风险：正式 `instruction.md` 只描述「instance_norm 对 0-size tensor 输入的行为异常」，不指出具体 `numel() == 0` 分支逻辑或具体代码位置。
+- 环境风险：中。任务需要 Paddle 源码环境，patch 涉及 C++ 文件，需要重新编译。
+- flaky 风险：低。测试使用固定的 0-size tensor 构造，不依赖随机数差异或多设备同步。
+- 拆分风险：低。该 PR 目标集中在 instance_norm 的 forward/backward kernel 的 0-size 处理，测试明确指向零尺寸分支，适合作为一个独立样本。
+- 其他不确定点：完整任务包阶段应确认新增 F2P（`TestInstanceNormOp_ZeroSize`）在 `base_commit` 上确实失败，并选择同文件中已有的 `TestInstanceNormOp` 等标准测试用例作为在 base 与修复后都稳定通过的 P2P nodeid。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73854/solution/code.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73854/solution/code.patch
@@ -1,0 +1,467 @@
+diff --git a/paddle/fluid/prim/api/composite_backward/composite_backward_api.h b/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
+index 04b59680a7..d4d9528c98 100644
+--- a/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
++++ b/paddle/fluid/prim/api/composite_backward/composite_backward_api.h
+@@ -1768,6 +1768,7 @@ void batch_norm_grad(const Tensor& x,
+ template <typename T>
+ void instance_norm_grad(const Tensor& x,
+                         const paddle::optional<Tensor>& scale,
++                        const paddle::optional<Tensor>& bias UNUSED,
+                         const Tensor& saved_mean,
+                         const Tensor& saved_variance,
+                         const Tensor& y_grad,
+diff --git a/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h b/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
+index b807d162c7..8933af0271 100644
+--- a/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
++++ b/paddle/fluid/primitive/decomp_rule/decomp_vjp/details.h
+@@ -1728,6 +1728,7 @@ void gather_nd_grad(const Tensor& x,
+ template <typename T>
+ void instance_norm_grad(const Tensor& x,
+                         const paddle::optional<Tensor>& scale,
++                        const paddle::optional<Tensor>& bias,
+                         const Tensor& saved_mean,
+                         const Tensor& saved_variance,
+                         const Tensor& y_grad,
+diff --git a/paddle/phi/infermeta/backward.cc b/paddle/phi/infermeta/backward.cc
+index 5cb7ba4b63..41cb89cd69 100644
+--- a/paddle/phi/infermeta/backward.cc
++++ b/paddle/phi/infermeta/backward.cc
+@@ -921,6 +921,7 @@ void GumbelSoftmaxGradInferMeta(const MetaTensor& out,
+ 
+ void InstanceNormGradInferMeta(const MetaTensor& x,
+                                const MetaTensor& scale,
++                               const MetaTensor& bias,
+                                const MetaTensor& saved_mean,
+                                const MetaTensor& saved_variance,
+                                const MetaTensor& y_grad,
+@@ -939,10 +940,18 @@ void InstanceNormGradInferMeta(const MetaTensor& x,
+   x_grad->set_dtype(x.dtype());
+   x_grad->set_layout(x.layout());
+   if (scale_grad) {
+-    scale_grad->set_dims({C});
++    if (C == 0) {
++      scale_grad->set_dims({scale.dims()[0]});
++    } else {
++      scale_grad->set_dims({C});
++    }
+   }
+   if (bias_grad) {
+-    bias_grad->set_dims({C});
++    if (C == 0) {
++      bias_grad->set_dims({bias.dims()[0]});
++    } else {
++      bias_grad->set_dims({C});
++    }
+   }
+ }
+ void InstanceNormDoubleGradInferMeta(const MetaTensor& x,
+diff --git a/paddle/phi/infermeta/backward.h b/paddle/phi/infermeta/backward.h
+index f72169dc2c..826643e6de 100644
+--- a/paddle/phi/infermeta/backward.h
++++ b/paddle/phi/infermeta/backward.h
+@@ -345,6 +345,7 @@ void GumbelSoftmaxGradInferMeta(const MetaTensor& out,
+ 
+ void InstanceNormGradInferMeta(const MetaTensor& x,
+                                const MetaTensor& scale,
++                               const MetaTensor& bias,
+                                const MetaTensor& saved_mean,
+                                const MetaTensor& saved_variance,
+                                const MetaTensor& y_grad,
+diff --git a/paddle/phi/infermeta/spmd_rules/instance_norm.cc b/paddle/phi/infermeta/spmd_rules/instance_norm.cc
+index 472d8ea1bb..aeede37d4e 100644
+--- a/paddle/phi/infermeta/spmd_rules/instance_norm.cc
++++ b/paddle/phi/infermeta/spmd_rules/instance_norm.cc
+@@ -131,6 +131,7 @@ SpmdInfo InstanceNormInferSpmd(const DistMetaTensor& x,
+ 
+ SpmdInfo InstanceNormGradInferSpmd(const DistMetaTensor& x,
+                                    const DistMetaTensor& scale,
++                                   const DistMetaTensor& bias UNUSED,
+                                    const DistMetaTensor& saved_mean,
+                                    const DistMetaTensor& saved_variance,
+                                    const DistMetaTensor& y_grad,
+diff --git a/paddle/phi/infermeta/spmd_rules/instance_norm.h b/paddle/phi/infermeta/spmd_rules/instance_norm.h
+index da204af836..af602cbb9c 100644
+--- a/paddle/phi/infermeta/spmd_rules/instance_norm.h
++++ b/paddle/phi/infermeta/spmd_rules/instance_norm.h
+@@ -27,6 +27,7 @@ SpmdInfo InstanceNormInferSpmd(const DistMetaTensor& x,
+ 
+ SpmdInfo InstanceNormGradInferSpmd(const DistMetaTensor& x,
+                                    const DistMetaTensor& scale,
++                                   const DistMetaTensor& bias,
+                                    const DistMetaTensor& saved_mean,
+                                    const DistMetaTensor& saved_variance,
+                                    const DistMetaTensor& y_grad,
+diff --git a/paddle/phi/infermeta/ternary.cc b/paddle/phi/infermeta/ternary.cc
+index 1ab4c3f7e5..2581cfe813 100644
+--- a/paddle/phi/infermeta/ternary.cc
++++ b/paddle/phi/infermeta/ternary.cc
+@@ -826,13 +826,6 @@ void InstanceNormInferMeta(const MetaTensor& x,
+                     common::errors::InvalidArgument(
+                         "The y in InstanceNormInferMeta can't be nullptr."));
+   const auto x_dims = x.dims();
+-  PADDLE_ENFORCE_NE(common::product(x_dims),
+-                    0,
+-                    common::errors::PreconditionNotMet(
+-                        "The Input variable X has not "
+-                        "been initialized. You may need to confirm "
+-                        "if you put exe.run(startup_program) "
+-                        "after optimizer.minimize function."));
+   PADDLE_ENFORCE_GE(
+       x_dims.size(),
+       2,
+@@ -867,13 +860,16 @@ void InstanceNormInferMeta(const MetaTensor& x,
+             scale_dim.size()));
+     bool check = config.is_runtime || contain_unknown_dim(scale_dim);
+     if (check) {
+-      PADDLE_ENFORCE_EQ(scale_dim[0],
+-                        C,
+-                        common::errors::InvalidArgument(
+-                            "ShapeError: the shape of scale must equal to [%d]"
+-                            "But received: the shape of scale is [%d]",
+-                            C,
+-                            scale_dim[0]));
++      if (C != 0) {
++        PADDLE_ENFORCE_EQ(
++            scale_dim[0],
++            C,
++            common::errors::InvalidArgument(
++                "ShapeError: the shape of scale must equal to [%d]"
++                "But received: the shape of scale is [%d]",
++                C,
++                scale_dim[0]));
++      }
+     }
+   }
+   if (bias) {
+@@ -889,13 +885,15 @@ void InstanceNormInferMeta(const MetaTensor& x,
+             bias_dim.size()));
+     bool check = config.is_runtime || !contain_unknown_dim(bias_dim);
+     if (check) {
+-      PADDLE_ENFORCE_EQ(bias_dim[0],
+-                        C,
+-                        common::errors::InvalidArgument(
+-                            "ShapeError: the shape of bias must equal to [%d]"
+-                            "But received: the shape of bias is [%d]",
+-                            C,
+-                            bias_dim[0]));
++      if (C != 0) {
++        PADDLE_ENFORCE_EQ(bias_dim[0],
++                          C,
++                          common::errors::InvalidArgument(
++                              "ShapeError: the shape of bias must equal to [%d]"
++                              "But received: the shape of bias is [%d]",
++                              C,
++                              bias_dim[0]));
++      }
+     }
+   }
+   y->set_dims(x_dims);
+diff --git a/paddle/phi/kernels/cpu/instance_norm_grad_kernel.cc b/paddle/phi/kernels/cpu/instance_norm_grad_kernel.cc
+index b53482c9d8..fea2a26dfa 100644
+--- a/paddle/phi/kernels/cpu/instance_norm_grad_kernel.cc
++++ b/paddle/phi/kernels/cpu/instance_norm_grad_kernel.cc
+@@ -44,6 +44,7 @@ template <typename T, typename Context>
+ void InstanceNormGradKernel(const Context& dev_ctx,
+                             const DenseTensor& x,
+                             const paddle::optional<DenseTensor>& scale,
++                            const paddle::optional<DenseTensor>& bias UNUSED,
+                             const DenseTensor& saved_mean,
+                             const DenseTensor& saved_variance,
+                             const DenseTensor& d_y,
+@@ -51,6 +52,19 @@ void InstanceNormGradKernel(const Context& dev_ctx,
+                             DenseTensor* d_x,
+                             DenseTensor* d_scale,
+                             DenseTensor* d_bias) {
++  phi::funcs::SetConstant<CPUContext, T> set_constant;
++  dev_ctx.template Alloc<T>(d_x);
++  if (x.numel() == 0) {
++    if (d_scale) {
++      dev_ctx.template Alloc<T>(d_scale);
++      set_constant(dev_ctx, d_scale, static_cast<T>(0));
++    }
++    if (d_bias) {
++      dev_ctx.template Alloc<T>(d_bias);
++      set_constant(dev_ctx, d_bias, static_cast<T>(0));
++    }
++    return;
++  }
+   const auto* scale_ptr = scale.get_ptr();
+ 
+   const auto& x_dims = x.dims();
+@@ -60,7 +74,6 @@ void InstanceNormGradKernel(const Context& dev_ctx,
+   const int NxC = N * C;
+   const int sample_size = static_cast<int>(x.numel() / N / C);
+ 
+-  dev_ctx.template Alloc<T>(d_x);
+   auto* place = dev_ctx.eigen_device();
+ 
+   Eigen::DSizes<int, 2> rshape(NxC, sample_size);
+@@ -83,8 +96,6 @@ void InstanceNormGradKernel(const Context& dev_ctx,
+   NxC_shape.set(0, NxC);
+ #endif
+ 
+-  phi::funcs::SetConstant<CPUContext, T> set_constant;
+-
+   DenseTensor scale_data;
+   if (!scale_ptr) {
+     scale_data.Resize({C});
+diff --git a/paddle/phi/kernels/cpu/instance_norm_kernel.cc b/paddle/phi/kernels/cpu/instance_norm_kernel.cc
+index 56af2dc5f2..21a740d41f 100644
+--- a/paddle/phi/kernels/cpu/instance_norm_kernel.cc
++++ b/paddle/phi/kernels/cpu/instance_norm_kernel.cc
+@@ -38,6 +38,22 @@ void InstanceNormKernel(const Context& dev_ctx,
+                         DenseTensor* y,
+                         DenseTensor* saved_mean,
+                         DenseTensor* saved_variance) {
++  phi::funcs::SetConstant<CPUContext, T> set_constant;
++  if (x.numel() == 0) {
++    dev_ctx.template Alloc<T>(y);
++    set_constant(dev_ctx, y, static_cast<T>(0));
++
++    if (saved_mean) {
++      dev_ctx.template Alloc<T>(saved_mean);
++      set_constant(dev_ctx, saved_mean, static_cast<T>(0));
++    }
++    if (saved_variance) {
++      dev_ctx.template Alloc<T>(saved_variance);
++      set_constant(dev_ctx, saved_variance, static_cast<T>(0));
++    }
++    return;
++  }
++
+   const auto& x_dims = x.dims();
+   T epsilon = static_cast<T>(epsilon_f);
+   const int N = static_cast<int>(x_dims[0]);
+@@ -63,7 +79,6 @@ void InstanceNormKernel(const Context& dev_ctx,
+   Eigen::IndexList<Eigen::type2index<1>> rdims;
+ #endif
+ 
+-  phi::funcs::SetConstant<CPUContext, T> set_constant;
+   DenseTensor saved_mean_tmp, saved_variance_tmp;
+   if (saved_mean) {
+     dev_ctx.template Alloc<T>(saved_mean);
+diff --git a/paddle/phi/kernels/gpu/instance_norm_grad_kernel.cu b/paddle/phi/kernels/gpu/instance_norm_grad_kernel.cu
+index 17e985385d..0b9b73efc4 100644
+--- a/paddle/phi/kernels/gpu/instance_norm_grad_kernel.cu
++++ b/paddle/phi/kernels/gpu/instance_norm_grad_kernel.cu
+@@ -305,6 +305,7 @@ template <typename T, typename Context>
+ void InstanceNormGradKernel(const Context &dev_ctx,
+                             const DenseTensor &x,
+                             const paddle::optional<DenseTensor> &scale,
++                            const paddle::optional<DenseTensor> &bias UNUSED,
+                             const DenseTensor &saved_mean,
+                             const DenseTensor &saved_variance,
+                             const DenseTensor &d_y,
+@@ -326,11 +327,25 @@ void InstanceNormGradKernel(const Context &dev_ctx,
+   x_tmp.ShareDataWith(x).Resize({1, NxC, H, W, D});
+   d_y_tmp.ShareDataWith(d_y).Resize({1, NxC, H, W, D});
+ 
++  phi::funcs::SetConstant<GPUContext, AccT> set_constant;
++
+   dev_ctx.template Alloc<T>(d_x);
++  if (x.numel() == 0) {
++    if (d_scale) {
++      dev_ctx.template Alloc<AccT>(d_scale);
++      set_constant(dev_ctx, d_scale, static_cast<AccT>(0));
++    }
++    if (d_bias) {
++      dev_ctx.template Alloc<AccT>(d_bias);
++      set_constant(dev_ctx, d_bias, static_cast<AccT>(0));
++    }
++    return;
++  }
+   if (d_scale && d_bias) {
+     dev_ctx.template Alloc<AccT>(d_scale);
+     dev_ctx.template Alloc<AccT>(d_bias);
+   }
++
+   if (scale_ptr) {
+     PADDLE_ENFORCE_EQ(
+         scale_ptr->dims().size(),
+@@ -354,8 +369,6 @@ void InstanceNormGradKernel(const Context &dev_ctx,
+                           scale_ptr->dims()));
+   }
+ 
+-  phi::funcs::SetConstant<GPUContext, AccT> set_constant;
+-
+   const int n = x.numel();
+   const int block = 512;
+   int max_threads = dev_ctx.GetMaxPhysicalThreadCount();
+diff --git a/paddle/phi/kernels/gpu/instance_norm_kernel.cu b/paddle/phi/kernels/gpu/instance_norm_kernel.cu
+index 672a351a1c..87cb873c29 100644
+--- a/paddle/phi/kernels/gpu/instance_norm_kernel.cu
++++ b/paddle/phi/kernels/gpu/instance_norm_kernel.cu
+@@ -60,6 +60,20 @@ void InstanceNormKernel(const Context &dev_ctx,
+   DenseTensor x_tmp;
+   x_tmp.ShareDataWith(x).Resize({1, NxC, H, W, D});
+   dev_ctx.template Alloc<T>(y);
++  phi::funcs::SetConstant<GPUContext, BatchNormParamType<T>> functor;
++  phi::funcs::SetConstant<GPUContext, T> functor_y;
++  if (x.numel() == 0) {
++    functor_y(dev_ctx, y, static_cast<T>(0));
++    if (saved_mean) {
++      dev_ctx.template Alloc<BatchNormParamType<T>>(saved_mean);
++      functor(dev_ctx, saved_mean, static_cast<BatchNormParamType<T>>(0));
++    }
++    if (saved_variance) {
++      dev_ctx.template Alloc<BatchNormParamType<T>>(saved_variance);
++      functor(dev_ctx, saved_variance, static_cast<BatchNormParamType<T>>(0));
++    }
++    return;
++  }
+ 
+ #ifdef PADDLE_WITH_HIP
+   miopenTensorDescriptor_t data_desc_;
+@@ -144,7 +158,6 @@ void InstanceNormKernel(const Context &dev_ctx,
+   auto handle = dev_ctx.cudnn_handle();
+ 
+   DenseTensor saved_mean_tmp, saved_variance_tmp;
+-  phi::funcs::SetConstant<GPUContext, BatchNormParamType<T>> functor;
+ 
+   if (saved_mean) {
+     dev_ctx.template Alloc<BatchNormParamType<T>>(saved_mean);
+diff --git a/paddle/phi/kernels/instance_norm_grad_kernel.h b/paddle/phi/kernels/instance_norm_grad_kernel.h
+index 2a661a3fd3..67171f99fb 100644
+--- a/paddle/phi/kernels/instance_norm_grad_kernel.h
++++ b/paddle/phi/kernels/instance_norm_grad_kernel.h
+@@ -22,6 +22,7 @@ template <typename T, typename Context>
+ void InstanceNormGradKernel(const Context& dev_ctx,
+                             const DenseTensor& x,
+                             const paddle::optional<DenseTensor>& scale,
++                            const paddle::optional<DenseTensor>& bias UNUSED,
+                             const DenseTensor& saved_mean,
+                             const DenseTensor& saved_variance,
+                             const DenseTensor& y_grad,
+diff --git a/paddle/phi/kernels/xpu/instance_norm_grad_kernel.cc b/paddle/phi/kernels/xpu/instance_norm_grad_kernel.cc
+index f8954fd60d..e54f3d206f 100644
+--- a/paddle/phi/kernels/xpu/instance_norm_grad_kernel.cc
++++ b/paddle/phi/kernels/xpu/instance_norm_grad_kernel.cc
+@@ -15,6 +15,7 @@
+ #include "paddle/phi/kernels/instance_norm_grad_kernel.h"
+ #include "paddle/phi/backends/xpu/enforce_xpu.h"
+ #include "paddle/phi/core/kernel_registry.h"
++#include "paddle/phi/kernels/full_kernel.h"
+ #include "paddle/phi/kernels/funcs/norm_utils.h"
+ 
+ namespace phi {
+@@ -23,6 +24,7 @@ template <typename T, typename Context>
+ void InstanceNormGradKernel(const Context& dev_ctx,
+                             const DenseTensor& x,
+                             const paddle::optional<DenseTensor>& scale,
++                            const paddle::optional<DenseTensor>& bias UNUSED,
+                             const DenseTensor& saved_mean,
+                             const DenseTensor& saved_variance,
+                             const DenseTensor& d_y,
+@@ -44,6 +46,23 @@ void InstanceNormGradKernel(const Context& dev_ctx,
+           x_dims.size()));
+ 
+   dev_ctx.template Alloc<T>(d_x);
++  if (x.numel() == 0) {
++    if (d_scale) {
++      phi::Full<float, Context>(
++          dev_ctx,
++          phi::IntArray(common::vectorize(d_scale->dims())),
++          0.f,
++          d_scale);
++    }
++    if (d_bias) {
++      phi::Full<float, Context>(
++          dev_ctx,
++          phi::IntArray(common::vectorize(d_bias->dims())),
++          0.f,
++          d_bias);
++    }
++    return;
++  }
+   T* d_scale_data = nullptr;
+   T* d_bias_data = nullptr;
+   if (d_scale && d_bias) {
+diff --git a/paddle/phi/kernels/xpu/instance_norm_kernel.cc b/paddle/phi/kernels/xpu/instance_norm_kernel.cc
+index 3423abfb00..27db4b05d2 100644
+--- a/paddle/phi/kernels/xpu/instance_norm_kernel.cc
++++ b/paddle/phi/kernels/xpu/instance_norm_kernel.cc
+@@ -15,8 +15,8 @@
+ #include "paddle/phi/kernels/instance_norm_kernel.h"
+ #include "paddle/phi/backends/xpu/enforce_xpu.h"
+ #include "paddle/phi/core/kernel_registry.h"
++#include "paddle/phi/kernels/full_kernel.h"
+ #include "paddle/phi/kernels/funcs/math_function.h"
+-
+ namespace phi {
+ 
+ template <typename T, typename Context>
+@@ -38,6 +38,27 @@ void InstanceNormKernel(const Context& dev_ctx,
+   dev_ctx.template Alloc<T>(y);
+   dev_ctx.template Alloc<float>(saved_mean);
+   dev_ctx.template Alloc<float>(saved_var);
++  if (x.numel() == 0) {
++    if (y) {
++      phi::Full<T, Context>(
++          dev_ctx, phi::IntArray(common::vectorize(y->dims())), 0, y);
++    }
++    if (saved_mean) {
++      phi::Full<float, Context>(
++          dev_ctx,
++          phi::IntArray(common::vectorize(saved_mean->dims())),
++          0.f,
++          saved_mean);
++    }
++    if (saved_var) {
++      phi::Full<float, Context>(
++          dev_ctx,
++          phi::IntArray(common::vectorize(saved_var->dims())),
++          0.f,
++          saved_var);
++    }
++    return;
++  }
+ 
+   xpu::ctx_guard RAII_GUARD(dev_ctx.x_context());
+ 
+diff --git a/paddle/phi/ops/yaml/backward.yaml b/paddle/phi/ops/yaml/backward.yaml
+index 439f39d005..b281548199 100644
+--- a/paddle/phi/ops/yaml/backward.yaml
++++ b/paddle/phi/ops/yaml/backward.yaml
+@@ -1805,7 +1805,7 @@
+   no_need_buffer : x
+ 
+ - backward_op : instance_norm_double_grad
+-  forward : instance_norm_grad(Tensor x, Tensor scale, Tensor saved_mean, Tensor saved_variance, Tensor grad_y, float epsilon) -> Tensor(grad_x), Tensor(grad_scale), Tensor(grad_bias)
++  forward : instance_norm_grad(Tensor x, Tensor scale, Tensor bias, Tensor saved_mean, Tensor saved_variance, Tensor grad_y, float epsilon) -> Tensor(grad_x), Tensor(grad_scale), Tensor(grad_bias)
+   args : (Tensor x, Tensor scale, Tensor saved_mean, Tensor saved_variance, Tensor grad_y, Tensor grad_x_grad, Tensor grad_scale_grad, Tensor grad_bias_grad, float epsilon)
+   output : Tensor(x_grad), Tensor(scale_grad), Tensor(grad_y_grad)
+   infer_meta :
+@@ -1817,7 +1817,7 @@
+ 
+ - backward_op : instance_norm_grad
+   forward : instance_norm(Tensor x, Tensor scale, Tensor bias, float epsilon) -> Tensor(y), Tensor(saved_mean), Tensor(saved_variance)
+-  args : (Tensor x, Tensor scale, Tensor saved_mean, Tensor saved_variance, Tensor y_grad, float epsilon=1e-5)
++  args : (Tensor x, Tensor scale, Tensor bias, Tensor saved_mean, Tensor saved_variance, Tensor y_grad, float epsilon=1e-5)
+   output : Tensor(x_grad), Tensor(scale_grad), Tensor(bias_grad)
+   infer_meta :
+     func : InstanceNormGradInferMeta
+@@ -1825,9 +1825,9 @@
+   kernel :
+     func : instance_norm_grad
+     data_type : x
+-  optional : scale
++  optional : scale, bias
+   backward : instance_norm_double_grad
+-  composite: instance_norm_grad(x, scale, saved_mean, saved_variance, y_grad, epsilon, x_grad, scale_grad, bias_grad)
++  composite: instance_norm_grad(x, scale, bias, saved_mean, saved_variance, y_grad, epsilon, x_grad, scale_grad, bias_grad)
+ 
+ - backward_op : inverse_grad
+   forward : inverse(Tensor x) -> Tensor(out)
+diff --git a/test/cpp/auto_parallel/spmd_rule_test.cc b/test/cpp/auto_parallel/spmd_rule_test.cc
+index 0733ee41d1..6466cdb25f 100644
+--- a/test/cpp/auto_parallel/spmd_rule_test.cc
++++ b/test/cpp/auto_parallel/spmd_rule_test.cc
+@@ -377,7 +377,7 @@ TEST(InstanceNorm, Ctor) {
+       common::make_ddim(mean_and_variance_shape), mean_and_variance_dist_attr);
+   phi::distributed::SpmdInfo backward_info =
+       phi::distributed::InstanceNormGradInferSpmd(
+-          x, scale, saved_mean, saved_variance, y_grad, epsilon);
++          x, scale, bias, saved_mean, saved_variance, y_grad, epsilon);
+   input_size = 5;
+   output_size = 3;
+   EXPECT_EQ(backward_info.first.size(), input_size);

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73854/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73854/tests/test.patch
@@ -1,0 +1,66 @@
+diff --git a/test/legacy_test/test_instance_norm_op_v2.py b/test/legacy_test/test_instance_norm_op_v2.py
+index b929e6bcfc1..6ffcb701472 100644
+--- a/test/legacy_test/test_instance_norm_op_v2.py
++++ b/test/legacy_test/test_instance_norm_op_v2.py
+@@ -488,6 +488,61 @@ class TestInstanceNormOpAmpNCHW(TestInstanceNormOp):
+             )
+ 
+ 
++class TestInstanceNormOp_ZeroSize(OpTest):
++    def setUp(self):
++        paddle.disable_static()
++        self.op_type = "instance_norm"
++        self.__class__.op_type = self.op_type
++        self.data_format = "NCHW"
++        self.eps = 1e-5
++        self.init_dtype()
++        self.init_shape()
++        self.init_value()
++        self.inputs = {'X': self.value, 'Scale': self.scale, 'Bias': self.bias}
++        self.attrs = {
++            'epsilon': self.eps,
++            'momentum': 0.9,
++            'data_format': self.data_format,
++        }
++        self.python_out_sig = ['Y']
++        self.python_api = instance_norm_wrapper
++        self.public_python_api = instance_norm_wrapper
++
++    def test_check_output(self):
++        self.check_output(
++            atol=1e-3,
++            check_pir=True,
++        )
++
++    def test_check_grad(self):
++        self.check_grad(
++            ['X', 'Scale', 'Bias'],
++            'Y',
++            check_pir=True,
++        )
++
++    def init_dtype(self):
++        self.dtype = np.float32
++
++    def init_shape(self):
++        self.shape = [2, 0, 4, 5]
++        self.scale_shape = [100]
++        y = np.random.random([2, 0, 4, 5]).astype(self.dtype)
++        mean = np.random.random(0).astype(self.dtype)
++        variance_1 = np.random.random(0).astype(self.dtype)
++        self.outputs = {
++            'Y': y,
++            'SavedMean': mean,
++            'SavedVariance': variance_1,
++        }
++
++    def init_value(self):
++        np.random.seed(0)
++        self.value = np.random.random(self.shape).astype(self.dtype)
++        self.scale = np.random.random(self.scale_shape).astype(np.float32)
++        self.bias = np.random.random(self.scale_shape).astype(np.float32)
++
++
+ if __name__ == '__main__':
+     paddle.enable_static()
+     unittest.main()

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73854/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73854/tests/test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# P2P tests (pass-to-pass)
+python -m pytest test/legacy_test/test_instance_norm_op_v2.py::TestInstanceNorm -q
+
+# F2P tests (fail-to-pass)
+python -m pytest test/legacy_test/test_instance_norm_op_v2.py::TestInstanceNormOp_ZeroSize -q


### PR DESCRIPTION
### 关联

- SWE-Paddle 共建 issue: [[Call for Bench] SWE-Paddle 社区共建 Paddle#79447](https://github.com/PaddlePaddle/Paddle/issues/79447)
- 来源 PR: [[0-size Tensor Job2 No.60] Add 0-size Tensor support for paddle.nn.functional.instance_norm PaddlePaddle/Paddle#73854](https://github.com/PaddlePaddle/Paddle/pull/73854)

### 说明

新增 SWE-Paddle 任务 `PaddlePaddle__Paddle-73854`。

该任务覆盖 `paddle.nn.functional.instance_norm` 对 0-size Tensor 的处理。测试包含已有 instance_norm regression case，以及 0-size Tensor 的目标场景，可在 CPU 环境运行。

### 验证结果

状态 | P2P | instance_norm F2P  
---|---|---  
Base + `tests/test.patch` | PASS | FAIL  
Base + test patch + `solution/code.patch` | PASS | PASS  


#### Base P2P

```
3 passed, 3 warnings in 2.22s

```

#### Base F2P：instance_norm 

```
FAILED test/legacy_test/test_instance_norm_op_v2.py::TestInstanceNormOp_ZeroSize::test_check_grad - RuntimeError: (PreconditionNotMet) The Input variable X has not been initialized. You may need to confirm if you put exe.run(startup_program) ...
FAILED test/legacy_test/test_instance_norm_op_v2.py::TestInstanceNormOp_ZeroSize::test_check_output - RuntimeError: (PreconditionNotMet) The Input variable X has not been initialized. You may need to confirm if you put exe.run(startup_program) ...
2 failed, 3 warnings in 3.85s 

```

#### Solution P2P

```
3 passed, 3 warnings in 1.37s
```

#### Solution F2P：instance_norm 

```
2 passed, 4 warnings in 1.37s
```