### PR TITLE
[SWE-Paddle] Fix 41202 Base Test

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-41202/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-41202/README.md
@@ -30,7 +30,7 @@ Allow DataLoader to sample a small portion of a dataset and automatically select
 - `proposal.md`: candidate proposal for maintainer triage.
 - `instruction.md`: self-contained problem statement for the coding agent.
 - `solution/code.patch`: gold production patch from the merged PR.
-- `tests/test.patch`: exact upstream test patch from the merged PR.
+- `tests/test.patch`: benchmark regression test adapted from the merged PR test coverage so Base can collect the P2P/F2P roles before Gold-only API lookup occurs.
 - `tests/test.sh`: minimal target test command.
 - `environment/README.md`: environment notes for reproduction.
 - `README.md`: task overview and verification entrypoint.
@@ -41,4 +41,4 @@ Allow DataLoader to sample a small portion of a dataset and automatically select
 bash tests/test.sh
 ```
 
-Expected behavior: applying `tests/test.patch` to `base_commit` should keep the disabled-mode P2P valid while the enabled auto-tune scenarios fail; applying both `tests/test.patch` and `solution/code.patch` should make the complete upstream test file pass.
+Expected behavior: applying `tests/test.patch` to `base_commit` should allow all three role candidates to be collected, keep the disabled-mode P2P valid, and make the two enabled auto-tune scenarios fail when they look up the Gold-only API. Applying both `tests/test.patch` and `solution/code.patch` should make all three tests pass.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-41202/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-41202/environment/README.md
@@ -14,9 +14,9 @@ This candidate is part of the SWE-Paddle community task set.
 
 1. Check out `PaddlePaddle/Paddle` at the base commit.
 2. Apply `tests/test.patch`.
-3. Run `bash tests/test.sh`; the enabled auto-tune scenarios should fail before the fix.
+3. Run `bash tests/test.sh`; Base should collect all three tests, the disabled-mode P2P should pass, and the two enabled auto-tune F2P cases should fail because `set_autotune_config` is not present in Base.
 4. Apply `solution/code.patch`.
-5. Run `bash tests/test.sh` again; the complete upstream test file should pass after the gold patch.
+5. Run `bash tests/test.sh` again; all three benchmark tests should pass after the gold patch.
 
 ## Minimal Test Command
 

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-41202/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-41202/proposal.md
@@ -37,7 +37,7 @@ DataLoader 缺少按实际读取耗时自动选择 worker 数量的能力，用�
 - 修复后预期：P2P、两个启用场景以及完整上游测试文件全部通过。
 - P2P 候选：`TestAutoTune::test_dataloader_disable_autotune`。
 - F2P 候选：`TestAutoTune::test_dataloader_use_autotune` 和 `TestAutoTune::test_distributer_batch_sampler_autotune`。
-- 测试来源：`tests/test.patch` 与 PR 合入时新增的测试文件 diff 完全一致，不改写上游断言。
+- 测试来源：`tests/test.patch` 基于 PR 合入时新增的测试覆盖做最小 benchmark 适配：将 Gold-only `set_autotune_config` 的导入延迟到两个 F2P 测试体内，并使 P2P 不依赖该新增 API，从而保证 Base 可收集完整角色节点；其余测试逻辑与上游覆盖保持一致。
 
 ## 6. 环境与资源
 

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-41202/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-41202/tests/test.patch
@@ -1,9 +1,9 @@
 diff --git a/python/paddle/fluid/tests/unittests/test_dataloader_autotune.py b/python/paddle/fluid/tests/unittests/test_dataloader_autotune.py
 new file mode 100755
-index 0000000000000000000000000000000000000000..a140bb5c79c93b2de2b65a7c65643b3abe376c0f
+index 0000000000000000000000000000000000000000..f834dc24fead91dac1a2ed1207736d89099840b9
 --- /dev/null
 +++ b/python/paddle/fluid/tests/unittests/test_dataloader_autotune.py
-@@ -0,0 +1,76 @@
+@@ -0,0 +1,78 @@
 +#   Copyright (c) 2022 PaddlePaddle Authors. All Rights Reserved.
 +#
 +# Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,7 +25,6 @@ index 0000000000000000000000000000000000000000..a140bb5c79c93b2de2b65a7c65643b3a
 +import paddle
 +import paddle.nn as nn
 +from paddle.io import Dataset, DataLoader, BatchSampler, SequenceSampler
-+from paddle.fluid.reader import set_autotune_config
 +import sys
 +
 +
@@ -57,12 +56,13 @@ index 0000000000000000000000000000000000000000..a140bb5c79c93b2de2b65a7c65643b3a
 +        self.dataset = RandomDataset(10)
 +
 +    def test_dataloader_use_autotune(self):
++        from paddle.fluid.reader import set_autotune_config
++
 +        set_autotune_config(True, 1)
 +        loader = DataLoader(
 +            self.dataset, batch_size=self.batch_size, num_workers=0)
 +
 +    def test_dataloader_disable_autotune(self):
-+        set_autotune_config(False)
 +        loader = DataLoader(
 +            self.dataset, batch_size=self.batch_size, num_workers=2)
 +        if (sys.platform == 'darwin' or sys.platform == 'win32'):
@@ -71,6 +71,8 @@ index 0000000000000000000000000000000000000000..a140bb5c79c93b2de2b65a7c65643b3a
 +            self.assertEqual(loader.num_workers, 2)
 +
 +    def test_distributer_batch_sampler_autotune(self):
++        from paddle.fluid.reader import set_autotune_config
++
 +        set_autotune_config(True, 1)
 +        batch_sampler = paddle.io.DistributedBatchSampler(
 +            self.dataset, batch_size=self.batch_size)


### PR DESCRIPTION
### 问题

`PaddlePaddle__Paddle-41202` 的 `tests/test.patch` 在模块级导入了 Gold 才新增的 `set_autotune_config`，导致 Base 在 pytest collection 阶段直接失败，无法正确形成 P2P/F2P role matrix。

### 修复

- 将 `set_autotune_config` 的导入移到两个 F2P 测试体内。
- P2P 不再依赖 Gold-only API。
- 同步更新任务说明文档。

### 验证

修复后：

- Base：3 个角色均可 collect，P2P PASS，2 个 F2P FAIL。
- Solution：P2P/F2P 全部 PASS，`tests/test.sh` 3 tests passed。