### PR TITLE
[SWE-Paddle] Fix 59383 test_numel_error for gold dynamic check

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-59383/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-59383/tests/test.patch
@@ -99,11 +99,14 @@ index 0000000..1111111
 +
 +    def test_numel_error(self):
 +        self.value_np = np.random.randn(5, 5).astype(self.dtype)
++        # numel validation runs only in dynamic mode; ensure dygraph path.
++        paddle.disable_static()
 +        x = paddle.to_tensor(self.x_np, dtype=self.dtype)
 +        mask = paddle.to_tensor(self.mask_np).astype('bool')
 +        value = paddle.to_tensor(self.value_np, dtype=self.dtype)
 +        with np.testing.assert_raises(AssertionError):
 +            paddle.masked_scatter(x, mask, value)
++        paddle.enable_static()
 +
 +
 +class TestMaskedScatterAPI(unittest.TestCase):


### PR DESCRIPTION
### 说明
修正 `PaddlePaddle__Paddle-59383` 的 `tests/test.patch`：
- 问题：Gold 中 numel 校验仅在 dynamic mode 执行，但 `test_numel_error` 在 static 模式下运行，无法抛出预期 `AssertionError`
- 修正：`test_numel_error` 中 `disable_static()` / 测完 `enable_static()`，与 gold 行为对齐