### PR TITLE
[SWE-Paddle]: Fix 76873 add legacy_test PYTHONPATH and split P2P/F2P

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-76873/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-76873/tests/test.sh
@@ -1,16 +1,30 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Target tests for PaddlePaddle__Paddle-76873 (#76873 + #77103).
-# Run from the root of a built PaddlePaddle/Paddle source checkout.
+export PYTHONPATH="test/legacy_test${PYTHONPATH:+:${PYTHONPATH}}"
+
+# P2P tests (pass-to-pass on base+test.patch and gold)
+python -m pytest \
+  test/legacy_test/test_rrelu_op.py::RReluTest \
+  test/legacy_test/test_selu_op.py::SeluTest \
+  test/ir/pir/cinn/symbolic/test_infer_sym_shape_unary_op.py::SumOpInferSymbolicShapeTest::test_eval_symbolic \
+  -q
+
+# F2P tests (fail-to-pass on base+test.patch; pass on gold after rebuild)
 python -m pytest \
   test/legacy_test/test_celu_op.py \
-  test/legacy_test/test_rrelu_op.py \
-  test/legacy_test/test_swish_op.py \
-  test/legacy_test/test_mish_op.py \
   test/legacy_test/test_hardsigmoid_op.py \
-  test/legacy_test/test_selu_op.py \
-  test/legacy_test/test_imperative_layers.py \
-  test/ir/pir/cinn/symbolic/test_infer_sym_shape_multinary_op.py \
-  test/ir/pir/cinn/symbolic/test_infer_sym_shape_unary_op.py \
+  test/legacy_test/test_mish_op.py \
+  test/legacy_test/test_swish_op.py \
+  test/legacy_test/test_rrelu_op.py::TestRRELUOpClass_Inplace \
+  test/legacy_test/test_rrelu_op.py::TestRRELUAPI \
+  test/legacy_test/test_selu_op.py::TestSELUOpClass_Inplace \
+  test/legacy_test/test_selu_op.py::TestSELUAPI \
+  test/legacy_test/test_imperative_layers.py::TestLayerPrint::test_layer_str \
+  test/ir/pir/cinn/symbolic/test_infer_sym_shape_multinary_op.py::CELUOpInferSymbolicShapeTest::test_eval_symbolic \
+  test/ir/pir/cinn/symbolic/test_infer_sym_shape_unary_op.py::RRELUOpInferSymbolicShapeTest::test_eval_symbolic \
+  test/ir/pir/cinn/symbolic/test_infer_sym_shape_unary_op.py::SELUOpInferSymbolicShapeTest::test_eval_symbolic \
+  test/ir/pir/cinn/symbolic/test_infer_sym_shape_unary_op.py::HardSigmoidInferSymbolicShapeTest::test_eval_symbolic \
+  test/ir/pir/cinn/symbolic/test_infer_sym_shape_unary_op.py::MishOpInferSymbolicShapeTest::test_eval_symbolic \
+  test/ir/pir/cinn/symbolic/test_infer_sym_shape_unary_op.py::SwishOpInferSymbolicShapeTest::test_eval_symbolic \
   -q


### PR DESCRIPTION
## 说明

- 针对 PaddlePaddle__Paddle-76873 修复 tests/test.sh：将 test/legacy_test 添加到 PYTHONPATH 中，以便 legacy（旧版）测试能够正常导入 op_test。
- 将测试拆分为先运行 P2P（现有的 rrelu/selu + symbolic sum 符号求和），再运行 F2P（inplace 激活 + layer repr 层表示 + symbolic inplace 用例）。
