### PR TITLE
[SWE-Paddle] Fix broadcast gradient in the PaddlePaddle__Paddle-76736 gold patch

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-76736/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-76736/README.md
@@ -49,4 +49,6 @@ A source rebuild is mandatory. The gold patch changes build-time API metadata an
 
 ## Test Curation
 
-The gold patch preserves all nine non-test sections from the merged commit without editing implementation hunks. The test patch intentionally excludes unrelated `asinh`/`atan` additions from `test_activation_op.py` and excludes the whitespace-only merged hunk in `test_atan2_op.py`. It retains the merged `atan2` compatibility class and adds deterministic public tests for Tensor methods and numerical broadcast gradients.
+The gold patch preserves all nine non-test sections from the merged commit, with one deliberate deviation in `paddle/phi/kernels/impl/atan2_grad_kernel_impl.h`: before the broadcast-gradient reduction it runs `SumInferMeta` on the gradient tensor, so `SumKernel` receives an output whose rank already matches the reduced result. This mirrors the in-tree `ReduceAsKernel` pattern. Without it the merged code aborts on CPU with `Input dimension size should be equal to 2, but received dimension size is 1` whenever a gradient is reduced along an inner broadcast axis, for example `x` of shape `[2, 1]` against `y` of shape `[1, 3]`; the base commit handles that case correctly because it broadcasts in Python before calling the operator.
+
+The test patch intentionally excludes unrelated `asinh`/`atan` additions from `test_activation_op.py` and excludes the whitespace-only merged hunk in `test_atan2_op.py`. It retains the merged `atan2` compatibility class and adds deterministic public tests for Tensor methods and numerical broadcast gradients.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-76736/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-76736/environment/README.md
@@ -49,7 +49,7 @@ The verifier should use its normal Paddle source-build procedure and ensure that
 
 ## Verification Status and Risks
 
-During package authoring, commit ancestry, patch boundaries, patch fidelity, Python syntax, shell syntax, and clean application against exact base file contents were checked. The nine fixed source files are also compared with their squash-commit versions during structural validation.
+During package authoring, commit ancestry, patch boundaries, patch fidelity, Python syntax, shell syntax, and clean application against exact base file contents were checked. The nine fixed source files are also compared with their squash-commit versions during structural validation. `paddle/phi/kernels/impl/atan2_grad_kernel_impl.h` intentionally differs from the squash commit by the `SumInferMeta` call documented in the package README; without it the broadcast-gradient node fails on CPU, so the difference must not be reverted.
 
 A Linux Paddle source configure/build and behavioral base/fixed pytest run were not executed in the community repository workspace because it does not contain a trustworthy Paddle source build for the pinned revision. Those steps remain pending for the SWE-Paddle Run/Test/Fix verifier and must not be inferred from structural checks.
 

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-76736/solution/code.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-76736/solution/code.patch
@@ -82,7 +82,7 @@ index f5773eb8057caa..dcd338ff2be992 100644
  
  namespace phi {
  
-@@ -84,34 +87,119 @@ void Atan2GradKernel(const Context& dev_ctx,
+@@ -84,34 +87,125 @@ void Atan2GradKernel(const Context& dev_ctx,
                       const DenseTensor& out_grad,
                       DenseTensor* x_grad,
                       DenseTensor* y_grad) {
@@ -210,12 +210,18 @@ index f5773eb8057caa..dcd338ff2be992 100644
 +    for_range(functor);
 +
 +    if (x_grad && !x_axes.empty()) {
++      phi::MetaTensor meta_x_grad(x_grad);
++      phi::SumInferMeta(
++          dx_b, phi::IntArray(x_axes), x_grad->dtype(), false, &meta_x_grad);
 +      phi::SumKernel<T, Context>(
 +          dev_ctx, dx_b, phi::IntArray(x_axes), x_grad->dtype(), false, x_grad);
 +      x_grad->Resize(x.dims());
 +    }
 +
 +    if (y_grad && !y_axes.empty()) {
++      phi::MetaTensor meta_y_grad(y_grad);
++      phi::SumInferMeta(
++          dy_b, phi::IntArray(y_axes), y_grad->dtype(), false, &meta_y_grad);
 +      phi::SumKernel<T, Context>(
 +          dev_ctx, dy_b, phi::IntArray(y_axes), y_grad->dtype(), false, y_grad);
 +      y_grad->Resize(y.dims());


### PR DESCRIPTION
atan2 梯度计算时忘了更新“压扁”后的形状，导致 CPU 上维度检查失败；修复方法是在求和前重新推断正确的形状，修完后 CPU 上就正常了。

@sunzhongkai588  Thx