### PR TITLE
[SWE-Paddle] fix tasks test.sh

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-72800/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-72800/tests/test.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Resolve repository root directory
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# Add repo root and test/legacy_test to PYTHONPATH
+export PYTHONPATH="${REPO_ROOT}:${REPO_ROOT}/test/legacy_test:${PYTHONPATH:-}"
+
 # P2P tests (pass-to-pass)
 python -m pytest test/legacy_test/test_cummax_op.py::TestCummaxOp -q
 python -m pytest test/legacy_test/test_cummin_op.py::TestCumminOp -q

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73125/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73125/tests/test.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Resolve repository root directory
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# Add repo root and test/legacy_test to PYTHONPATH
+export PYTHONPATH="${REPO_ROOT}:${REPO_ROOT}/test/legacy_test:${PYTHONPATH:-}"
+
 # P2P tests (pass-to-pass)
 python -m pytest test/legacy_test/test_determinant_op.py::TestDeterminantOp -q
 python -m pytest test/legacy_test/test_determinant_op.py::TestSlogDeterminantOp -q

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73385/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73385/tests/test.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Resolve repository root directory
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# Add repo root and test/legacy_test to PYTHONPATH
+export PYTHONPATH="${REPO_ROOT}:${REPO_ROOT}/test/legacy_test:${PYTHONPATH:-}"
+
 # P2P tests (pass-to-pass)
 python -m pytest test/legacy_test/test_eigvals_op.py::TestEigvalsOp -q
 python -m pytest test/legacy_test/test_svdvals_op.py::TestSvdvalsOp -q

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73387/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73387/tests/test.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Resolve repository root directory
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# Add repo root and test/legacy_test to PYTHONPATH
+export PYTHONPATH="${REPO_ROOT}:${REPO_ROOT}/test/legacy_test:${PYTHONPATH:-}"
+
 # P2P tests (pass-to-pass)
 python -m pytest test/legacy_test/test_gather_tree_op.py::TestGatherTreeOp -q
 

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73535/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73535/tests/test.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Resolve repository root directory
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# Add repo root and test/legacy_test to PYTHONPATH
+export PYTHONPATH="${REPO_ROOT}:${REPO_ROOT}/test/legacy_test:${PYTHONPATH:-}"
+
 # P2P tests (pass-to-pass)
 python -m pytest test/legacy_test/test_functional_conv1d.py::TestFunctionalConv1DError -q
 

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-73569/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-73569/tests/test.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Resolve repository root directory
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# Add repo root and test/legacy_test to PYTHONPATH
+export PYTHONPATH="${REPO_ROOT}:${REPO_ROOT}/test/legacy_test:${PYTHONPATH:-}"
+
 # P2P tests (pass-to-pass)
 python -m pytest test/legacy_test/test_matmul_v2_op.py::TestMatMulV2Op -q
 

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-74184/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-74184/tests/test.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Resolve repository root directory
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# Add repo root and test/legacy_test to PYTHONPATH
+export PYTHONPATH="${REPO_ROOT}:${REPO_ROOT}/test/legacy_test:${PYTHONPATH:-}"
+
 # P2P tests (pass-to-pass)
 python -m pytest test/legacy_test/test_linalg_pinv_op.py::LinalgPinvTestCase -q
 

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-74212/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-74212/tests/test.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Resolve repository root directory
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# Add repo root and test/legacy_test to PYTHONPATH
+export PYTHONPATH="${REPO_ROOT}:${REPO_ROOT}/test/legacy_test:${PYTHONPATH:-}"
+
 # P2P tests (pass-to-pass)
 python -m pytest test/legacy_test/test_multiplex_op.py::TestMultiplexOp -q
 

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-74221/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-74221/tests/test.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Resolve repository root directory
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# Add repo root and test/legacy_test to PYTHONPATH
+export PYTHONPATH="${REPO_ROOT}:${REPO_ROOT}/test/legacy_test:${PYTHONPATH:-}"
+
 # P2P tests (pass-to-pass)
 python -m pytest test/legacy_test/test_fold_op.py::TestFoldOp -q
 

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-74305/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-74305/tests/test.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Resolve repository root directory
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# Add repo root and test/legacy_test to PYTHONPATH
+export PYTHONPATH="${REPO_ROOT}:${REPO_ROOT}/test/legacy_test:${PYTHONPATH:-}"
+
 # P2P tests (pass-to-pass)
 python -m pytest test/legacy_test/test_unique.py::TestUniqueOp -q
 


### PR DESCRIPTION
Tasks: 72800, 73125, 73385, 73387, 73535, 73569, 74184, 74212, 74221, 74305
修复任务中test.sh的路径配置
<img width="750" height="386" alt="image" src="https://github.com/user-attachments/assets/7816290e-4573-49ec-a7ff-5a0cd3b6674a" />
