### PR TITLE
[SWE-Paddle] Further Fix PaddlePaddle__Paddle-78441

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78441/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78441/README.md
@@ -26,7 +26,7 @@ The gold change includes operator schemas and code generation inputs, infermeta,
 
 ## Test Classification
 
-- **F2P:** the new `test/legacy_test/test_aminmax_op.py` suite and `test/ir/pir/cinn/symbolic/test_infer_sym_shape_unary_op.py::AminmaxOpInferSymbolicShapeTest`. They fail on the base build and pass after applying `solution/code.patch` and rebuilding.
+- **F2P:** the 26 cases in the new `test/legacy_test/test_aminmax_op.py` suite plus `test/ir/pir/cinn/symbolic/test_infer_sym_shape_unary_op.py::AminmaxOpInferSymbolicShapeTest`, 27 nodes in total. They fail on the base build and pass after applying `solution/code.patch` and rebuilding. The symbolic-shape node only reports the `sym_shape_str` attribute it asserts on when it runs under the upstream FLAGS environment, which `tests/test.sh` now sets; see the verification notes below.
 - **P2P:** four existing amin/amax regression nodes in `test/legacy_test/test_max_min_amax_amin_op.py`:
   - `TestAmaxAPI_Compatibility::test_dygraph_Compatibility`
   - `TestAminAPI_Compatibility::test_dygraph_Compatibility`
@@ -42,7 +42,7 @@ The gold change includes operator schemas and code generation inputs, infermeta,
 - `environment/README.md`: source-build and reproduction instructions.
 - `solution/code.patch`: exact non-test diff from base to gold commit.
 - `tests/test.patch`: exact test-only diff from base to gold commit.
-- `tests/test.sh`: wrapper that sets the required per-suite `PYTHONPATH`, runs the four amin/amax P2P nodes, then runs the new legacy and symbolic-shape F2P targets.
+- `tests/test.sh`: wrapper that sets the required per-suite `PYTHONPATH` and the symbolic-shape FLAGS environment, runs the four amin/amax P2P nodes, then runs the new legacy and symbolic-shape F2P targets.
 
 ## Verification
 
@@ -58,5 +58,7 @@ On `base_commit + tests/test.patch`, the four P2P nodes must pass and both F2P t
 
 - legacy operator tests need `test/legacy_test` and `test` on `PYTHONPATH`;
 - the symbolic-shape test needs `test/ir/pir/cinn` before any directory containing the other `utils.py`, plus its own `test/ir/pir/cinn/symbolic` directory.
+
+It also exports `FLAGS_check_infer_symbolic=1 FLAGS_enable_pir_api=1 FLAGS_prim_enable_dynamic=true FLAGS_prim_all=True FLAGS_cinn_new_group_scheduler=1` for the symbolic-shape node, mirroring how `test/ir/pir/cinn/symbolic/CMakeLists.txt` registers that file. Without those flags the node raises `KeyError: 'sym_shape_str'` on the gold build too, because the attribute it reads is only attached when `CheckInferSymbolicIfNeed` actually runs the shape optimization pass.
 
 A pre-existing release or nightly wheel cannot validate this task because the change introduces a compiled operator and updates build-time code-generation inputs.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78441/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78441/environment/README.md
@@ -14,7 +14,7 @@
 
 Start with a clean checkout at the exact base commit and initialize its submodules. A release or nightly wheel is insufficient: the implementation adds compiled kernels and changes build-time operator schemas, generated bindings, infermeta, and symbolic-shape registration.
 
-Build Paddle from source after applying `solution/code.patch`. A CPU build is sufficient for benchmark acceptance; GPU hardware is not required. Keep the build configuration capable of running legacy Python operator tests and PIR symbolic-shape tests. The upstream test module also contains a CINN dynamic-shape case, so enable CINN when the target environment supports that test dependency. If CINN is unavailable, report that limitation rather than treating a skipped or uncollectable case as complete verification.
+Build Paddle from source after applying `solution/code.patch`. A CPU build is sufficient for benchmark acceptance; GPU hardware is not required. `-DWITH_CINN=ON` is required, not optional: `TestAminmaxDynamicShape::test_all_dynamic` requests the CINN backend and `paddle.base.libpaddle.pir.apply_cinn_pass` raises `Unimplemented("... please compile PaddlePaddle with CINN")` without it, and the symbolic-shape node needs the same build option for `check_infer_symbolic_if_need` to be more than a no-op. If CINN is unavailable, report that limitation rather than treating a skipped or uncollectable case as complete verification.
 
 A typical CPU configuration is:
 
