### PR TITLE
fix(swe-paddle-52948): avoid nested python.paddle pytest entry

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-52948/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-52948/environment/README.md
@@ -38,6 +38,10 @@ bash tests/test.sh
 - Historical (2023-04) wheels may be hard to pin exactly; if using a newer
   wheel, confirm `to_static` / static Variable APIs still match the base-era
   contracts exercised by the tests.
+- Do not invoke pytest on `python/paddle/fluid/tests/unittests/...` from the
+  repo root: that nests `python.paddle` and can trigger VarBase double
+  registration against an installed paddle. `tests/test.sh` cds into the
+  unittest directory and loads the file as a flat module.
 - `test_hook_in_init_for_layer` uses random input; prefer fixed seeds when
   deriving stable F2P / P2P node IDs.
 - Gold patch is the **net** of #52948 and #53572 relative to the base commit

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-52948/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-52948/tests/test.sh
@@ -3,7 +3,20 @@ set -euo pipefail
 
 # Target tests for PaddlePaddle__Paddle-52948 (#52948 + #53572).
 # Run from the root of a PaddlePaddle/Paddle checkout with Paddle importable.
-python -m pytest \
-  test/dygraph_to_static/test_tensor_hook.py \
-  python/paddle/fluid/tests/unittests/test_tensor_register_hook.py \
-  -q
+#
+# Do NOT pass python/paddle/... paths to pytest from the repo root: pytest then
+# nests imports as python.paddle and can re-register VarBase against the
+# installed paddle (double registration). Run the fluid unittest from its
+# own directory as a flat module instead.
+
+python -m pytest test/dygraph_to_static/test_tensor_hook.py -q
+
+(
+  cd python/paddle/fluid/tests/unittests
+  # Prefer importlib mode so parents of this dir are not added as packages.
+  if python -m pytest --help 2>/dev/null | grep -q -- '--import-mode'; then
+    python -m pytest test_tensor_register_hook.py -q --import-mode=importlib
+  else
+    python -m unittest test_tensor_register_hook
+  fi
+)


### PR DESCRIPTION
Run fluid register_hook tests from their unittest directory as a flat module so VarBase is not double-registered against the installed paddle.