### PR TITLE
[SWE-Paddle] Add task PaddlePaddle__Paddle-79657

### DIFF
--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79657/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79657/README.md
@@ -1,0 +1,55 @@
+# PaddlePaddle__Paddle-79657
+
+This directory converts Paddle PR #79657 into a SWE-Paddle community task candidate.
+
+## Source
+
+| Field | Value |
+| --- | --- |
+| Repo | `PaddlePaddle/Paddle` |
+| PR | [79657](https://github.com/PaddlePaddle/Paddle/pull/79657) |
+| PR title | `[Operator Mechanism] Fix paddle.compat.min/max gradient indexing` |
+| Base commit | `16037ff1effb88625041f9a1c540e8b2af3ab5c1` |
+| Gold commit | `20519ee630ec4929776b33341f690adc2fc48001` |
+| Merged at | `2026-08-17` |
+| Task type | `bug_fix` |
+| Resource | Single NVIDIA GPU |
+
+## Summary
+
+Fixed incorrect gradient indexing in `paddle.compat.min/max` on CUDA when `keepdim=False` and the reduction axis is not trailing. The upstream gradient elements were not routed to the correct input positions, producing wrong backward results.
+
+## Why This Is A Good SWE-Paddle Candidate
+
+- It targets a real GPU backward indexing defect in the `paddle.compat` API layer.
+- It requires understanding reduction shape alignment, `keepdim` semantics, and CUDA kernel gradient routing.
+- The scope is well-bounded: only CUDA backward with `keepdim=False` and non-trailing axes is affected.
+- Forward behavior, `keepdim=True`, trailing-axis, and CPU paths are unaffected and must be preserved.
+
+## Verification Matrix
+
+| State | P2P tests | F2P tests |
+| --- | --- | --- |
+| Base (`16037ff`) | PASS | FAIL |
+| Gold (`20519ee`) | PASS | PASS |
+
+- **P2P** (pass-to-pass): existing elementwise min/max, `keepdim=True` backward, trailing-axis backward, forward shape and values.
+- **F2P** (fail-to-pass): CUDA backward with `keepdim=False` and non-trailing axes for both `min` and `max`, including positive and negative axis indices with nonuniform upstream gradients.
+
+## Files
+
+- `proposal.md`: candidate proposal for maintainer triage.
+- `instruction.md`: self-contained problem statement for the coding agent.
+- `solution/code.patch`: gold patch from the merged PR.
+- `tests/test.patch`: independent test patch exposing the target behavior.
+- `tests/test.sh`: minimal target test command.
+- `environment/README.md`: environment notes for reproduction.
+- `README.md`: task overview and verification entrypoint.
+
+## Verification
+
+```bash
+bash tests/test.sh
+```
+
+Expected behavior: applying `tests/test.patch` to `base_commit` should preserve forward, `keepdim=True`, trailing-axis, and CPU behavior while failing CUDA backward with `keepdim=False` and non-trailing axes; applying both `tests/test.patch` and `solution/code.patch` should pass all target tests.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79657/environment/README.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79657/environment/README.md
@@ -1,0 +1,45 @@
+# Environment Notes
+
+This candidate is part of the SWE-Paddle community task set.
+
+## Expected Environment
+
+- Repository: `PaddlePaddle/Paddle`
+- Base commit: `16037ff1effb88625041f9a1c540e8b2af3ab5c1`
+- Gold commit: `20519ee630ec4929776b33341f690adc2fc48001`
+- Resource: Single NVIDIA GPU
+- GPU required: yes
+- Build type: CUDA source build
+
+## Critical Build Note
+
+This task fixes a `.cu` file (CUDA kernel source). A full Paddle source build from the checkout is **required** to verify the fix. Simply installing a prebuilt wheel or overlaying Python source files is insufficient — the modified CUDA kernel must be recompiled into the Paddle runtime. After applying the gold patch, a complete `make` rebuild of the affected CUDA targets (or a full Paddle build) is mandatory before running tests.
+
+## GPU Preflight
+
+Before running any tests, verify that:
+
+1. A CUDA-capable GPU is available and visible to `nvidia-smi`.
+2. The CUDA toolkit version matches the Paddle build requirements for the base commit.
+3. `python -c "import paddle; print(paddle.device.get_device())"` reports a valid CUDA device.
+
+## Run Order
+
+1. Check out `PaddlePaddle/Paddle` at the base commit.
+2. Build Paddle from source with CUDA support.
+3. Apply `tests/test.patch`.
+4. Run `bash tests/test.sh`; CUDA backward with `keepdim=False` and non-trailing axes should fail before the fix; forward, `keepdim=True`, trailing-axis, and CPU behavior should pass.
+5. Apply `solution/code.patch`.
+6. **Rebuild** the affected CUDA targets (full source rebuild recommended).
+7. Run `bash tests/test.sh` again; all target tests should pass after the gold patch.
+
+## Minimal Test Command
+
+```bash
+bash tests/test.sh
+```
+
+## Notes
+
+- No runtime results are claimed here — all expected outcomes are described in terms of test pass/fail behavior.
+- The verifier is responsible for deriving stable F2P and P2P node IDs from repeated runs.

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79657/instruction.md
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79657/instruction.md
@@ -1,0 +1,28 @@
+# 修复 `paddle.compat.min/max` CUDA 反向传播梯度索引错误
+
+## 详细描述
+
+`paddle.compat.min(input, dim=..., keepdim=False)` 和 `paddle.compat.max(input, dim=..., keepdim=False)` 在 CUDA 设备上沿非末尾维度执行反向传播时，上游梯度未能被正确路由到对应的输入位置。
+
+具体表现为：当 `keepdim=False` 且 `dim` 不是末尾维度时，反向传播产生的输入梯度与预期的梯度回写结果不一致。各位置的上游梯度被错误地映射到了输入张量的错误位置。
+
+## 验收说明
+
+### 必须通过的行为
+
+- `paddle.compat.min` 和 `paddle.compat.max` 在 CUDA 上沿非末尾维度反向传播时，每个非均匀上游梯度必须被路由到其对应的输入位置，梯度结果与正确的梯度回写结果一致。
+- 正轴和等价负轴在非末尾维度场景下都应正确。
+
+### 必须保持不变的行为
+
+- 前向计算结果和输出 shape 不应改变。
+- `keepdim=True` 的反向传播行为不应改变。
+- 末尾维度的反向传播行为不应改变。
+- CPU 设备上的行为不应改变。
+- 已有的 elementwise min/max 行为不应改变。
+
+## 技术要求
+
+* 熟悉 C++ 和 CUDA
+* 了解 Paddle 的 `paddle.compat.min/max` API
+* 了解 reduction 算子的 `keepdim` 语义和反向传播梯度回写机制

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79657/solution/code.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79657/solution/code.patch
@@ -1,0 +1,48 @@
+diff --git a/paddle/phi/kernels/gpu/min_max_with_index_grad_kernel.cu b/paddle/phi/kernels/gpu/min_max_with_index_grad_kernel.cu
+index bf49a61..562f04d 100644
+--- a/paddle/phi/kernels/gpu/min_max_with_index_grad_kernel.cu
++++ b/paddle/phi/kernels/gpu/min_max_with_index_grad_kernel.cu
+@@ -30,9 +30,13 @@ using EnableIfNonInteger =
+     typename std::enable_if<!std::is_integral<T>::value, int>::type;
+ 
+ // Here if keepdim=True, this will fallback to a simplified version of
+-// take_along_axis. However, if keepdim=False (by default), indices will
+-// not have equal rank will the input values (and values_grad), therefore
+-// needs an unsqueeze operation by shallow copying indices and Resize
++// take_along_axis. However, if keepdim=False (by default), indices and
++// values_grad will not have equal rank with the input, therefore both of
++// them need an unsqueeze operation by shallow copying and Resize.
++// values_grad must be unsqueezed together with indices: the scatter functor
++// walks the index tensor with the input rank and reads values_grad through
++// `src.strides()[i]`, so a lower-rank values_grad makes every stride shift
++// by one dim (only dim == rank-1 happens to be unaffected).
+ #define DEFINE_WITH_INDEX_GRAD_KERNEL(OpType)                                \
+   template <typename T, typename Context, EnableIfNonInteger<T> = 0>         \
+   void OpType##WithIndexGradKernel(const Context& dev_ctx,                   \
+@@ -53,15 +57,21 @@ using EnableIfNonInteger =
+       dim_val += x.dims().size();                                            \
+     }                                                                        \
+     DenseTensor shallow_copied_inds(indices);                                \
++    DenseTensor shallow_copied_grad(values_grad);                            \
+     if (!keepdim) {                                                          \
+-      auto indices_dim = x.dims();                                           \
+-      indices_dim[dim_val] = 1;                                              \
+-      shallow_copied_inds.Resize(indices_dim);                               \
++      auto unsqueezed_dims = x.dims();                                       \
++      unsqueezed_dims[dim_val] = 1;                                          \
++      shallow_copied_inds.Resize(unsqueezed_dims);                           \
++      shallow_copied_grad.Resize(unsqueezed_dims);                           \
+     }                                                                        \
+     funcs::SetConstant<Context, T> functor;                                  \
+     functor(dev_ctx, x_grad, static_cast<T>(0));                             \
+-    funcs::gpu_scatter_add_kernel<T, int64_t>(                               \
+-        *x_grad, dim_val, shallow_copied_inds, values_grad, true, dev_ctx);  \
++    funcs::gpu_scatter_add_kernel<T, int64_t>(*x_grad,                       \
++                                              dim_val,                       \
++                                              shallow_copied_inds,           \
++                                              shallow_copied_grad,           \
++                                              true,                          \
++                                              dev_ctx);                      \
+   }                                                                          \
+   template <typename T, typename Context, EnableIfInteger<T> = 0>            \
+   void OpType##WithIndexGradKernel(const Context& dev_ctx,                   \

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79657/tests/test.patch
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79657/tests/test.patch
@@ -1,0 +1,78 @@
+diff --git a/test/legacy_test/test_compat_minmax.py b/test/legacy_test/test_compat_minmax.py
+index e371bbf..347fbc3 100644
+--- a/test/legacy_test/test_compat_minmax.py
++++ b/test/legacy_test/test_compat_minmax.py
+@@ -555,5 +555,73 @@ class TestCompatMax(TestCompatMinMaxBase):
+         )
+ 
+ 
++class TestCompatMinMaxCUDAGrad(unittest.TestCase):
++    """CUDA-only backward gradient indexing tests for paddle.compat.min/max.
++
++    Verifies that upstream gradients are correctly routed to input positions
++    when keepdim=False and the reduction axis is not trailing.  Uses unique
++    float64 values and nonuniform upstream gradients so that every element
++    is distinguishable.
++    """
++
++    def setUp(self):
++        self._prev_device = paddle.get_device()
++        paddle.set_device('gpu:0')
++
++    def tearDown(self):
++        paddle.set_device(self._prev_device)
++
++    def _run_backward(self, op_name, dim, keepdim):
++        """Run backward gradient check for a single (op, dim, keepdim) combo."""
++        shape = [2, 3, 4]
++        numel = int(np.prod(shape))
++        x_np = ((np.arange(numel) * 7) % numel).astype('float64').reshape(shape)
++        test_op = paddle.compat.min if op_name == 'min' else paddle.compat.max
++        reduce_index = np.argmin if op_name == 'min' else np.argmax
++
++        axis = dim % len(shape)
++        if keepdim:
++            out_shape = list(shape)
++            out_shape[axis] = 1
++        else:
++            out_shape = [s for i, s in enumerate(shape) if i != axis]
++
++        np_out_numel = int(np.prod(out_shape))
++        dy_np = (np.arange(1, np_out_numel + 1) * 0.5).astype('float64').reshape(
++            out_shape
++        )
++
++        expected_grad = np.zeros(shape, dtype='float64')
++        np.put_along_axis(
++            expected_grad,
++            np.expand_dims(reduce_index(x_np, axis=axis), axis=axis),
++            dy_np if keepdim else np.expand_dims(dy_np, axis=axis),
++            axis=axis,
++        )
++
++        data = paddle.to_tensor(x_np, stop_gradient=False)
++        result = test_op(data, dim=dim, keepdim=keepdim)
++        self.assertEqual(list(result.values.shape), out_shape)
++        result.values.backward(paddle.to_tensor(dy_np))
++        np.testing.assert_allclose(
++            data.grad.numpy(),
++            expected_grad,
++            atol=1e-6,
++            err_msg=f"{op_name} backward mismatch at dim={dim}, keepdim={keepdim}",
++        )
++
++    def test_p2p_grad(self):
++        """P2P: keepdim=True non-trailing and keepdim=False trailing for min/max."""
++        for op in ('min', 'max'):
++            self._run_backward(op, dim=0, keepdim=True)
++            self._run_backward(op, dim=-1, keepdim=False)
++
++    def test_f2p_grad(self):
++        """F2P: keepdim=False dims 0,1,-2 for min/max."""
++        for op in ('min', 'max'):
++            for dim in (0, 1, -2):
++                self._run_backward(op, dim=dim, keepdim=False)
++
++
+ if __name__ == '__main__':
+     unittest.main()