@@ -68,7 +68,7 @@ If the build system produces a wheel tagged for a different Python ABI, install 
    - `TestAminAPI_Compatibility::test_dygraph_Compatibility`
    - `TestAmaxAminOutAPI::test_amax_out_in_dygraph`
    - `TestAmaxAminOutAPI::test_amin_out_in_dygraph`
-2. F2P legacy target: `test/legacy_test/test_aminmax_op.py`.
+2. F2P legacy target: the 26 cases in `test/legacy_test/test_aminmax_op.py`.
 3. F2P symbolic-shape target: `test/ir/pir/cinn/symbolic/test_infer_sym_shape_unary_op.py::AminmaxOpInferSymbolicShapeTest`.
 
 For the legacy suites, `PYTHONPATH` includes `test/legacy_test` and `test` so `op_test`, `utils`, and `white_list` imports resolve. For the symbolic-shape suite, `PYTHONPATH` includes `test/ir/pir/cinn` and `test/ir/pir/cinn/symbolic`, with the CINN/PIR directory first because it and `test/legacy_test` both contain a module named `utils.py`.
@@ -77,12 +77,35 @@ The wrapper runs both F2P suites even when the first one fails, so the Base run 
 
 Expected post-fix results are passing forward, gradient, API compatibility, static/dynamic, output-tensor, dynamic-shape, and symbolic-shape cases, with all four amin/amax P2P nodes passing before and after the fix.
 
+## FLAGS required by the symbolic-shape node
+
+`AminmaxOpInferSymbolicShapeTest` asserts on the `sym_shape_str` attribute that `check_infer_results` reads from each `pd_op.aminmax` operation. That attribute is written by `pir::shape::SetShapeAttrForOp` from the shape optimization pass, and on the `@to_static` path used by this test the pass is only added by `cinn::dialect::ir::CheckInferSymbolicIfNeed`, reached through `paddle.base.libpaddle.pir.check_infer_symbolic_if_need`. Two conditions gate it:
+
+- the binding compiles to `// Do nothing.` unless `PADDLE_WITH_CINN` is defined, so the build must be configured with `-DWITH_CINN=ON`;
+- `CheckInferSymbolicIfNeed` returns early unless `FLAGS_prim_forward`, `FLAGS_prim_backward` and `FLAGS_check_infer_symbolic` are all set. Setting the environment variable `FLAGS_prim_all=True` sets both prim flags.
+
+When either condition is missing the node fails with `KeyError: 'sym_shape_str'` on the gold revision as well, which is a harness gap rather than a gap in `solution/code.patch`: that patch does implement `AminmaxOpInferSymbolicShape` and does add `paddle::dialect::InferSymbolicShapeInterface` to the op in `ops.yaml`.
+
+`tests/test.sh` therefore runs the node with the same FLAGS environment that `test/ir/pir/cinn/symbolic/CMakeLists.txt` uses for this file:
+
+```bash
+FLAGS_check_infer_symbolic=1 FLAGS_enable_pir_api=1 \
+  FLAGS_prim_enable_dynamic=true FLAGS_prim_all=True \
+  FLAGS_cinn_new_group_scheduler=1
+```
+
+Upstream additionally wraps that whole `CMakeLists.txt` in `if(WITH_GPU)` and labels the tests `RUN_TYPE=CINN`, so a GPU + CINN build is the configuration the node was written against. A CPU build with `-DWITH_CINN=ON` is the minimum this task needs.
+
 ## Local validation note
 
 - `test/legacy_test/test_max_min_amax_amin_op.py` is byte-for-byte unchanged between the base and gold revisions.
 - With an installed compatible CPU runtime and the exact base test sources, the four selected P2P nodes passed (`4 passed`).
 - With the legacy `PYTHONPATH` configured by `tests/test.sh`, `test_aminmax_op.py` collected successfully and then failed at `AttributeError: module 'paddle' has no attribute 'aminmax'`, which is the expected base-like signal on a runtime without the gold patch.
