### PR TITLE
[SWE-Paddle] Fix 57741 memcpy F2P test

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-57741/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-57741/tests/test.patch
@@ -5,7 +5,7 @@ diff --git a/test/dygraph_to_static/test_tensor_memcpy_on_cpu.py b/test/dygraph_
  import unittest
  
  import numpy as np
-+from dygraph_to_static_util import test_and_compare_with_new_ir
++from dygraph_to_static_util import test_and_compare_with_new_ir as compare_with_new_ir
  
  import paddle
  
@@ -13,53 +13,7 @@ diff --git a/test/dygraph_to_static/test_tensor_memcpy_on_cpu.py b/test/dygraph_
          x2 = tensor_copy_to_cpu(x1)
          return x1.place, x2.place, x2.numpy()
  
-+    @test_and_compare_with_new_ir(False)
++    @compare_with_new_ir(False)
      def test_tensor_cpu_on_default_cpu(self):
          paddle.base.framework._set_expected_place(paddle.CPUPlace())
          dygraph_x1_place, dygraph_place, dygraph_res = self._run(
-@@ -67,6 +69,7 @@
-         x2 = tensor_copy_to_cuda(x1)
-         return x1.place, x2.place, x2.numpy()
- 
-+    @test_and_compare_with_new_ir(False)
-     def test_tensor_cuda_on_default_cpu(self):
-         if not paddle.base.is_compiled_with_cuda():
-             return
-diff --git a/test/dygraph_to_static/test_tensor_memcpy_on_gpu.py b/test/dygraph_to_static/test_tensor_memcpy_on_gpu.py
---- a/test/dygraph_to_static/test_tensor_memcpy_on_gpu.py
-+++ b/test/dygraph_to_static/test_tensor_memcpy_on_gpu.py
-@@ -16,6 +16,7 @@
- import unittest
- 
- import numpy as np
-+from dygraph_to_static_util import test_and_compare_with_new_ir
- 
- import paddle
- 
-@@ -48,6 +49,7 @@
-         x2 = tensor_copy_to_cpu(x1)
-         return x1.place, x2.place, x2.numpy()
- 
-+    @test_and_compare_with_new_ir(False)
-     def test_tensor_cpu_on_default_gpu(self):
-         if paddle.base.is_compiled_with_cuda():
-             place = paddle.CUDAPlace(
-@@ -74,6 +76,7 @@
-         x2 = tensor_copy_to_cuda(x1)
-         return x1.place, x2.place, x2.numpy()
- 
-+    @test_and_compare_with_new_ir(False)
-     def test_tensor_cuda_on_default_gpu(self):
-         if paddle.base.is_compiled_with_cuda():
-             place = paddle.CUDAPlace(
-diff --git a/test/white_list/new_ir_op_test_white_list b/test/white_list/new_ir_op_test_white_list
---- a/test/white_list/new_ir_op_test_white_list
-+++ b/test/white_list/new_ir_op_test_white_list
-@@ -136,6 +136,7 @@
- test_matrix_power_op
- test_maxout_op
- test_mean_op
-+test_memcpy_op
- test_mode_op
- test_multi_dot_op
- test_multiplex_op

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-57741/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-57741/tests/test.patch
@@ -17,3 +17,108 @@ diff --git a/test/dygraph_to_static/test_tensor_memcpy_on_cpu.py b/test/dygraph_
      def test_tensor_cpu_on_default_cpu(self):
          paddle.base.framework._set_expected_place(paddle.CPUPlace())
          dygraph_x1_place, dygraph_place, dygraph_res = self._run(
+@@ -67,9 +69,12 @@
+         x2 = tensor_copy_to_cuda(x1)
+         return x1.place, x2.place, x2.numpy()
+ 
++    @unittest.skipIf(
++        not paddle.base.is_compiled_with_cuda(),
++        "requires CUDA build",
++    )
++    @compare_with_new_ir(False)
+     def test_tensor_cuda_on_default_cpu(self):
+-        if not paddle.base.is_compiled_with_cuda():
+-            return
+ 
+         """
+         Note(liudongxue01): If the following asserts fail to run,
+@@ -96,9 +101,11 @@
+         x2 = tensor_copy_to_cuda_with_warning(x1, device_id=1, blocking=False)
+         return x1.place, x2.place, x2.numpy()
+ 
++    @unittest.skipIf(
++        not paddle.base.is_compiled_with_cuda(),
++        "requires CUDA build",
++    )
+     def test_with_warning_on_cpu(self):
+-        if not paddle.base.is_compiled_with_cuda():
+-            return
+ 
+         paddle.base.framework._set_expected_place(paddle.CPUPlace())
+ 
+diff --git a/test/dygraph_to_static/test_tensor_memcpy_on_gpu.py b/test/dygraph_to_static/test_tensor_memcpy_on_gpu.py
+--- a/test/dygraph_to_static/test_tensor_memcpy_on_gpu.py
++++ b/test/dygraph_to_static/test_tensor_memcpy_on_gpu.py
+@@ -16,6 +16,7 @@
+ import unittest
+ 
+ import numpy as np
++from dygraph_to_static_util import test_and_compare_with_new_ir as compare_with_new_ir
+ 
+ import paddle
+ 
+@@ -48,13 +49,15 @@
+         x2 = tensor_copy_to_cpu(x1)
+         return x1.place, x2.place, x2.numpy()
+ 
++    @unittest.skipIf(
++        not paddle.base.is_compiled_with_cuda(),
++        "requires CUDA build",
++    )
++    @compare_with_new_ir(False)
+     def test_tensor_cpu_on_default_gpu(self):
+-        if paddle.base.is_compiled_with_cuda():
+-            place = paddle.CUDAPlace(
+-                int(os.environ.get('FLAGS_selected_gpus', 0))
+-            )
+-        else:
+-            return
++        place = paddle.CUDAPlace(
++            int(os.environ.get('FLAGS_selected_gpus', 0))
++        )
+         paddle.base.framework._set_expected_place(place)
+         dygraph_x1_place, dygraph_place, dygraph_res = self._run(
+             to_static=False
+@@ -74,13 +77,15 @@
+         x2 = tensor_copy_to_cuda(x1)
+         return x1.place, x2.place, x2.numpy()
+ 
++    @unittest.skipIf(
++        not paddle.base.is_compiled_with_cuda(),
++        "requires CUDA build",
++    )
++    @compare_with_new_ir(False)
+     def test_tensor_cuda_on_default_gpu(self):
+-        if paddle.base.is_compiled_with_cuda():
+-            place = paddle.CUDAPlace(
+-                int(os.environ.get('FLAGS_selected_gpus', 0))
+-            )
+-        else:
+-            return
++        place = paddle.CUDAPlace(
++            int(os.environ.get('FLAGS_selected_gpus', 0))
++        )
+         paddle.base.framework._set_expected_place(place)
+         dygraph_x1_place, dygraph_place, dygraph_res = self._run(
+             to_static=False
+@@ -100,13 +105,14 @@
+         x2 = tensor_copy_to_cuda_with_warning(x1, device_id=1, blocking=False)
+         return x1.place, x2.place, x2.numpy()
+ 
++    @unittest.skipIf(
++        not paddle.base.is_compiled_with_cuda(),
++        "requires CUDA build",
++    )
+     def test_with_warning_on_gpu(self):
+-        if paddle.base.is_compiled_with_cuda():
+-            place = paddle.CUDAPlace(
+-                int(os.environ.get('FLAGS_selected_gpus', 0))
+-            )
+-        else:
+-            return
++        place = paddle.CUDAPlace(
++            int(os.environ.get('FLAGS_selected_gpus', 0))
++        )
+         paddle.base.framework._set_expected_place(place)
+ 
+         x1 = paddle.ones([1, 2, 3])

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-57741/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-57741/tests/test.sh
@@ -4,7 +4,12 @@ set -euo pipefail
 # Target tests for PaddlePaddle__Paddle-57741.
 # Run from the root of a built PaddlePaddle/Paddle source checkout.
 #
-# F2P: CPU dy2static memcpy via PIR/new-IR executor (no CUDA required).
+# F2P: dy2static memcpy via PIR/new-IR executor.
+# - CPU path always runs.
+# - GPU paths use @unittest.skipIf when CUDA is unavailable (no bare-return pass).
 python -m pytest \
   test/dygraph_to_static/test_tensor_memcpy_on_cpu.py::TestTensorCopyToCpuOnDefaultCPU::test_tensor_cpu_on_default_cpu \
+  test/dygraph_to_static/test_tensor_memcpy_on_cpu.py::TestTensorCopyToCudaOnDefaultCPU::test_tensor_cuda_on_default_cpu \
+  test/dygraph_to_static/test_tensor_memcpy_on_gpu.py::TestTensorCopyToCpuOnDefaultGPU::test_tensor_cpu_on_default_gpu \
+  test/dygraph_to_static/test_tensor_memcpy_on_gpu.py::TestTensorCopyToCudaOnDefaultGPU::test_tensor_cuda_on_default_gpu \
   -q

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-57741/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-57741/tests/test.sh
@@ -3,9 +3,8 @@ set -euo pipefail
 
 # Target tests for PaddlePaddle__Paddle-57741.
 # Run from the root of a built PaddlePaddle/Paddle source checkout.
+#
+# F2P: CPU dy2static memcpy via PIR/new-IR executor (no CUDA required).
 python -m pytest \
-  test/dygraph_to_static/test_tensor_memcpy_on_cpu.py \
+  test/dygraph_to_static/test_tensor_memcpy_on_cpu.py::TestTensorCopyToCpuOnDefaultCPU::test_tensor_cpu_on_default_cpu \
   -q
-
-# Optional if CUDA is available:
-# python -m pytest test/dygraph_to_static/test_tensor_memcpy_on_gpu.py -q


### PR DESCRIPTION

### 说明
修正 `PaddlePaddle__Paddle-57741` 验证矩阵：

- CPU F2P：`test_tensor_cpu_on_default_cpu`
- GPU F2P（有 CUDA 时）：`test_tensor_cuda_on_default_cpu`、`test_tensor_cpu_on_default_gpu`、`test_tensor_cuda_on_default_gpu`
- CUDA 用例改为 `@skipIf`，避免 CPU verifier 下 bare-return 假 Pass
- 装饰器 import 使用 `compare_with_new_ir` 别名，避免 helper 误收集