### PR TITLE
fix(swe-paddle-59383): add legacy_test and white_list to PYTHONPATH

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-59383/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-59383/environment/README.md
@@ -34,5 +34,10 @@ bash tests/test.sh
 
 - Historical wheels around 2023-12 may be hard to pin exactly; confirm
   `paddle.where` / basic dygraph+static APIs still match the exercised contracts.
+- `tests/test.sh` must put `test/legacy_test` and `test` on `PYTHONPATH` so
+  `op_test` / `white_list` resolve during collection. Without that, the original
+  entry fails before any F2P assertion runs.
+- CUDA / BF16 cases in `test_masked_scatter.py` use `@unittest.skipIf` on
+  CPU-only builds; skips are not passes.
 - Gold is the **net** of #59383 and #60835 relative to the base commit
   (sequential PR diffs on base; not a raw `base..later-merge` tree diff).

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-59383/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-59383/tests/test.sh
@@ -3,6 +3,13 @@ set -euo pipefail
 
 # Target tests for PaddlePaddle__Paddle-59383 (#59383 + #60835).
 # Run from the root of a PaddlePaddle/Paddle checkout with Paddle importable.
+#
+# test_masked_scatter.py imports op_test, and op_test imports white_list.
+# Both live under the test tree, so PYTHONPATH must include:
+#   - test/legacy_test  -> op_test
+#   - test              -> white_list package
+export PYTHONPATH="test/legacy_test:test${PYTHONPATH:+:${PYTHONPATH}}"
+
 python -m pytest \
   test/legacy_test/test_masked_scatter.py \
   test/legacy_test/test_inplace.py \


### PR DESCRIPTION
test_masked_scatter imports op_test, which imports white_list. Put test/legacy_test and test on PYTHONPATH so the original pytest entry can collect without ModuleNotFoundError.