-- With the CINN/PIR `PYTHONPATH` configured by `tests/test.sh`, `AminmaxOpInferSymbolicShapeTest` collected successfully.
+- With the CINN/PIR `PYTHONPATH` configured by `tests/test.sh`, `AminmaxOpInferSymbolicShapeTest` collected successfully. Running it without the FLAGS environment reproduces `KeyError: 'sym_shape_str'` regardless of which revision is installed, which is why `tests/test.sh` now exports the same flags that upstream's CTest registration uses.
+
+The FLAGS change itself was derived from the gold revision's source rather than from a local run. CINN cannot be built on Windows, where the work was done: `cmake/cinn/external/llvm.cmake`, `isl.cmake` and `ginac.cmake` fetch glibc-only Linux archives, and the available local build reports `paddle.is_compiled_with_cinn() == False`, so the node cannot reach a passing state there under any flag combination. What the source does establish is that the gate in `CheckInferSymbolicIfNeed` is the only thing standing between the node and the attribute it reads; that `aminmax` has no prim decomposition rule, so `FLAGS_prim_all` cannot remove `pd_op.aminmax` from the program and make the assertion vacuous; and that the base revision exposes no `paddle.aminmax` at all, so the node stays Base-red with or without the flags. The preceding validation round also reported `TestAminmaxDynamicShape::test_all_dynamic` as Gold-green, and that case requests `backend="CINN"` while `ApplyCinnPass` raises `Unimplemented` without `PADDLE_WITH_CINN`, which indicates the validation environment does have CINN compiled in. A confirming two-round run on such an environment is still required.
+
+If the node still fails there, the fallback is to drop it from the F2P set and reclassify it rather than to make it conditional: a node that disappears when CINN is absent would make the F2P set depend on the environment. The symbolic-shape registration it targets would stay covered by `test_aminmax_op.py::TestAminmaxInferSymbolicShapePass::test_infer_symbolic_shape_pass`, which calls `paddle.base.libpaddle.pir.infer_symbolic_shape_pass` directly and needs neither a CINN build nor extra flags.
 
 ## Limitations
 

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-78441/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-78441/tests/test.sh
@@ -26,7 +26,21 @@ fi
 # The symbolic-shape suite needs a different utils.py. Keep the CINN/PIR
 # directory ahead of the legacy test directory because both modules are named
 # utils.py.
+#
+# It also needs the same FLAGS environment that upstream's CTest registration
+# uses. check_infer_results reads the op attribute `sym_shape_str`, which is
+# attached by the shape optimization pass that CheckInferSymbolicIfNeed adds,
+# and that function returns early unless FLAGS_prim_forward,
+# FLAGS_prim_backward and FLAGS_check_infer_symbolic are all set
+# (FLAGS_prim_all sets the two prim flags). Without them the node raises
+# KeyError: 'sym_shape_str' on the gold build as well. The flags below mirror
+# test/ir/pir/cinn/symbolic/CMakeLists.txt.
 if ! PYTHONPATH="$repo_root/test/ir/pir/cinn:$repo_root/test/ir/pir/cinn/symbolic${PYTHONPATH:+:$PYTHONPATH}" \
+  FLAGS_check_infer_symbolic=1 \
+  FLAGS_enable_pir_api=1 \
+  FLAGS_prim_enable_dynamic=true \
+  FLAGS_prim_all=True \
+  FLAGS_cinn_new_group_scheduler=1 \
   "$PYTHON_BIN" -m pytest \
   test/ir/pir/cinn/symbolic/test_infer_sym_shape_unary_op.py::AminmaxOpInferSymbolicShapeTest \
   -q; then


### PR DESCRIPTION
接 #1437、#1545。核心验证报告 `F2P 26 / 27 · P2P 4 · Gold 1F`：只有
`test/ir/pir/cinn/symbolic/test_infer_sym_shape_unary_op.py::AminmaxOpInferSymbolicShapeTest`
在 Gold 上仍抛 `KeyError: 'sym_shape_str'`，两轮 RC 均为 1。

## 原因

问题在 wrapper，不在 `solution/code.patch` —— 后者已实现 `AminmaxOpInferSymbolicShape`
并在 `ops.yaml` 注册了 `InferSymbolicShapeInterface`。

`check_infer_results` 读的 `sym_shape_str` 属性由 shape optimization pass 写入；该测试走
`@to_static` 的 PHI 路径，这条路径上只有 `cinn::dialect::ir::CheckInferSymbolicIfNeed`
会挂载这个 pass，而它开头即：

```cpp
if (!(FLAGS_prim_forward && FLAGS_prim_backward) || !FLAGS_check_infer_symbolic) return;

原 tests/test.sh 用裸 pytest 调用，一个 FLAG 都没设，pass 从不执行，属性自然不存在。

改动

- tests/test.sh：按 test/ir/pir/cinn/symbolic/CMakeLists.txt 注册该文件的方式补齐
  FLAGS_check_infer_symbolic=1 FLAGS_enable_pir_api=1 FLAGS_prim_enable_dynamic=true FLAGS_prim_all=True FLAGS_cinn_new_group_scheduler=1。FLAGS 仅作用于该 pytest 进程，
  27 个 F2P 节点全部保留。
- environment/README.md：记录该 FLAGS 门控；并说明 -DWITH_CINN=ON 为必需而非可选
  （check_infer_symbolic_if_need 无 PADDLE_WITH_CINN 时编译为 no-op）。
- README.md：F2P 分类写明 26 + 1 = 27 个节点。

@sunzhongkai588  Thx