### PR TITLE
[SWE-Paddle] Add PYTHONPATH and amin/amax P2P guards for PaddlePaddle_78441

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78441/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78441/README.md
@@ -24,6 +24,17 @@ Add `paddle.aminmax` and the corresponding Tensor method so one reduction return
 
 The gold change includes operator schemas and code generation inputs, infermeta, CPU/GPU kernel registrations, backward support, PIR symbolic-shape inference, Python exports and signatures, plus focused tests. CPU is the benchmark acceptance backend; GPU registration is retained in the gold patch but does not make GPU hardware a verifier requirement.
 
+## Test Classification
+
+- **F2P:** the new `test/legacy_test/test_aminmax_op.py` suite and `test/ir/pir/cinn/symbolic/test_infer_sym_shape_unary_op.py::AminmaxOpInferSymbolicShapeTest`. They fail on the base build and pass after applying `solution/code.patch` and rebuilding.
+- **P2P:** four existing amin/amax regression nodes in `test/legacy_test/test_max_min_amax_amin_op.py`:
+  - `TestAmaxAPI_Compatibility::test_dygraph_Compatibility`
+  - `TestAminAPI_Compatibility::test_dygraph_Compatibility`
+  - `TestAmaxAminOutAPI::test_amax_out_in_dygraph`
+  - `TestAmaxAminOutAPI::test_amin_out_in_dygraph`
+
+  The gold patch does not modify this file; these nodes must pass on both base and gold builds.
+
 ## Artifacts
 
 - `proposal.md`: approved candidate proposal and source rationale.
@@ -31,14 +42,21 @@ The gold change includes operator schemas and code generation inputs, infermeta,
 - `environment/README.md`: source-build and reproduction instructions.
 - `solution/code.patch`: exact non-test diff from base to gold commit.
 - `tests/test.patch`: exact test-only diff from base to gold commit.
-- `tests/test.sh`: strict target-test wrapper.
+- `tests/test.sh`: wrapper that sets the required per-suite `PYTHONPATH`, runs the four amin/amax P2P nodes, then runs the new legacy and symbolic-shape F2P targets.
 
 ## Verification
 
-From the root of a correctly rebuilt Paddle checkout, after applying the patches in the documented order:
+From the root of a Paddle checkout after applying the patches in the documented order:
 
 ```bash
 bash tests/test.sh
 ```
+
+On `base_commit + tests/test.patch`, the four P2P nodes must pass and both F2P targets must fail during API lookup, op creation, graph construction, or execution; the wrapper records both F2P failures and exits nonzero. On `base_commit + tests/test.patch + solution/code.patch` after rebuilding, all P2P and F2P targets must pass.
+
+`tests/test.sh` sets `PYTHONPATH` per test suite:
+
+- legacy operator tests need `test/legacy_test` and `test` on `PYTHONPATH`;
+- the symbolic-shape test needs `test/ir/pir/cinn` before any directory containing the other `utils.py`, plus its own `test/ir/pir/cinn/symbolic` directory.
 
 A pre-existing release or nightly wheel cannot validate this task because the change introduces a compiled operator and updates build-time code-generation inputs.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78441/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78441/environment/README.md
@@ -40,9 +40,10 @@ From the Paddle repository root, with this task directory available as `$TASK_DI
 git checkout 35b36cca24a780061268d20d6abe512e758837e6
 git submodule update --init --recursive
 git apply "$TASK_DIR/tests/test.patch"
+PYTHON_BIN=python bash "$TASK_DIR/tests/test.sh"
 ```
 
-At this state the new test module is present, but the API and compiled operator do not exist. Running the target tests should fail during import, API lookup, graph construction, or execution. The existing reduction P2P tests should remain usable with the base build.
+At this state the new test module is present, but the API and compiled operator do not exist. The wrapper must first pass the four existing amin/amax P2P nodes, then fail while the F2P targets import, create, or execute the missing operation.
 
 Then apply the implementation and rebuild:
 
