### PR TITLE
[SWE-Paddle] add P2P runner coverage for Paddle-78522

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78522/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78522/README.md
@@ -22,7 +22,7 @@ This directory converts Paddle PR #78522 into a SWE-Paddle community task candid
 
 - 真实来源于已合入的分布式启动改进，行为边界集中在任务间进程清理。
 - upstream test 使用 mock 验证 PID 过滤、调用顺序和异常语义，无需 GPU、网络或真实子进程竞态。
-- Base 缺少目标清理契约，upstream test 可稳定形成 F2P；已有 launch utility 测试用于保护 P2P。
+- Base 缺少目标清理契约，upstream test 可稳定形成 3 个 F2P；`tests/test.sh` 同时执行 Base 已存在的 `TestCoverage::test_find_free_ports` 作为独立 P2P。
 
 ## Files
 
@@ -40,4 +40,4 @@ This directory converts Paddle PR #78522 into a SWE-Paddle community task candid
 bash tests/test.sh
 ```
 
-Expected behavior: applying `tests/test.patch` to `base_commit` should fail on the target behavior; applying both `tests/test.patch` and `solution/code.patch` should pass the target tests.
+Expected behavior: on Base, the existing launch P2P passes while the three cleanup F2Ps fail; after applying `solution/code.patch`, the P2P remains green and all three F2Ps pass.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78522/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78522/proposal.md
@@ -35,7 +35,7 @@
 - 目标测试文件：`test/legacy_test/test_launch_main_kill.py`
 - 修复前预期：upstream test 中 PID 过滤、进程不存在处理和权限错误处理 3 个节点因目标契约缺失而失败。
 - 修复后预期：上述 3 个 F2P 节点全部通过，完整目标测试文件通过。
-- P2P 候选：`test/legacy_test/test_launch_coverage.py::TestCoverage::test_gpus`，保护已有 launch utility 初始化和集群参数处理行为。
+- P2P：`test/legacy_test/test_launch_coverage.py::TestCoverage::test_find_free_ports`，这是 Base 已存在且 CPU 可稳定运行的 launch utility 回归节点，并由 `tests/test.sh` 实际执行。
 
 ## 6. 环境与资源
 
@@ -44,7 +44,7 @@
 - 是否能提供 Docker：暂无
 - patch 类型：Python-only
 - 环境建议：使用与 checkout 兼容的 Paddle wheel；该任务不需要 source build。
-- 最小测试命令：`bash tests/test.sh`
+- 最小测试命令：`bash tests/test.sh`（实际执行 1 个既有 P2P + 3 个新增 F2P）
 - 是否有 oracle 日志：由 SWE-Paddle verifier 结果另行维护
 
 ## 7. 风险自查

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78522/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78522/tests/test.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
-python -m pytest test/legacy_test/test_launch_main_kill.py -q
+python -m pytest   test/legacy_test/test_launch_coverage.py::TestCoverage::test_find_free_ports   test/legacy_test/test_launch_main_kill.py   -q


### PR DESCRIPTION
### 问题

`PaddlePaddle__Paddle-78522` 当前 runner 只执行 3 个新增 cleanup F2P，已有 launch utility P2P 未实际进入 `tests/test.sh`，因此 Core Validation 得到 `F2P 3 · P2P 0`

### 修复

将 Base 已存在且 CPU 可稳定运行的 `TestCoverage::test_find_free_ports` 加入 `tests/test.sh`，作为独立 P2P，并同步更新任务说明。

### 验证

- Base: 1 P2P PASS，3 F2P FAIL as expected。
- Solution: 1 P2P + 3 F2P 全部 PASS。
- `tests/test.sh`: Solution 下 4 tests passed。
- Cross verification: `VERIFICATION PASSED`.