### PR TITLE
[SWE-Paddle] Fix swe-78911

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78911/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78911/proposal.md
@@ -32,7 +32,7 @@
 ## 5. 验证思路
 
 - 目标测试命令：`bash tests/test.sh`
-- 目标测试文件：`test/legacy_test/test_recompute_context.py`
+- 目标测试文件：`test/legacy_test/test_recompute_context_detection.py`
 - 修复前预期：前向上下文及梯度回归用例通过；反向重计算上下文用例失败。
 - 修复后预期：前向、反向重计算、上下文清理和梯度用例全部通过。
 - P2P：验证 recompute 梯度结果及执行结束后的上下文清理。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78911/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78911/tests/test.patch
@@ -1,8 +1,8 @@
-diff --git a/test/legacy_test/test_recompute_context.py b/test/legacy_test/test_recompute_context.py
+diff --git a/test/legacy_test/test_recompute_context_detection.py b/test/legacy_test/test_recompute_context_detection.py
 new file mode 100644
 index 0000000..18d7357
 --- /dev/null
-+++ b/test/legacy_test/test_recompute_context.py
++++ b/test/legacy_test/test_recompute_context_detection.py
 @@ -0,0 +1,70 @@
 +# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
 +#

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78911/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78911/tests/test.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-python -m pytest test/legacy_test/test_recompute_context.py -q
+python -m pytest test/legacy_test/test_recompute_context_detection.py -q


### PR DESCRIPTION
```
未通过原因
test patch 把 exact Base 已存在的 test_recompute_context.py 声明成新文件，apply 报 already exists in index
```


Fix the test patch for PaddlePaddle__Paddle-78911.

The base commit already contains `test_recompute_context.py`, so the added SWE-Paddle test is renamed to avoid the file conflict, with `test.sh` and `proposal.md` updated accordingly.

Validation:
- Base: 2 failed, 1 passed
<img width="1969" height="150" alt="image" src="https://github.com/user-attachments/assets/9d373f06-6c47-4a0c-90be-20c367ad4260" />

- Gold: 3 passed
<img width="1146" height="186" alt="image" src="https://github.com/user-attachments/assets/d76734ec-6772-40e5-a49f-738ddd6782e1" />
