### PR TITLE
[SWE-Paddle] fix for task PaddlePaddle__Paddle-78342

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78342/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78342/README.md
@@ -23,7 +23,7 @@ In static mode, a Tensor condition contributes an executable assertion to the pr
 ## Test Classification
 
 - **F2P:** the seven `TestAssertAPI` cases added to `test/legacy_test/test_api_compatibility_part2.py` cover truthy and falsy Python conditions, truthy and falsy Tensor conditions, the default message, compatible calling forms, and static-graph execution.
-- **P2P:** all pre-existing tests in `test/legacy_test/test_api_compatibility_part2.py` remain the regression baseline and should pass before and after the solution.
+- **P2P:** `test/legacy_test/test_assert_close.py::TestAssertClose` guards `paddle.testing.assert_close`, which lives in the same comparison module and package export list that the solution patch edits, and passes before and after the solution.
 
 ## Artifact Map
 
@@ -31,11 +31,11 @@ In static mode, a Tensor condition contributes an executable assertion to the pr
 - `instruction.md`: self-contained observable public API requirements.
 - `solution/code.patch`: exact base-to-gold diff for the three production files.
 - `tests/test.patch`: exact base-to-gold diff for the legacy unittest file.
-- `tests/test.sh`: strict direct-Python unittest wrapper.
+- `tests/test.sh`: narrowed pytest wrapper with explicit P2P and F2P selections.
 - `environment/README.md`: revisions, runtime assumptions, patch order, and verification guidance.
 
 ## Verification Summary
 
 - Both patches are exported from the exact base-to-gold Git diff with the required production/test boundary.
 - Packaging checks cover patch whitespace, shell syntax, isolated test-first application order, byte-for-byte gold equivalence, and Python syntax.
-- Runtime execution is best-effort when the exact base build is unavailable. The target class was verified fail-before/pass-after with a loadable runtime from ancestor commit `56be465924264e1251cf127dbff56d17a7554d01`, 91 commits before the base; full-file P2P limitations are recorded in `environment/README.md`.
+- The target class was verified fail-before/pass-after and the P2P selection verified passing in both states, with the pass-after run performed on a runtime built from the exact base commit. Per-runtime results and why the wrapper selects a class instead of the whole compatibility file are recorded in `environment/README.md`.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78342/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78342/environment/README.md
@@ -29,13 +29,19 @@ git apply /path/to/PaddlePaddle__Paddle-78342/solution/code.patch
 PYTHON_BIN=python bash /path/to/PaddlePaddle__Paddle-78342/tests/test.sh
 ```
 
-The first run is expected to fail the seven new `TestAssertAPI` cases because `paddle._assert` is absent. Existing tests in the file remain the P2P baseline. After applying the solution and refreshing the runtime's Python package, the full unittest file should pass.
+The first run is expected to fail the seven new `TestAssertAPI` cases because `paddle._assert` is absent, while the P2P selection already passes. After applying the solution and refreshing the runtime's Python package, both selections should pass.
 
-The wrapper deliberately executes the Paddle unittest file directly:
+The wrapper runs a narrowed selection instead of the whole compatibility file:
 
 ```bash
