### PR TITLE
[SWE-Paddle] add Paddle 58343 SWE task

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-58343/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-58343/README.md
@@ -1,0 +1,46 @@
+# PaddlePaddle__Paddle-58343
+
+This directory converts Paddle PR #58343 into a SWE-Paddle community task candidate.
+
+## Source
+
+| Field | Value |
+| --- | --- |
+| Repo | `PaddlePaddle/Paddle` |
+| PR | [58343](https://github.com/PaddlePaddle/Paddle/pull/58343) |
+| PR title | `[Hackathon 5th No.49][pir] add logical compare method  - Part 4` |
+| Base commit | `2c45c5eb70e14413d7a00aa75272e28e3c9b6862` |
+| PR head | `0d13cc84fed00d453b27789f94acb5f35afafed9` |
+| Merged at | `2023-10-30T03:46:14Z` (merge commit `e303266536391d32946d332dfc43d1aaa2dcb9bf`) |
+| Hackathon | `5th` task `49`, part 4 |
+| Task type | `feature_implementation` |
+| Resource | CPU |
+
+## Summary
+
+为 PIR 静态图中的 `OpResult` 补齐不等、位运算和标量幂能力，让相关位运算接口正确进入 PIR 分支，并保护已有大小比较行为。`==` / `__eq__` 保持现有内部对象比较语义，不属于本任务。
+
+## Why This Sample
+
+- 来自已合入的 Paddle Hackathon PR，问题和修复都是真实框架研发内容。
+- 同时覆盖 Python 运算符协议、PIR `OpResult` 方法补齐、共享标量构造和模式分发，不是机械注册。
+- gold patch 只有两个纯 Python 实现文件，CPU 即可验证。
+- 6 个 F2P 与 9 个 P2P 位于同一测试文件，Run/Test/Fix 信号集中。
+- `__eq__` 是明确的非目标边界，可防止模型用看似完整但破坏 PIR 内部语义的实现通过测试。
+
+## Files
+
+- `proposal.md`: candidate proposal and maintainer triage context.
+- `instruction.md`: self-contained problem statement for the coding agent.
+- `solution/code.patch`: gold patch from the merged PR (2 implementation files).
+- `tests/test.patch`: test patch exposing comparison, bitwise, and scalar-power behavior.
+- `tests/test.sh`: target and regression test command.
+- `environment/README.md`: base commit, compatible runtime, and reproduction notes.
+
+## Verification
+
+```bash
+bash tests/test.sh
+```
+
+Expected behavior: with `tests/test.patch` applied to `base_commit`, 6 target tests error while 9 regression tests pass. After also applying `solution/code.patch`, all 15 tests pass. The documented Paddle 2.6.0 compatibility overlay reproduces this complete red/green signal.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-58343/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-58343/environment/README.md
@@ -1,0 +1,56 @@
+# Environment Notes
+
+## Expected Environment
+
+- Repository: `PaddlePaddle/Paddle`
+- Base commit: `2c45c5eb70e14413d7a00aa75272e28e3c9b6862`
+- Resource: CPU
+- GPU required: no
+- Network service or external model required: no
+- Suggested Python: 3.10
+- Test framework: Python `unittest`
+- Patch type: pure Python; no C++/CUDA/kernel rebuild is required once a base-compatible Paddle binary is available and the checkout's Python sources are loaded.
+
+## Verified Compatibility Environment
+
+The Run/Test/Fix behavior was reproduced with:
+
+- Image: `paddlepaddle/paddle:2.6.0`
+- Container platform: `linux/amd64`
+- Python: `3.10.13`
+- Paddle binary commit: `e032331bf78b0f9b51806c6761254c8b977f02b4`
+
+The image contains PIR binary and Python API changes made after this task's base commit. Verification therefore overlaid the historical/fixed `math_op_patch.py` and `logic.py` files and used a runtime-only mapping between the old and new monkey-patch entrypoint names. That mapping is environment glue and is not part of either task patch.
+
+The historical base source already binds `<`, `<=`, `>`, and `>=` for `OpResult` in C++ pybind. Therefore `test_less` and `test_greater` are P2P guards, not F2P cases. The compatibility overlay reproduces the expected six-error red state and the complete green state.
+
+## Run Order (Run / Test / Fix)
+
+1. Check out `PaddlePaddle/Paddle` at the base commit.
+2. Prepare a base-compatible compiled Paddle runtime and ensure the checkout's `python/` sources are the package under test.
+3. Apply `tests/test.patch`.
+4. Run `bash tests/test.sh`; the 6 F2P tests should error while the 9 P2P tests pass.
+5. Apply `solution/code.patch`.
+6. Run `bash tests/test.sh` again; all 15 tests should pass. The gold patch is Python-only, so no native rebuild is needed.
+
+## Minimal Test Command
+
+```bash
+python test/legacy_test/test_math_op_patch_pir.py -v
+```
+
+The script intentionally contains only the target test command. Checkout, patch application, binary selection, and Python source overlay belong to the verifier.
+
+## Expected Results
+
+- **Base + test patch**: `test_pow`, four bitwise tests, and `test_equal_and_nequal` error; `test_less`, `test_greater`, and the 7 unchanged tests pass.
+- **Paddle 2.6.0 compatibility overlay + test patch**: the same 6 errors and 9 passes.
+- **Base + test patch + gold patch**: all 15 tests pass.
+
+## Patch Provenance and Risks
+
+- The provided patches are split from the three-file merge-base diff between base `2c45c5eb70e14413d7a00aa75272e28e3c9b6862` and PR head `0d13cc84fed00d453b27789f94acb5f35afafed9`.
+- Both patches apply cleanly to the base commit and the combined tree passes `git diff --check`.
+- No exact wheel for the 2023 base commit is available in the current nightly index; PIR Python/binary compatibility must be fixed by the verifier environment.
+- `__eq__` is intentionally excluded. Enabling elementwise equality without first changing PIR backward semantics would break internal object/set comparisons.
+- The original tests use random values for bitwise and power inputs without a fixed seed, but assertions compare deterministic elementwise results and do not depend on probabilistic thresholds.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-58343/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-58343/instruction.md
@@ -1,0 +1,35 @@
+# 补齐 PIR OpResult 的比较、位运算与标量幂行为
+
+## 详细描述
+
+在 PIR 静态图中，`paddle.static.data` 等接口返回 `paddle.pir.OpResult`。该对象的部分 Python 比较和位运算协议尚不完整，相关表达式可能在构图阶段抛出 `TypeError`、退化成 Python `bool`，或进入不支持 PIR 的旧静态图路径；标量幂调用也无法可靠构造标量输入。
+
+需要让 PIR `OpResult` 支持以下行为：
+
+- `x != y`、`x.not_equal(y)` 和 `x.__ne__(y)` 生成等价的逐元素布尔结果。
+- `x < y`、`x <= y`、`x > y`、`x >= y` 与对应的命名方法和 dunder 调用行为一致。
+- 整数 `OpResult` 支持 `x & y`、`x | y`、`x ^ y` 和 `~x`，并与对应的位运算方法结果一致。
+- `x.__pow__(2)` 与 `x ** 2` 一致，`x.__rpow__(2)` 与 `2 ** x` 一致。
+- 上述表达式构造出的 PIR 程序可在 CPU executor 中运行，结果与对应的 NumPy 或动态图计算一致。
+
+`x == y` / `x.__eq__(y)` 不属于本任务。它们的现有对象比较语义被 PIR 内部逻辑依赖，必须保持不变。
+
+## 验收说明
+
+- 不等和四种大小比较均返回可被 executor 获取的逐元素布尔结果，而不是 Python `bool`。
+- `int32` 输入的四种位运算结果正确。
+- `float32` 输入的标量正向和反向幂结果正确。
+- 既有的整除、取模、矩阵乘法、属性访问和其他数学方法保持可用。
+- 不允许通过删除测试、弱化断言、切回旧静态图、绕过 PIR executor 或改写 `__eq__` 语义来通过任务。
+
+## 技术要求
+
+- 熟悉 Python rich comparison 与位运算协议。
+- 了解 Paddle PIR 静态图和 `OpResult` 的公开行为。
+- 修复应局限于必要的 Python API 行为，不修改 C++ PIR backward、算子数值语义或底层 kernel。
+
+## Acceptance Criteria
+
+- The PIR `OpResult` comparison, bitwise, and scalar-power behavior described above should be implemented.
+- Existing valid `OpResult` methods, attributes, and equality semantics should remain unchanged.
+- Do not satisfy the task by deleting tests, weakening assertions, leaving PIR mode, bypassing execution, or redefining equality.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-58343/proposal.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-58343/proposal.md
@@ -1,0 +1,75 @@
+# 任务提案：PaddlePaddle__Paddle-58343
+
+## 1. 来源信息
+
+- Instance ID：`PaddlePaddle__Paddle-58343`
+- PR 链接：https://github.com/PaddlePaddle/Paddle/pull/58343
+- PR 标题：`[Hackathon 5th No.49][pir] add logical compare method  - Part 4`
+- `base_commit`：`2c45c5eb70e14413d7a00aa75272e28e3c9b6862`（GitHub PR 记录的 base，也是 PR head 的 merge-base）
+- PR head：`0d13cc84fed00d453b27789f94acb5f35afafed9`
+- merged 时间：`2023-10-30T03:46:14Z`（merge commit `e303266536391d32946d332dfc43d1aaa2dcb9bf`）
+- 你的身份：原 PR 作者（GitHub @gouzil）
+- 后续联系人：GitHub @gouzil
+
+## 2. 问题一句话
+
+PIR 静态图中的 `OpResult` 缺少不等与位运算符支持，部分位运算接口也没有进入 PIR 分支；同时标量幂运算会因标量构造入口不兼容而在构图阶段失败，已有的大小比较行为则需要保持不回归。
+
+## 3. 为什么适合作为 SWE-Paddle 样本
+
+- **真实性**：任务来自 Paddle Hackathon 5th No.49 的已合入 PR，是补齐 PIR `OpResult` Python 行为的真实框架开发工作，并经过 Paddle reviewer 审核。
+- **代表性**：覆盖 PIR 静态图、Python rich comparison、位运算符重载、`OpResult` monkey patch、动态图/PIR 模式分发和 executor 数值验证，代表旧静态图能力迁移到 PIR 时常见的多入口一致性问题。
+- **边界清楚**：目标包含 `!=`、`<`、`<=`、`>`、`>=`、`&`、`|`、`^`、`~` 和标量正向/反向幂；`==` / `__eq__` 明确不在范围内，必须保留 PIR 内部依赖的现有对象比较语义。
+- **非平凡性**：模型需要同时补齐不等与位运算入口、修正三个公开位运算接口的 PIR 分发，并修复共享标量构造路径，同时保护已有大小比较行为。只补 dunder、只改公开函数或只修 `pow` 都不能通过完整测试。
+- **验收边界**：比较结果应为可执行的布尔 `OpResult`，位运算使用整数输入；不修改 C++ PIR backward、底层 kernel 或 `__eq__` 语义。
+
+## 4. 任务类型和标签
+
+- 任务类型：`feature_implementation`
+- 执行后端：`cpu`
+- 设备范围：`cpu_only`
+- 模块标签：`[python_api, pir, static_graph, opresult, comparison, bitwise, operator_overload, monkey_patch, legacy_test]`
+
+## 5. 验证思路
+
+- 目标测试文件：`test/legacy_test/test_math_op_patch_pir.py`
+- 目标测试命令：
+
+  ```bash
+  python test/legacy_test/test_math_op_patch_pir.py -v
+  ```
+
+- F2P 用例：
+  - `TestMathOpPatchesPir.test_pow`
+  - `TestMathOpPatchesPir.test_bitwise_not`
+  - `TestMathOpPatchesPir.test_bitwise_xor`
+  - `TestMathOpPatchesPir.test_bitwise_or`
+  - `TestMathOpPatchesPir.test_bitwise_and`
+  - `TestMathOpPatchesPir.test_equal_and_nequal`
+- 修复前预期：在 `base_commit + test_patch` 环境中，6 个 F2P 应因缺失运算符、返回 Python `bool` 或标量构造入口不可用而失败；9 个 P2P 继续通过。
+- 修复后预期：继续应用仅含两个非测试 Python 文件改动的 gold patch 后，目标文件中的 15 个用例全部通过，PIR executor 结果与 NumPy/动态图结果一致。
+- P2P 候选：PR 新增的 `test_less`、`test_greater`，以及存量 `test_mod`、`test_matmul`、`test_floordiv`、`test_item`、`test_place`、`test_some_dim`、`test_math_exists`。历史 base 的 C++ pybind 已提供四种大小比较，因此前两个用例在 gold 前就应通过。
+- 已完成兼容性 Run/Test/Fix 预验证：`paddlepaddle/paddle:2.6.0` 覆盖历史 Python 文件后，base 为 `6 errors + 9 passes`，应用 gold 后为 `15 passes`；该红态与历史 base 源码中的比较运算绑定一致。
+
+## 6. 环境与资源
+
+- 是否能提供 Docker：有；兼容性预验证使用官方 CPU 镜像
+- Dockerfile 或镜像地址：`paddlepaddle/paddle:2.6.0`，以 `--platform linux/amd64` 运行
+- Paddle 来源：`PaddlePaddle/Paddle` source checkout at `base_commit`；测试补丁和 gold patch 来自 #58343 的三文件 merge-base diff
+- 如果使用 wheel，请填写 wheel URL、Python 版本和平台标签：未找到与 `base_commit` 精确对应的历史 wheel；镜像内为 Paddle `2.6.0`（commit `e032331bf78b0f9b51806c6761254c8b977f02b4`）、Python `3.10.13`、Linux x86_64
+- OS / Python / CUDA / cuDNN / 其他关键依赖：Linux x86_64、Python 3.10、NumPy、`unittest`；CPU 测试，不依赖 CUDA/cuDNN
+- 硬件：CPU；本次在 macOS arm64 主机上通过 Docker amd64 仿真验证
+- patch 类型：纯 Python，不含 C++、CUDA、kernel 或 infermeta 编译改动
+- 最小测试命令：`python test/legacy_test/test_math_op_patch_pir.py -v`
+- 是否有 oracle 日志：有本次本地预验证输出；正式 verifier 仍需归档精确历史环境日志
+- 兼容性说明：2.6.0 镜像包含该 PR 之后的 PIR 编译层和 Python 入口改名。本次仅在运行时覆盖 base/fixed Python 文件并适配 monkey-patch 入口名称；这些环境适配不进入任务补丁。
+
+## 7. 风险自查
+
+- 泄露风险：`instruction.md` 只描述可观察的比较、位运算和幂行为，不给出修改文件、内部 helper、注册列表或实现顺序。
+- 环境风险：精确历史 wheel 已不在当前 nightly 索引；虽然兼容镜像复现了预期红绿信号，正式 verifier 仍应优先 source build 精确基线，或提供与该 commit 同期的固定镜像。
+- flaky 风险：低。测试显式使用 CPU，比较使用固定数组，位运算和幂的随机输入不依赖概率阈值或训练收敛。
+- 拆分风险：PR 同时包含比较、位运算和标量 `pow` 修复，但三者共享 `OpResult` patch 入口和同一回归文件；拆分会造成重叠 gold patch，因此按原 PR 粒度保留。
+- 语义风险：`__eq__` 被原 PR 明确排除，因为 PIR backward 的集合逻辑依赖现有对象比较。任务不能把逐元素 `==` 纳入验收，也不能通过改写 `__eq__` 顺带实现其他比较。
+- 依赖风险：任务依赖同系列前序 PR（尤其 #58219）已存在于 base；前序算术运算和 monkey-patch 基础设施不应重复纳入本任务。
+- patch 提取风险：补丁按 merge-base `2c45c5eb70e14413d7a00aa75272e28e3c9b6862` 到 PR head 的三文件 diff 拆分，并已在该 base 上通过 `git apply --check` 与 `git diff --check`。

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-58343/solution/code.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-58343/solution/code.patch
@@ -1,0 +1,105 @@
+diff --git a/python/paddle/pir/math_op_patch.py b/python/paddle/pir/math_op_patch.py
+index 6f0acfaedb..8de1bff7f6 100644
+--- a/python/paddle/pir/math_op_patch.py
++++ b/python/paddle/pir/math_op_patch.py
+@@ -261,14 +261,16 @@ def monkey_patch_opresult():
+                             break
+                     else:
+                         # when break is not triggered, enter the else branch
+-                        other_var_opresult = paddle.fill_constant(
+-                            self.shape,
+-                            lhs_dtype,
+-                            other_var,
++                        other_var_opresult = (
++                            paddle.tensor.creation.fill_constant(
++                                self.shape,
++                                lhs_dtype,
++                                other_var,
++                            )
+                         )
+                 else:
+                     # add fill_op to current_block
+-                    other_var_opresult = paddle.fill_constant(
++                    other_var_opresult = paddle.tensor.creation.fill_constant(
+                         [],
+                         lhs_dtype,
+                         other_var,
+@@ -390,6 +392,34 @@ def monkey_patch_opresult():
+             '__matmul__',
+             _binary_creator_('__matmul__', paddle.tensor.matmul, False, None),
+         ),
++        #  for logical compare
++        # TODO(gouzil): Open after deleting c++ logic
++        # (
++        #     '__eq__',
++        #     _binary_creator_('__eq__', paddle.tensor.equal, False, None),
++        # ),
++        (
++            '__ne__',
++            _binary_creator_('__ne__', paddle.tensor.not_equal, False, None),
++        ),
++        (
++            '__lt__',
++            _binary_creator_('__lt__', paddle.tensor.less_than, False, None),
++        ),
++        (
++            '__le__',
++            _binary_creator_('__le__', paddle.tensor.less_equal, False, None),
++        ),
++        (
++            '__gt__',
++            _binary_creator_('__gt__', paddle.tensor.greater_than, False, None),
++        ),
++        (
++            '__ge__',
++            _binary_creator_(
++                '__ge__', paddle.tensor.greater_equal, False, None
++            ),
++        ),
+     ]
+ 
+     global _already_patch_opresult
+@@ -409,6 +439,12 @@ def monkey_patch_opresult():
+             if method_impl:
+                 setattr(OpResult, method_name, method_impl)
+ 
++        # Bit operation symbol
++        for magic_method, origin_method in paddle.tensor.magic_method_func:
++            impl = getattr(paddle.tensor, origin_method, None)
++            if impl:
++                setattr(OpResult, magic_method, impl)
++
+         # Handling __getitem__
+         from ..base.variable_index import _getitem_static
+ 
+diff --git a/python/paddle/tensor/logic.py b/python/paddle/tensor/logic.py
+index 0c9bafb8b5..865b2a62d4 100755
+--- a/python/paddle/tensor/logic.py
++++ b/python/paddle/tensor/logic.py
+@@ -1213,7 +1213,7 @@ def bitwise_or(x, y, out=None, name=None):
+             Tensor(shape=[3], dtype=int64, place=Place(cpu), stop_gradient=True,
+             [-1, -1, -3])
+     """
+-    if in_dynamic_mode() and out is None:
++    if in_dynamic_or_pir_mode() and out is None:
+         return _C_ops.bitwise_or(x, y)
+ 
+     return _bitwise_op(
+@@ -1272,7 +1272,7 @@ def bitwise_xor(x, y, out=None, name=None):
+             Tensor(shape=[3], dtype=int64, place=Place(cpu), stop_gradient=True,
+             [-1, -3, -4])
+     """
+-    if in_dynamic_mode() and out is None:
++    if in_dynamic_or_pir_mode() and out is None:
+         return _C_ops.bitwise_xor(x, y)
+     return _bitwise_op(
+         op_name="bitwise_xor", x=x, y=y, name=name, out=out, binary_op=True
+@@ -1328,7 +1328,7 @@ def bitwise_not(x, out=None, name=None):
+             Tensor(shape=[3], dtype=int64, place=Place(cpu), stop_gradient=True,
+             [ 4,  0, -2])
+     """
+-    if in_dynamic_mode() and out is None:
++    if in_dynamic_or_pir_mode() and out is None:
+         return _C_ops.bitwise_not(x)
+ 
+     return _bitwise_op(

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-58343/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-58343/tests/test.patch
@@ -1,0 +1,277 @@
+diff --git a/test/legacy_test/test_math_op_patch_pir.py b/test/legacy_test/test_math_op_patch_pir.py
+index 9a7ab29ea4..95a6be11bf 100644
+--- a/test/legacy_test/test_math_op_patch_pir.py
++++ b/test/legacy_test/test_math_op_patch_pir.py
+@@ -48,9 +48,8 @@ class TestMathOpPatchesPir(unittest.TestCase):
+         y_np = np.random.random([10, 1024]).astype('float32')
+         res_np_b = x_np**y_np
+         res_np_c = paddle.pow(paddle.to_tensor(x_np), 2)
+-        # TODO(gouzil): solve paddle.fill_constant problem
+-        # res_np_d = x_np.__pow__(2)
+-        # res_np_e = x_np.__rpow__(2)
++        res_np_d = x_np.__pow__(2)
++        res_np_e = x_np.__rpow__(2)
+         paddle.enable_static()
+         # Calculate results under pir
+         with paddle.pir_utils.IrGuard():
+@@ -64,19 +63,19 @@ class TestMathOpPatchesPir(unittest.TestCase):
+                 )
+                 b = x**y
+                 c = x.pow(2)
+-                # d = x.__pow__(2)
+-                # e = x.__rpow__(2)
++                d = x.__pow__(2)
++                e = x.__rpow__(2)
+                 # TODO(gouzil): Why not use `paddle.static.default_main_program()`？
+                 # Because different case do not isolate parameters (This is a known problem)
+-                (b_np, c_np) = exe.run(
++                (b_np, c_np, d_np, e_np) = exe.run(
+                     main_program,
+                     feed={"x": x_np, "y": y_np},
+-                    fetch_list=[b, c],
++                    fetch_list=[b, c, d, e],
+                 )
+                 np.testing.assert_allclose(res_np_b, b_np, rtol=1e-05)
+                 np.testing.assert_allclose(res_np_c, c_np, rtol=1e-05)
+-                # np.testing.assert_allclose(res_np_d, d_np, rtol=1e-05)
+-                # np.testing.assert_allclose(res_np_e, e_np, rtol=1e-05)
++                np.testing.assert_allclose(res_np_d, d_np, rtol=1e-05)
++                np.testing.assert_allclose(res_np_e, e_np, rtol=1e-05)
+ 
+     def test_mod(self):
+         paddle.disable_static()
+@@ -163,6 +162,234 @@ class TestMathOpPatchesPir(unittest.TestCase):
+                 np.testing.assert_allclose(res_np_c, c_np, atol=1e-05)
+                 np.testing.assert_allclose(res_np_d, d_np, atol=1e-05)
+ 
++    def test_bitwise_not(self):
++        paddle.disable_static()
++        x_np = np.random.randint(-100, 100, [2, 3, 5]).astype("int32")
++        res_np_b = ~x_np
++        res_np_c = paddle.bitwise_not(paddle.to_tensor(x_np))
++        res_np_d = x_np.__invert__()
++        paddle.enable_static()
++        with paddle.pir_utils.IrGuard():
++            main_program, exe, program_guard = new_program()
++            with program_guard:
++                x = paddle.static.data(name='x', shape=[2, 3, 5], dtype='int32')
++                b = ~x
++                c = x.bitwise_not()
++                d = x.__invert__()
++                (b_np, c_np, d_np) = exe.run(
++                    main_program,
++                    feed={"x": x_np},
++                    fetch_list=[b, c, d],
++                )
++                np.testing.assert_array_equal(res_np_b, b_np)
++                np.testing.assert_array_equal(res_np_c, c_np)
++                np.testing.assert_array_equal(res_np_d, d_np)
++
++    def test_bitwise_xor(self):
++        paddle.disable_static()
++        x_np = np.random.randint(-100, 100, [2, 3, 5]).astype("int32")
++        y_np = np.random.randint(-100, 100, [2, 3, 5]).astype("int32")
++        res_np_b = x_np ^ y_np
++        res_np_c = paddle.bitwise_xor(
++            paddle.to_tensor(x_np), paddle.to_tensor(y_np)
++        )
++        res_np_d = x_np.__xor__(y_np)
++        paddle.enable_static()
++        with paddle.pir_utils.IrGuard():
++            main_program, exe, program_guard = new_program()
++            with program_guard:
++                x = paddle.static.data(name="x", shape=[2, 3, 5], dtype="int32")
++                y = paddle.static.data(name="y", shape=[2, 3, 5], dtype="int32")
++                b = x ^ y
++                c = x.bitwise_xor(y)
++                d = x.__xor__(y)
++                (b_np, c_np, d_np) = exe.run(
++                    main_program,
++                    feed={"x": x_np, "y": y_np},
++                    fetch_list=[b, c, d],
++                )
++                np.testing.assert_array_equal(res_np_b, b_np)
++                np.testing.assert_array_equal(res_np_c, c_np)
++                np.testing.assert_array_equal(res_np_d, d_np)
++
++    def test_bitwise_or(self):
++        paddle.disable_static()
++        x_np = np.random.randint(-100, 100, [2, 3, 5]).astype("int32")
++        y_np = np.random.randint(-100, 100, [2, 3, 5]).astype("int32")
++        res_np_b = x_np | y_np
++        res_np_c = paddle.bitwise_or(
++            paddle.to_tensor(x_np), paddle.to_tensor(y_np)
++        )
++        res_np_d = x_np.__or__(y_np)
++        paddle.enable_static()
++        with paddle.pir_utils.IrGuard():
++            main_program, exe, program_guard = new_program()
++            with program_guard:
++                x = paddle.static.data(name="x", shape=[2, 3, 5], dtype="int32")
++                y = paddle.static.data(name="y", shape=[2, 3, 5], dtype="int32")
++                b = x | y
++                c = x.bitwise_or(y)
++                d = x.__or__(y)
++                (b_np, c_np, d_np) = exe.run(
++                    main_program,
++                    feed={"x": x_np, "y": y_np},
++                    fetch_list=[b, c, d],
++                )
++                np.testing.assert_array_equal(res_np_b, b_np)
++                np.testing.assert_array_equal(res_np_c, c_np)
++                np.testing.assert_array_equal(res_np_d, d_np)
++
++    def test_bitwise_and(self):
++        paddle.disable_static()
++        x_np = np.random.randint(-100, 100, [2, 3, 5]).astype("int32")
++        y_np = np.random.randint(-100, 100, [2, 3, 5]).astype("int32")
++        res_np_b = x_np & y_np
++        res_np_c = paddle.bitwise_and(
++            paddle.to_tensor(x_np), paddle.to_tensor(y_np)
++        )
++        res_np_d = x_np.__and__(y_np)
++        paddle.enable_static()
++        with paddle.pir_utils.IrGuard():
++            main_program, exe, program_guard = new_program()
++            with program_guard:
++                x = paddle.static.data(name="x", shape=[2, 3, 5], dtype="int32")
++                y = paddle.static.data(name="y", shape=[2, 3, 5], dtype="int32")
++                b = x & y
++                c = x.bitwise_and(y)
++                d = x.__and__(y)
++                (b_np, c_np, d_np) = exe.run(
++                    main_program,
++                    feed={"x": x_np, "y": y_np},
++                    fetch_list=[b, c, d],
++                )
++                np.testing.assert_array_equal(res_np_b, b_np)
++                np.testing.assert_array_equal(res_np_c, c_np)
++                np.testing.assert_array_equal(res_np_d, d_np)
++
++    # for logical compare
++    def test_equal_and_nequal(self):
++        paddle.disable_static()
++        x_np = np.array([3, 4, 10, 14, 9, 18]).astype('float32')
++        y_np = np.array([3, 4, 11, 15, 8, 18]).astype('float32')
++        # TODO(gouzil): Open after deleting c++ logic
++        # res_np_b = x_np == y_np
++        # res_np_c = paddle.equal(paddle.to_tensor(x_np), paddle.to_tensor(y_np))
++        # res_np_d = x_np.__eq__(y_np)
++        res_np_e = x_np != y_np
++        res_np_f = paddle.not_equal(
++            paddle.to_tensor(x_np), paddle.to_tensor(y_np)
++        )
++        res_np_g = x_np.__ne__(y_np)
++        paddle.enable_static()
++        with paddle.pir_utils.IrGuard():
++            main_program, exe, program_guard = new_program()
++            with program_guard:
++                x = paddle.static.data(name="x", shape=[-1, 1], dtype='float32')
++                y = paddle.static.data(name="y", shape=[-1, 1], dtype='float32')
++                # b = x == y
++                # c = x.equal(y)
++                # d = x.__eq__(y)
++                e = x != y
++                f = x.not_equal(y)
++                g = x.__ne__(y)
++                (e_np, f_np, g_np) = exe.run(
++                    main_program,
++                    feed={"x": x_np, "y": y_np},
++                    fetch_list=[e, f, g],
++                )
++                # np.testing.assert_array_equal(res_np_b, b_np)
++                # np.testing.assert_array_equal(res_np_c, c_np)
++                # np.testing.assert_array_equal(res_np_d, d_np)
++                np.testing.assert_array_equal(res_np_e, e_np)
++                np.testing.assert_array_equal(res_np_f, f_np)
++                np.testing.assert_array_equal(res_np_g, g_np)
++
++    def test_less(self):
++        paddle.disable_static()
++        x_np = np.array([3, 4, 10, 14, 9, 18]).astype('float32')
++        y_np = np.array([3, 4, 11, 15, 8, 18]).astype('float32')
++        z_np = np.array([3, 4, 10, 14, 9, 18]).astype('float32')
++        res_np_b = x_np < y_np
++        res_np_c = paddle.less_than(
++            paddle.to_tensor(x_np), paddle.to_tensor(y_np)
++        )
++        res_np_d = x_np.__lt__(y_np)
++        res_np_e = x_np <= y_np
++        res_np_f = paddle.less_equal(
++            paddle.to_tensor(x_np), paddle.to_tensor(y_np)
++        )
++        res_np_g = x_np.__le__(y_np)
++        res_np_h = x_np <= z_np
++        paddle.enable_static()
++        with paddle.pir_utils.IrGuard():
++            main_program, exe, program_guard = new_program()
++            with program_guard:
++                x = paddle.static.data(name="x", shape=[-1, 1], dtype='float32')
++                y = paddle.static.data(name="y", shape=[-1, 1], dtype='float32')
++                z = paddle.static.data(name="z", shape=[-1, 1], dtype='float32')
++                b = x < y
++                c = x.less_than(y)
++                d = x.__lt__(y)
++                e = x <= y
++                f = x.less_equal(y)
++                g = x.__le__(y)
++                h = x <= z
++                (b_np, c_np, d_np, e_np, f_np, g_np, h_np) = exe.run(
++                    main_program,
++                    feed={"x": x_np, "y": y_np, "z": z_np},
++                    fetch_list=[b, c, d, e, f, g, h],
++                )
++                np.testing.assert_array_equal(res_np_b, b_np)
++                np.testing.assert_array_equal(res_np_c, c_np)
++                np.testing.assert_array_equal(res_np_d, d_np)
++                np.testing.assert_array_equal(res_np_e, e_np)
++                np.testing.assert_array_equal(res_np_f, f_np)
++                np.testing.assert_array_equal(res_np_g, g_np)
++                np.testing.assert_array_equal(res_np_h, h_np)
++
++    def test_greater(self):
++        paddle.disable_static()
++        x_np = np.array([3, 4, 10, 14, 9, 18]).astype('float32')
++        y_np = np.array([3, 4, 11, 15, 8, 18]).astype('float32')
++        z_np = np.array([3, 4, 10, 14, 9, 18]).astype('float32')
++        res_np_b = x_np > y_np
++        res_np_c = paddle.greater_than(
++            paddle.to_tensor(x_np), paddle.to_tensor(y_np)
++        )
++        res_np_d = x_np.__gt__(y_np)
++        res_np_e = x_np >= y_np
++        res_np_f = paddle.greater_equal(
++            paddle.to_tensor(x_np), paddle.to_tensor(y_np)
++        )
++        res_np_g = x_np.__ge__(y_np)
++        res_np_h = x_np >= z_np
++        paddle.enable_static()
++        with paddle.pir_utils.IrGuard():
++            main_program, exe, program_guard = new_program()
++            with program_guard:
++                x = paddle.static.data(name="x", shape=[-1, 1], dtype='float32')
++                y = paddle.static.data(name="y", shape=[-1, 1], dtype='float32')
++                z = paddle.static.data(name="z", shape=[-1, 1], dtype='float32')
++                b = x > y
++                c = x.greater_than(y)
++                d = x.__gt__(y)
++                e = x >= y
++                f = x.greater_equal(y)
++                g = x.__ge__(y)
++                h = x >= z
++                (b_np, c_np, d_np, e_np, f_np, g_np, h_np) = exe.run(
++                    main_program,
++                    feed={"x": x_np, "y": y_np, "z": z_np},
++                    fetch_list=[b, c, d, e, f, g, h],
++                )
++                np.testing.assert_array_equal(res_np_b, b_np)
++                np.testing.assert_array_equal(res_np_c, c_np)
++                np.testing.assert_array_equal(res_np_d, d_np)
++                np.testing.assert_array_equal(res_np_e, e_np)
++                np.testing.assert_array_equal(res_np_f, f_np)
++                np.testing.assert_array_equal(res_np_g, g_np)
++                np.testing.assert_array_equal(res_np_h, h_np)
++
+     def test_item(self):
+         with paddle.pir_utils.IrGuard():
+             x = paddle.static.data(name='x', shape=[3, 2, 1])

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-58343/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-58343/tests/test.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run from the root of a PaddlePaddle/Paddle source checkout.
+export PYTHONPATH="test/legacy_test${PYTHONPATH:+:${PYTHONPATH}}"
+PYTHON_BIN="${PYTHON_BIN:-python}"
+
+# P2P: existing regression coverage, unchanged by the gold patch.
+"${PYTHON_BIN}" -m pytest -v \
+  test/legacy_test/test_math_op_patch_pir.py::TestMathOpPatchesPir::test_less \
+  test/legacy_test/test_math_op_patch_pir.py::TestMathOpPatchesPir::test_greater \
+  test/legacy_test/test_math_op_patch_pir.py::TestMathOpPatchesPir::test_mod \
+  test/legacy_test/test_math_op_patch_pir.py::TestMathOpPatchesPir::test_matmul \
+  test/legacy_test/test_math_op_patch_pir.py::TestMathOpPatchesPir::test_floordiv \
+  test/legacy_test/test_math_op_patch_pir.py::TestMathOpPatchesPir::test_item \
+  test/legacy_test/test_math_op_patch_pir.py::TestMathOpPatchesPir::test_place \
+  test/legacy_test/test_math_op_patch_pir.py::TestMathOpPatchesPir::test_some_dim \
+  test/legacy_test/test_math_op_patch_pir.py::TestMathOpPatchesPir::test_math_exists
+
+# F2P: target behavior added by the gold patch.
+"${PYTHON_BIN}" -m pytest -v \
+  test/legacy_test/test_math_op_patch_pir.py::TestMathOpPatchesPir::test_pow \
+  test/legacy_test/test_math_op_patch_pir.py::TestMathOpPatchesPir::test_bitwise_not \
+  test/legacy_test/test_math_op_patch_pir.py::TestMathOpPatchesPir::test_bitwise_xor \
+  test/legacy_test/test_math_op_patch_pir.py::TestMathOpPatchesPir::test_bitwise_or \
+  test/legacy_test/test_math_op_patch_pir.py::TestMathOpPatchesPir::test_bitwise_and \
+  test/legacy_test/test_math_op_patch_pir.py::TestMathOpPatchesPir::test_equal_and_nequal


### PR DESCRIPTION
## 背景

本 PR 新增一个由 PaddlePaddle/Paddle PR #58343 转换而来的 SWE-Paddle 候选任务。原 PR 为 PIR `OpResult` 补充了标量幂、位运算和不等比较能力；修复前，即使 Paddle 已提供对应的 Tensor API，PIR 静态图用户仍无法一致地使用这些 Python 运算符。

任务固定在 Paddle 基线提交 `2c45c5eb70e14413d7a00aa75272e28e3c9b6862`，gold 提交为 `0d13cc84fed00d453b27789f94acb5f35afafed9`。

## 根因与任务范围

历史实现存在三个问题：PIR `OpResult` 未注册所需的 Python 魔术方法；标量幂使用了与 PIR 不兼容的常量构造路径；多个位运算 API 仅在动态图模式下进入正确分支。因此，任务要求在共享的 Python 实现路径中补齐这些能力。

`__eq__` 被明确排除在任务范围外，因为 Paddle 内部依赖它现有的对象比较语义，直接改成逐元素相等会破坏内部集合和对象比较逻辑。

任务包包含自洽的任务说明与候选提案、从 base 到 gold 的精确实现补丁和测试补丁、CPU 环境说明，以及使用精确 pytest nodeid 的验证脚本。

## 验证设计

验证脚本先运行 9 个 P2P 回归用例，再运行 6 个 F2P 目标用例。脚本自行设置 legacy test 所需的 `PYTHONPATH`，支持通过 `PYTHON_BIN` 指定 Python，并在同一次 pytest 调用中执行全部 F2P，确保基线能够完整记录 6 个失败，而不是遇到首个失败后提前退出。

已完成以下验证：

- `tests/test.sh` 通过 `bash -n` 语法检查。
- 两个 patch 与指定文件从 base 到 gold 的原始 diff 完全一致。
- 两个 patch 均可干净应用到精确基线提交。
- 在文档指定的 `paddlepaddle/paddle:2.6.0` 兼容运行时中，base 加测试补丁得到 9 个 P2P 通过、6 个 F2P 失败。
- 在全新容器中继续应用 gold 补丁后，同一验证脚本得到 9 个 P2P 通过、6 个 F2P 通过。

本任务不需要 GPU、外部服务或原生代码重新编译。
