### PR TITLE
[SWE-Paddle] add P2P coverage for Paddle-78048

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78048/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78048/tests/test.patch
@@ -206,3 +206,61 @@ index d3f0eb4a448932a04ef6d2bd7b2d55cd731e199f..e6e8fb3b294b287b6392c612996f2325
 +
  if __name__ == '__main__':
      unittest.main()
+diff --git a/test/swe_paddle/test_pr78048_p2p.py b/test/swe_paddle/test_pr78048_p2p.py
+new file mode 100644
+index 0000000000000000000000000000000000000000..7e1b4ce24c2abab1fb9911e4ae421d6ff0601751
+--- /dev/null
++++ b/test/swe_paddle/test_pr78048_p2p.py
+@@ -0,0 +1,52 @@
++from __future__ import annotations
++
++import numpy as np
++import paddle
++
++
++def _assert_split_equal(actual, expected):
++    assert len(actual) == len(expected)
++    for out, ref in zip(actual, expected):
++        np.testing.assert_allclose(out.numpy(), ref)
++
++
++def test_p2p_hsplit_original_parameters():
++    paddle.disable_static()
++    try:
++        x_np = np.arange(24, dtype="float32").reshape(4, 6)
++        x = paddle.to_tensor(x_np)
++        expected = np.array_split(x_np, 2, axis=1)
++        _assert_split_equal(paddle.hsplit(x, 2), expected)
++        _assert_split_equal(
++            paddle.hsplit(x=x, num_or_indices=2), expected
++        )
++    finally:
++        paddle.enable_static()
++
++
++def test_p2p_dsplit_original_parameters():
++    paddle.disable_static()
++    try:
++        x_np = np.arange(48, dtype="float32").reshape(2, 4, 6)
++        x = paddle.to_tensor(x_np)
++        expected = np.array_split(x_np, 2, axis=2)
++        _assert_split_equal(paddle.dsplit(x, 2), expected)
++        _assert_split_equal(
++            paddle.dsplit(x=x, num_or_indices=2), expected
++        )
++    finally:
++        paddle.enable_static()
++
++
++def test_p2p_vsplit_original_parameters():
++    paddle.disable_static()
++    try:
++        x_np = np.arange(24, dtype="float32").reshape(6, 4)
++        x = paddle.to_tensor(x_np)
++        expected = np.array_split(x_np, 2, axis=0)
++        _assert_split_equal(paddle.vsplit(x, 2), expected)
++        _assert_split_equal(
++            paddle.vsplit(x=x, num_or_indices=2), expected
++        )
++    finally:
++        paddle.enable_static()

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78048/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78048/tests/test.sh
@@ -2,6 +2,9 @@
 set -euo pipefail
 
 python -m pytest \
+  test/swe_paddle/test_pr78048_p2p.py::test_p2p_hsplit_original_parameters \
+  test/swe_paddle/test_pr78048_p2p.py::test_p2p_dsplit_original_parameters \
+  test/swe_paddle/test_pr78048_p2p.py::test_p2p_vsplit_original_parameters \
   test/legacy_test/test_api_compatibility.py::TestHsplitAPI::test_dygraph_Compatibility \
   test/legacy_test/test_api_compatibility.py::TestDsplitAPI::test_dygraph_Compatibility \
   test/legacy_test/test_api_compatibility.py::TestVsplitAPI::test_dygraph_Compatibility \


### PR DESCRIPTION
### 问题

`PaddlePaddle__Paddle-78048` 当前三个目标节点都同时包含新参数别名调用，因此在 Base 上均被识别为 F2P，没有独立可回收集的 meaningful P2P。

### 修复

为 `hsplit`、`dsplit`、`vsplit` 分别增加独立的原参数调用 P2P，并将其加入 `tests/test.sh`。

### 验证

- Base：6 个角色均可 collect，3 P2P PASS，3 F2P FAIL as expected。
- Solution：3 P2P + 3 F2P 全部 PASS，`tests/test.sh` 6 tests passed。