--- a/swe-paddle/tasks/PaddlePaddle__Paddle-79657/tests/test.sh
+++ b/swe-paddle/tasks/PaddlePaddle__Paddle-79657/tests/test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+PYTHON_BIN="${PYTHON_BIN:-python}"
+
+cd "${repo_root}"
+
+# Fail hard when CUDA is unavailable: this task targets a CUDA-only kernel.
+"${PYTHON_BIN}" -c "
+import paddle
+assert paddle.is_compiled_with_cuda(), 'Paddle is not compiled with CUDA'
+assert paddle.device.cuda.device_count() >= 1, 'No CUDA device available'
+"
+
+export PYTHONPATH="${repo_root}/python:${repo_root}/test/legacy_test:${repo_root}/test${PYTHONPATH:+:${PYTHONPATH}}"
+
+# P2P node first: pass-to-pass behavior (passes on base and gold).
+# Dedicated CUDA gradient node plus existing forward/reduce and elementwise
+# regression nodes for both min and max.
+"${PYTHON_BIN}" -m pytest -xvs \
+  test/legacy_test/test_compat_minmax.py::TestCompatMinMaxCUDAGrad::test_p2p_grad \
+  test/legacy_test/test_compat_minmax.py::TestCompatMinMaxBase::test_case2_reduce_dim \
+  test/legacy_test/test_compat_minmax.py::TestCompatMax::test_case2_reduce_dim \
+  test/legacy_test/test_compat_minmax.py::TestCompatMinMaxBase::test_case3_elementwise \
+  test/legacy_test/test_compat_minmax.py::TestCompatMax::test_case3_elementwise
+
+# F2P node second: fail-to-pass behavior (fails on base, passes on gold).
+"${PYTHON_BIN}" -m pytest -xvs test/legacy_test/test_compat_minmax.py::TestCompatMinMaxCUDAGrad::test_f2p_grad


### PR DESCRIPTION
## 关联

- SWE-Paddle 共建 issue：https://github.com/PaddlePaddle/Paddle/issues/79447
- 来源 PR：https://github.com/PaddlePaddle/Paddle/pull/79657
- Proposal PR：https://github.com/PaddlePaddle/community/pull/1568

## 说明

`PaddlePaddle__Paddle-79657` 的完整任务。

## 验证

| 状态 | P2P | min/max backward F2P |
| --- | ---: | ---: |
| Base + `tests/test.patch` |  PASS |  FAIL |
| Base + test patch + `solution/code.patch` |  PASS |  PASS |

P2P 覆盖：

- `keepdim=True` 的非末尾维度反向传播；
- `keepdim=False` 的末尾维度反向传播；
- 现有 `min/max` forward、reduce 和 elementwise 行为。

F2P 覆盖：

- `keepdim=False`；
- 非末尾正轴和等价负轴；
- `paddle.compat.min` 与 `paddle.compat.max`；
- 非均匀上游梯度；
- 与 NumPy 梯度回写结果对比。