@@ -51,23 +52,37 @@ git apply "$TASK_DIR/solution/code.patch"
 # Re-run CMake if needed, then rebuild and reinstall Paddle.
 cmake --build build --parallel
 python -m pip install --no-deps --force-reinstall build/python/dist/*.whl
-bash "$TASK_DIR/tests/test.sh"
+PYTHON_BIN=python bash "$TASK_DIR/tests/test.sh"
 ```
+
+After the rebuild, all P2P nodes and all F2P targets must pass.
 
 If the build system produces a wheel tagged for a different Python ABI, install and run tests with the matching interpreter. Do not rename the wheel to bypass ABI checks.
 
 ## Exact target tests
 
-`tests/test.sh` runs:
+`tests/test.sh` sets `PYTHONPATH` per suite and runs, in order:
 
-```bash
-python -m pytest test/legacy_test/test_aminmax_op.py -q
-python -m pytest \
-  test/ir/pir/cinn/symbolic/test_infer_sym_shape_unary_op.py::AminmaxOpInferSymbolicShapeTest \
-  -q
-```
+1. Four P2P nodes from `test/legacy_test/test_max_min_amax_amin_op.py`:
+   - `TestAmaxAPI_Compatibility::test_dygraph_Compatibility`
+   - `TestAminAPI_Compatibility::test_dygraph_Compatibility`
+   - `TestAmaxAminOutAPI::test_amax_out_in_dygraph`
+   - `TestAmaxAminOutAPI::test_amin_out_in_dygraph`
+2. F2P legacy target: `test/legacy_test/test_aminmax_op.py`.
+3. F2P symbolic-shape target: `test/ir/pir/cinn/symbolic/test_infer_sym_shape_unary_op.py::AminmaxOpInferSymbolicShapeTest`.
 
-Expected post-fix results are passing forward, gradient, API compatibility, static/dynamic, output-tensor, dynamic-shape, and symbolic-shape cases. Stable pre-existing tests for `min`, `max`, `amin`, and `amax` can be added by the verifier as P2P regression guards.
+For the legacy suites, `PYTHONPATH` includes `test/legacy_test` and `test` so `op_test`, `utils`, and `white_list` imports resolve. For the symbolic-shape suite, `PYTHONPATH` includes `test/ir/pir/cinn` and `test/ir/pir/cinn/symbolic`, with the CINN/PIR directory first because it and `test/legacy_test` both contain a module named `utils.py`.
+
+The wrapper runs both F2P suites even when the first one fails, so the Base run records both F2P roles before exiting nonzero.
+
+Expected post-fix results are passing forward, gradient, API compatibility, static/dynamic, output-tensor, dynamic-shape, and symbolic-shape cases, with all four amin/amax P2P nodes passing before and after the fix.
+
+## Local validation note
+
+- `test/legacy_test/test_max_min_amax_amin_op.py` is byte-for-byte unchanged between the base and gold revisions.
+- With an installed compatible CPU runtime and the exact base test sources, the four selected P2P nodes passed (`4 passed`).
+- With the legacy `PYTHONPATH` configured by `tests/test.sh`, `test_aminmax_op.py` collected successfully and then failed at `AttributeError: module 'paddle' has no attribute 'aminmax'`, which is the expected base-like signal on a runtime without the gold patch.
+- With the CINN/PIR `PYTHONPATH` configured by `tests/test.sh`, `AminmaxOpInferSymbolicShapeTest` collected successfully.
 
 ## Limitations
 

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78441/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78441/tests/test.sh
@@ -1,7 +1,36 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-python -m pytest test/legacy_test/test_aminmax_op.py -q
-python -m pytest \
+PYTHON_BIN="${PYTHON_BIN:-python}"
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+# P2P (pass-to-pass): existing amin/amax API compatibility, out-tensor, and
+# gradient behavior. The gold patch does not modify this test file.
+PYTHONPATH="$repo_root/test/legacy_test:$repo_root/test${PYTHONPATH:+:$PYTHONPATH}" \
+  "$PYTHON_BIN" -m pytest -q \
+  test/legacy_test/test_max_min_amax_amin_op.py::TestAmaxAPI_Compatibility::test_dygraph_Compatibility \
+  test/legacy_test/test_max_min_amax_amin_op.py::TestAminAPI_Compatibility::test_dygraph_Compatibility \
+  test/legacy_test/test_max_min_amax_amin_op.py::TestAmaxAminOutAPI::test_amax_out_in_dygraph \
+  test/legacy_test/test_max_min_amax_amin_op.py::TestAmaxAminOutAPI::test_amin_out_in_dygraph
+
+# F2P (fail-to-pass): run both target suites even when the first one fails,
+# so Base logs contain the complete role matrix before the wrapper exits 1.
+f2p_status=0
+
+if ! PYTHONPATH="$repo_root/test/legacy_test:$repo_root/test${PYTHONPATH:+:$PYTHONPATH}" \
+  "$PYTHON_BIN" -m pytest test/legacy_test/test_aminmax_op.py -q; then
+  f2p_status=1
+fi
+
+# The symbolic-shape suite needs a different utils.py. Keep the CINN/PIR
+# directory ahead of the legacy test directory because both modules are named
+# utils.py.
+if ! PYTHONPATH="$repo_root/test/ir/pir/cinn:$repo_root/test/ir/pir/cinn/symbolic${PYTHONPATH:+:$PYTHONPATH}" \
+  "$PYTHON_BIN" -m pytest \
   test/ir/pir/cinn/symbolic/test_infer_sym_shape_unary_op.py::AminmaxOpInferSymbolicShapeTest \
-  -q
+  -q; then
+  f2p_status=1
+fi
+
+exit "$f2p_status"


### PR DESCRIPTION
# 关联

- SWE-Paddle 共建 issue: https://github.com/PaddlePaddle/Paddle/issues/79447
- 来源 PR: https://github.com/PaddlePaddle/Paddle/pull/78441

## 说明

- 修复 `tests/test.sh` 缺少 PYTHONPATH 导致的 op_test collection 失败。
- legacy 测试和 CINN/PIR symbolic 测试分别设置独立的 PYTHONPATH，避免两个 utils.py 冲突。
- 加入 4 个明确的 amin/amax P2P 节点。
- Base 状态下 P2P 通过，两个 F2P 均失败；Gold 状态下全部通过。

## 本地 sanity

- P2P: 4 passed
- legacy F2P 修复后可正常 collection，并在 base-like runtime 上按预期失败于缺失 paddle.aminmax
- symbolic F2P 修复后可正常 collection

@sunzhongkai588  Thx