-"${PYTHON_BIN:-python}" test/legacy_test/test_api_compatibility_part2.py
+# P2P tests (pass-to-pass)
+"${PYTHON_BIN:-python}" -m pytest test/legacy_test/test_assert_close.py::TestAssertClose -q
+
+# F2P tests (fail-to-pass)
+"${PYTHON_BIN:-python}" -m pytest test/legacy_test/test_api_compatibility_part2.py::TestAssertAPI -q
 ```
+
+`TestAssertClose` is the P2P guard because `assert_close` lives in `python/paddle/testing/_comparison.py` and is re-exported from `python/paddle/testing/__init__.py`, the two files the solution patch edits besides the top-level namespace. Running the full `test_api_compatibility_part2.py` is not usable as a P2P baseline: unrelated compatibility cases in that file depend on API changes that a non-exact runtime does not carry, so the file is red both before and after the solution.
 
 ## Compatibility Risks
 
@@ -48,4 +54,6 @@ The wrapper deliberately executes the Paddle unittest file directly:
 
 Package validation passed for artifact presence, unchanged `proposal.md`, shell syntax, patch whitespace, exact file boundaries, test-first then solution application, byte-for-byte equality with the gold revision, and Python syntax compilation. Neither the wrapper nor the environment commands invokes an alternate test runner.
 
-Runtime validation used an isolated overlay backed by the loadable Python 3.10 build at `56be465924264e1251cf127dbff56d17a7554d01`, 91 commits behind the exact base. Before the solution, all seven `TestAssertAPI` cases errored because `paddle._assert` was absent. After the solution, all seven target cases passed, including static execution. The full direct-Python wrapper ran 80 tests but reported 23 errors in unrelated compatibility APIs whose required changes postdate the older runtime, so this run is not claimed as complete P2P validation. The Python 3.9 build at `555b4a95615a35b301f348e081e56435a6d75da6` remains unusable because loading its native extension raises `SIGBUS`. The dirty `/workspace/Paddle` checkout was not modified.
+Runtime validation used an isolated overlay backed by the loadable Python 3.10 build at `56be465924264e1251cf127dbff56d17a7554d01`, 91 commits behind the exact base. Before the solution, all seven `TestAssertAPI` cases errored because `paddle._assert` was absent. After the solution, all seven target cases passed, including static execution. The full direct-Python wrapper ran 80 tests but reported 23 errors in unrelated compatibility APIs whose required changes postdate the older runtime, so running the whole file is not usable as P2P validation. The Python 3.9 build at `555b4a95615a35b301f348e081e56435a6d75da6` remains unusable because loading its native extension raises `SIGBUS`. The dirty `/workspace/Paddle` checkout was not modified.
+
+The narrowed wrapper was validated separately. In the fail-before state, on a base checkout with only `tests/test.patch` applied and an ancestor CPU runtime at Paddle commit `7743e779aff3e35b8bd748b2c69b9332f5d8dfd7`, `test_assert_close.py::TestAssertClose` passed 24 cases while all seven `TestAssertAPI` cases failed. Running the whole `test_api_compatibility_part2.py` in that same state reported 79 errors out of 80 cases, which is why the file itself cannot serve as a P2P baseline. The pass-after state was confirmed on a runtime built from the exact base commit, with the three patched production files installed into that package: both the P2P and the F2P selection pass.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78342/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78342/tests/test.sh
@@ -3,4 +3,8 @@ set -euo pipefail
 
 PYTHON_BIN="${PYTHON_BIN:-python}"
 
-"${PYTHON_BIN}" test/legacy_test/test_api_compatibility_part2.py
+# P2P tests (pass-to-pass)
+"${PYTHON_BIN}" -m pytest test/legacy_test/test_assert_close.py::TestAssertClose -q
+
+# F2P tests (fail-to-pass)
+"${PYTHON_BIN}" -m pytest test/legacy_test/test_api_compatibility_part2.py::TestAssertAPI -q


### PR DESCRIPTION
tests/test.sh ran the whole test/legacy_test/test_api_compatibility_part2.py file, which is red both before and after the solution: unrelated compatibility cases in that file depend on API changes a non-exact runtime does not carry, so the run yielded no usable P2P conclusion (80 tests / 79 errors at base).

Narrow the wrapper to explicit P2P and F2P selections, matching the convention used by the other task packages:

- P2P: test/legacy_test/test_assert_close.py::TestAssertClose, which guards paddle.testing.assert_close in the same comparison module and package export list that solution/code.patch edits.
- F2P: test/legacy_test/test_api_compatibility_part2.py::TestAssertAPI.

Before:
<img width="1255" height="323" alt="Screenshot 2026-08-26 223852" src="https://github.com/user-attachments/assets/f42d7ecc-2abe-4224-8ca6-5fb9a11b0cf9" />

After:
<img width="1272" height="121" alt="Screenshot 2026-08-27 003559" src="https://github.com/user-attachments/assets/6a76bbff-efe6-41d8-ad48-e53620bcae1d" />

@sunzhongkai588  Thx